### PR TITLE
change ruby 3.2.0 preview3

### DIFF
--- a/.github/workflows/test_on_macos.yml
+++ b/.github/workflows/test_on_macos.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        ruby: ['2.6.10', '2.7.6', '3.0.4', '3.1.2', '3.2.0-preview2', 'head']
+        ruby: ['2.6.10', '2.7.6', '3.0.4', '3.1.2', '3.2.0-preview3', 'head']
         duckdb: ['0.5.1', '0.5.0']
 
     steps:

--- a/.github/workflows/test_on_ubuntu.yml
+++ b/.github/workflows/test_on_ubuntu.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ['2.6.10', '2.7.6', '3.0.4', '3.1.2', '3.2.0-preview2', 'head']
+        ruby: ['2.6.10', '2.7.6', '3.0.4', '3.1.2', '3.2.0-preview3', 'head']
         duckdb: ['0.5.1', '0.5.0']
 
     steps:


### PR DESCRIPTION
Changed preview version of Ruby(preview2->preview3).
This version was not yet supported on windows. (https://github.com/ruby/setup-ruby/tree/v1)