### PR TITLE
use duckdb_value_string instead of duckdb_value_varchar (#406).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # ChangeLog
 
+- use duckdb_value_string instead of duckdb_value_varchar if duckdb_value_string is available.
 - bump Ruby to 3.2.0rc1
 - bump duckdb to 0.6.0
 

--- a/ext/duckdb/extconf.rb
+++ b/ext/duckdb/extconf.rb
@@ -10,6 +10,9 @@ raise 'duckdb >= 0.2.9 is required. Install duckdb >= 0.2.9' unless have_func('d
 # ducdb >= 0.3.3 if duckdb_append_data_chunk() is defined.
 have_func('duckdb_append_data_chunk', 'duckdb.h')
 
+# check duckdb >= 0.6.0
+have_func('duckdb_value_string', 'duckdb.h')
+
 have_func('duckdb_free', 'duckdb.h')
 
 create_makefile('duckdb/duckdb_native')

--- a/ext/duckdb/result.c
+++ b/ext/duckdb/result.c
@@ -271,14 +271,25 @@ static VALUE duckdb_result__to_double(VALUE oDuckDBResult, VALUE row_idx, VALUE 
 
 static VALUE duckdb_result__to_string(VALUE oDuckDBResult, VALUE row_idx, VALUE col_idx) {
     rubyDuckDBResult *ctx;
+#ifdef HAVE_DUCKDB_H_GE_V060
+    duckdb_string p;
+#else
     char *p;
+#endif
     VALUE obj;
     TypedData_Get_Struct(oDuckDBResult, rubyDuckDBResult, &result_data_type, ctx);
 
+#ifdef HAVE_DUCKDB_H_GE_V060
+    p = duckdb_value_string(&(ctx->result), NUM2LL(col_idx), NUM2LL(row_idx));
+    if (p.data) {
+        obj = rb_utf8_str_new(p.data, p.size);
+        duckdb_free(p.data);
+#else
     p = duckdb_value_varchar(&(ctx->result), NUM2LL(col_idx), NUM2LL(row_idx));
     if (p) {
         obj = rb_utf8_str_new_cstr(p);
         duckdb_free(p);
+#endif
         return obj;
     }
     return Qnil;

--- a/ext/duckdb/ruby-duckdb.h
+++ b/ext/duckdb/ruby-duckdb.h
@@ -8,6 +8,10 @@
 #define HAVE_DUCKDB_H_GE_V033 1
 #endif
 
+#ifdef HAVE_DUCKDB_VALUE_STRING
+#define HAVE_DUCKDB_H_GE_V060 1
+#endif
+
 #include "./error.h"
 #include "./database.h"
 #include "./connection.h"


### PR DESCRIPTION
duckdb_value_varchar will be deprecated.