### PR TITLE
Replace 'rb_raise' with 'raise' in rb files

### DIFF
--- a/lib/duckdb/appender.rb
+++ b/lib/duckdb/appender.rb
@@ -41,7 +41,7 @@ module DuckDB
             append_varchar(value.to_s)
           end
         else
-          rb_raise(ArgumentError, "2nd argument `#{value}` must be Integer.")
+          raise(ArgumentError, "2nd argument `#{value}` must be Integer.")
         end
       end
 
@@ -88,7 +88,7 @@ module DuckDB
         when Date
           append_varchar(value.strftime('%Y-%m-%d'))
         else
-          rb_raise(DuckDB::Error, "not supported type #{value} (value.class)")
+          raise(DuckDB::Error, "not supported type #{value} (#{value.class})")
         end
       end
 

--- a/lib/duckdb/prepared_statement.rb
+++ b/lib/duckdb/prepared_statement.rb
@@ -22,7 +22,7 @@ module DuckDB
       when Integer
         bind_varchar(i, value.to_s)
       else
-        rb_raise(ArgumentError, "2nd argument `#{value}` must be Integer.")
+        raise(ArgumentError, "2nd argument `#{value}` must be Integer.")
       end
     end
 
@@ -40,7 +40,7 @@ module DuckDB
     def bind(i, value)
       case value
       when NilClass
-        respond_to?(:bind_null) ? bind_null(i) : rb_raise(DuckDB::Error, 'This bind method does not support nil value. Re-compile ruby-duckdb with DuckDB version >= 0.1.1')
+        respond_to?(:bind_null) ? bind_null(i) : raise(DuckDB::Error, 'This bind method does not support nil value. Re-compile ruby-duckdb with DuckDB version >= 0.1.1')
       when Float
         bind_double(i, value)
       when Integer
@@ -63,7 +63,7 @@ module DuckDB
       when Date
         bind_varchar(i, value.strftime('%Y-%m-%d'))
       else
-        rb_raise(DuckDB::Error, "not supported type #{value} (value.class)")
+        raise(DuckDB::Error, "not supported type `#{value}` (#{value.class})")
       end
     end
 

--- a/test/duckdb_test/appender_test.rb
+++ b/test/duckdb_test/appender_test.rb
@@ -149,6 +149,11 @@ if defined?(DuckDB::Appender)
         sub_test_append_column(:append_hugeint, 'HUGEINT', 18_446_744_073_709_551_615)
         sub_test_append_column(:append_hugeint, 'HUGEINT', -170_141_183_460_469_231_731_687_303_715_884_105_727)
         sub_test_append_column(:append_hugeint, 'HUGEINT', 170_141_183_460_469_231_731_687_303_715_884_105_727)
+
+        e = assert_raises(ArgumentError) {
+          sub_test_append_column(:append_hugeint, 'HUGEINT', 18.555)
+        }
+        assert_equal("2nd argument `18.555` must be Integer.", e.message)
       end
 
       def test_append_varchar
@@ -307,6 +312,11 @@ if defined?(DuckDB::Appender)
         sub_test_append_column(:append, 'BLOB', value, nil, expected)
 
         sub_test_append_column(:append, 'VARCHAR', nil, nil, nil)
+
+        e = assert_raises(DuckDB::Error) {
+          sub_test_append_column(:append, 'INTEGER', [127])
+        }
+        assert_equal('not supported type [127] (Array)', e.message)
 
         # FIXME: issue https://github.com/suketa/ruby-duckdb/issues/176
         if LessThanEqualVersion028

--- a/test/duckdb_test/prepared_statement_test.rb
+++ b/test/duckdb_test/prepared_statement_test.rb
@@ -189,6 +189,12 @@ module DuckDBTest
       stmt = DuckDB::PreparedStatement.new(con, 'SELECT * FROM a WHERE col_hugeint = $1')
       stmt.bind_hugeint(1, 170141183460469231731687303715884105727)
       assert_equal(1, stmt.execute.each.size)
+
+      stmt = DuckDB::PreparedStatement.new(con, 'SELECT * FROM a WHERE col_hugeint = $1')
+      e = assert_raises(ArgumentError) {
+        stmt.bind_hugeint(1, 1.5)
+      }
+      assert_equal('2nd argument `1.5` must be Integer.', e.message)
     end
 
     def test_bind_float
@@ -446,6 +452,16 @@ module DuckDBTest
       assert_equal(1, r.each.size)
     ensure
       con.query('DELETE FROM a WHERE id IS NULL')
+    end
+
+    def test_bind_with_unsupported_type
+      con = PreparedStatementTest.con
+      stmt = DuckDB::PreparedStatement.new(con, 'SELECT * FROM a WHERE col_integer = $1')
+
+      e = assert_raises(DuckDB::Error) {
+        stmt.bind(1, [123])
+      }
+      assert_equal('not supported type `[123]` (Array)', e.message)
     end
   end
 end


### PR DESCRIPTION
# What it does

- Replace `rb_raise` with `raise` in ruby files
- Write tests for raise cases

# Why is it important

- Using `rb_raise` causes `undefined method` exception