### PR TITLE
fix: have_func arguments order

### DIFF
--- a/ext/duckdb/extconf.rb
+++ b/ext/duckdb/extconf.rb
@@ -2,7 +2,7 @@ require 'mkmf'
 
 def duckdb_library_available?(func)
   header = find_header('duckdb.h') || find_header('duckdb.h', '/opt/homebrew/include')
-  library = have_func('duckdb', func) || find_library('duckdb', func, '/opt/homebrew/opt/duckdb/lib')
+  library = have_func(func, 'duckdb') || find_library('duckdb', func, '/opt/homebrew/opt/duckdb/lib')
   header && library
 end
 

--- a/ext/duckdb/extconf.rb
+++ b/ext/duckdb/extconf.rb
@@ -2,7 +2,7 @@ require 'mkmf'
 
 def duckdb_library_available?(func)
   header = find_header('duckdb.h') || find_header('duckdb.h', '/opt/homebrew/include')
-  library = have_func(func, 'duckdb') || find_library('duckdb', func, '/opt/homebrew/opt/duckdb/lib')
+  library = have_func(func, 'duckdb.h') || find_library('duckdb', func, '/opt/homebrew/opt/duckdb/lib')
   header && library
 end
 


### PR DESCRIPTION
https://docs.ruby-lang.org/en/3.2/MakeMakefile.html#method-i-have_func
`func` is the first argument of `have_func` method

`rake build` result after change
```
root@cea3c125f267:~/ruby-duckdb# bundle exec rake build
cd tmp/x86_64-linux/duckdb_native/3.2.1
/usr/local/bin/ruby -I. -r.rake-compiler-siteconf.rb ../../../../ext/duckdb/extconf.rb
checking for duckdb.h... yes
checking for duckdb_pending_prepared() in duckdb... no
checking for duckdb_pending_prepared() in -lduckdb... yes
checking for duckdb_append_data_chunk() in duckdb.h... yes
checking for duckdb_value_string() in duckdb.h... yes
checking for duckdb_free() in duckdb.h... yes
creating Makefile
```