### PR TITLE
Fix reading from boolean column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # ChangeLog
 
+- bug fix: reading the boolean column
+
 # 0.5.1
 - bump duckdb 0.5.1
 

--- a/ext/duckdb/result.c
+++ b/ext/duckdb/result.c
@@ -62,7 +62,7 @@ rubyDuckDBResult *get_struct_result(VALUE obj) {
 
 static VALUE to_ruby_obj_boolean(duckdb_result *result, idx_t col_idx, idx_t row_idx) {
     bool bval = duckdb_value_boolean(result, col_idx, row_idx);
-    return bval ? Qtrue : Qnil;
+    return bval ? Qtrue : Qfalse;
 }
 
 static VALUE to_ruby_obj_smallint(duckdb_result *result, idx_t col_idx, idx_t row_idx) {

--- a/test/duckdb_test/appender_test.rb
+++ b/test/duckdb_test/appender_test.rb
@@ -89,9 +89,7 @@ if defined?(DuckDB::Appender)
 
       def test_append_bool
         assert_duckdb_appender(true, 'BOOLEAN') { |a| a.append_bool(true) }
-
-        # FIXME
-        # assert_duckdb_appender(false, 'BOOLEAN') { |a| a.append_bool(false) }
+        assert_duckdb_appender(false, 'BOOLEAN') { |a| a.append_bool(false) }
       end
 
       def test_append_int8

--- a/test/duckdb_test/result_test.rb
+++ b/test/duckdb_test/result_test.rb
@@ -29,7 +29,8 @@ module DuckDBTest
         expected_string,
         expected_date,
         expected_timestamp,
-        expected_blob
+        expected_blob,
+        expected_boolean_false
       ]
       assert_equal([expected_ary, 0], @result.each.with_index.to_a.first)
     end
@@ -75,7 +76,7 @@ module DuckDBTest
     end
 
     def test_result_null
-      assert_equal(Array.new(11), @result.reverse_each.first)
+      assert_equal(Array.new(12), @result.reverse_each.first)
     end
 
     def test_including_enumerable
@@ -100,8 +101,8 @@ module DuckDBTest
     end
 
     def test_column_count
-      assert_equal(11, @result.column_count)
-      assert_equal(11, @result.column_size)
+      assert_equal(12, @result.column_count)
+      assert_equal(12, @result.column_size)
       r = @@con.query('SELECT boolean_col, smallint_col from table1')
       assert_equal(2, r.column_count)
       assert_equal(2, r.column_size)
@@ -193,7 +194,8 @@ module DuckDBTest
           varchar_col VARCHAR,
           date_col DATE,
           timestamp_col timestamp,
-          blob_col BLOB
+          blob_col BLOB,
+          boolean_col2 BOOLEAN,
         )
       SQL
     end
@@ -212,14 +214,19 @@ module DuckDBTest
           '#{expected_string}',
           '#{expected_date}',
           '#{expected_timestamp}',
-          '#{expected_blob}'
+          '#{expected_blob}',
+          '#{expected_boolean_false}'
         ),
-        (NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+        (NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
       SQL
     end
 
     def expected_boolean
       true
+    end
+
+    def expected_boolean_false
+      false
     end
 
     def expected_smallint


### PR DESCRIPTION
Fix the following bug

```ruby
con.execute('create table t (col boolean)')
con.execute('insert into t values(false)');
r = con.execute('select col from t')
r.first.first #=> expected false, but always true.
```