### PR TITLE
skip test_bind_null if bind_null method is not defined

### DIFF
--- a/test/duckdb_test/prepared_statement_test.rb
+++ b/test/duckdb_test/prepared_statement_test.rb
@@ -199,6 +199,7 @@ module DuckDBTest
     def test_bind_null
       con = PreparedStatementTest.con
       stmt = DuckDB::PreparedStatement.new(con, 'INSERT INTO a(id) VALUES ($1)')
+      skip 'bind_null is not defined in DuckDB::PreparedStatement (DuckDB version <= 0.1.1?)' unless stmt.respond_to?(:bind_null)
       stmt.bind_null(1)
       assert_instance_of(DuckDB::Result, stmt.execute)
       r = con.query('SELECT * FROM a WHERE id IS NULL')


### PR DESCRIPTION
DuckDB::PreparedStatement#bind_null is not defined with DuckDB
version <= 0.1.1. So skip test_bind_null if bind_null is not defined.