### PR TITLE
use UTF-8 encoding when constructing strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,14 +21,14 @@ You must have [DuckDB](http://www.duckdb.org) engine installed in order to build
 3. Move the files to their respective location:
     - Extract the `duckdb.h` and `duckdb.hpp` file to `/usr/local/include`
     - Extract the `libduckdb.so` file to `/usr/local/lib`
-    
+
     ```sh
     unzip libduckdb-linux-amd64.zip -d libduckdb
     sudo mv libduckdb/duckdb.* /usr/local/include/
     sudo mv libduckdb/libduckdb.so /usr/local/lib
     ```
 4. To create the necessary link, run `ldconfig` as root:
-  
+
     ```sh
     sudo ldconfig /usr/local/lib # adding a --verbose flag is optional - but this will let you know if the libduckdb.so library has been linked
     ```
@@ -42,20 +42,20 @@ brew install duckdb
 
 ## How to Install
 
-```
+```sh
 gem install duckdb
 ```
 > this will work fine with the above pre-requisite setup.
 
 or you must specify the location of the C header and library files:
 
-```
+```sh
 gem install duckdb -- --with-duckdb-include=/duckdb_header_directory --with-duckdb-lib=/duckdb_library_directory
 ```
 
 ## Usage
 
-```
+```ruby
 require 'duckdb'
 
 db = DuckDB::Database.open # database in memory
@@ -75,7 +75,7 @@ end
 
 Or, you can use block.
 
-```
+```ruby
 require 'duckdb'
 
 DuckDB::Database.open do |db|
@@ -99,7 +99,7 @@ end
 BLOB is available with DuckDB v0.2.5 or later.
 Use `DuckDB::Blob.new` or use sting#force_encoding(Encoding::BINARY)
 
-```
+```ruby
 require 'duckdb'
 
 DuckDB::Database.open do |db|
@@ -121,7 +121,7 @@ end
 
 Appender class provides Ruby interface of [DuckDB Appender](https://duckdb.org/docs/data/appender)
 
-```
+```ruby
 require 'duckdb'
 require 'benchmark'
 
@@ -183,7 +183,7 @@ end
 
 Config class provides Ruby interface of [DuckDB configuration](https://duckdb.org/docs/api/c/config).
 
-```
+```ruby
 require 'duckdb'
 config = DuckDB::Config.new
 config['default_order'] = 'DESC'

--- a/ext/duckdb/column.c
+++ b/ext/duckdb/column.c
@@ -48,7 +48,7 @@ VALUE duckdb_column_get_name(VALUE oDuckDBColumn) {
     rubyDuckDBResult *ctxresult;
     Data_Get_Struct(result, rubyDuckDBResult, ctxresult);
 
-    return rb_str_new2(duckdb_column_name(&(ctxresult->result), ctx->col));
+    return rb_utf8_str_new_cstr(duckdb_column_name(&(ctxresult->result), ctx->col));
 }
 
 VALUE create_column(VALUE oDuckDBResult, idx_t col) {

--- a/ext/duckdb/config.c
+++ b/ext/duckdb/config.c
@@ -46,7 +46,7 @@ static VALUE config_s_get_config_flag(VALUE klass, VALUE value) {
         rb_raise(eDuckDBError, "failed to get config information of index %ld", i);
     }
 
-    return rb_ary_new3(2, rb_str_new2(pkey), rb_str_new2(pdesc));
+    return rb_ary_new3(2, rb_utf8_str_new_cstr(pkey), rb_utf8_str_new_cstr(pdesc));
 }
 
 static VALUE config_set_config(VALUE self, VALUE key, VALUE value) {

--- a/ext/duckdb/result.c
+++ b/ext/duckdb/result.c
@@ -260,7 +260,7 @@ static VALUE duckdb_result__to_string(VALUE oDuckDBResult, VALUE row_idx, VALUE 
 
     p = duckdb_value_varchar(&(ctx->result), NUM2LL(col_idx), NUM2LL(row_idx));
     if (p) {
-        obj = rb_str_new2(p);
+        obj = rb_utf8_str_new_cstr(p);
         duckdb_free(p);
         return obj;
     }
@@ -311,7 +311,7 @@ static VALUE duckdb_result__enum_dictionary_value(VALUE oDuckDBResult, VALUE col
     if (logical_type) {
         p = duckdb_enum_dictionary_value(logical_type, NUM2LL(idx));
         if (p) {
-            value = rb_str_new2(p);
+            value = rb_utf8_str_new_cstr(p);
             duckdb_free(p);
         }
     }

--- a/test/duckdb_test/column_test.rb
+++ b/test/duckdb_test/column_test.rb
@@ -27,6 +27,7 @@ module DuckDBTest
         interval
         hugeint
         varchar
+        varchar
       ]
       if DuckDBVersion.duckdb_version >= '0.3.3'
         expected.push(:decimal)
@@ -57,6 +58,7 @@ module DuckDBTest
         interval_col
         hugeint_col
         varchar_col
+        ủȵȋɕṓ𝓭е_𝒄𝗈ł
       ]
       if DuckDBVersion.duckdb_version >= '0.3.3'
         expected.push('decimal_col')
@@ -64,7 +66,7 @@ module DuckDBTest
       end
       assert_equal(
         expected,
-        @columns.map(&:name),
+        @columns.map(&:name)
       )
     end
 
@@ -80,7 +82,7 @@ module DuckDBTest
     end
 
     def create_type_enum_sql
-      "CREATE TYPE mood AS ENUM ('sad', 'ok', 'happy');"
+      "CREATE TYPE mood AS ENUM ('sad', 'ok', 'happy', '𝘾𝝾օɭ 😎');"
     end
 
     def create_table_sql
@@ -102,7 +104,8 @@ module DuckDBTest
           timestamp_col timestamp,
           interval_col INTERVAL,
           hugeint_col HUGEINT,
-          varchar_col VARCHAR
+          varchar_col VARCHAR,
+          ủȵȋɕṓ𝓭е_𝒄𝗈ł VARCHAR
       SQL
 
       if DuckDBVersion.duckdb_version >= '0.3.3'
@@ -133,7 +136,8 @@ module DuckDBTest
           '2019-11-03 12:34:56',
           '1 day',
           170141183460469231731687303715884105727,
-          'string'
+          'string',
+          'ȕɲᎥᴄⲟ𝑑ẽ 𝑠τᵲïņ𝕘 😃'
       SQL
 
       if DuckDBVersion.duckdb_version >= '0.3.3'

--- a/test/duckdb_test/enum_test.rb
+++ b/test/duckdb_test/enum_test.rb
@@ -17,7 +17,7 @@ module DuckDBTest
 
       def self.create_enum_sql
         <<~SQL
-          CREATE TYPE mood AS ENUM ('sad', 'ok', 'happy')
+          CREATE TYPE mood AS ENUM ('sad', 'ok', 'happy', '𝘾𝝾օɭ 😎')
         SQL
       end
 
@@ -37,12 +37,13 @@ module DuckDBTest
       end
 
       def test_result__enum_dictionary_size
-        assert_equal(3, @result.send(:_enum_dictionary_size, 1))
+        assert_equal(4, @result.send(:_enum_dictionary_size, 1))
       end
 
       def test_result__enum_dictionary_value
         assert_equal('sad', @result.send(:_enum_dictionary_value, 1, 0))
         assert_equal('ok', @result.send(:_enum_dictionary_value, 1, 1))
+        assert_equal('𝘾𝝾օɭ 😎', @result.send(:_enum_dictionary_value, 1, 3))
       end
 
       # FIXME

--- a/test/duckdb_test/result_test.rb
+++ b/test/duckdb_test/result_test.rb
@@ -247,7 +247,7 @@ module DuckDBTest
     end
 
     def expected_string
-      'string'
+      '𝘶ñîҫȫ𝘥ẹ 𝖘ţ𝗋ⅰɲ𝓰 😃'
     end
 
     def expected_date


### PR DESCRIPTION
Changes all occurrences of `rb_str_new2` to `rb_utf8_str_new_cstr` in order to construct all Ruby strings with UTF-8 encoding. This affects column names, values for `VARCHAR` and `ENUM` types and config attributes.