### PR TITLE
use _to_hugeint_internal instead of _to_hugeint

### DIFF
--- a/.github/workflows/test_on_macos.yml
+++ b/.github/workflows/test_on_macos.yml
@@ -56,11 +56,11 @@ jobs:
     - name: Build with Ruby ${{ matrix.ruby }}
       run: |
         bundle install --jobs 4 --retry 3
-        bundle exec rake build
+        rake build
 
     - name: run test with Ruby ${{ matrix.ruby }}
       run: |
-        bundle exec rake test
+        rake test
 
   post-test:
     name: All tests passed on macos

--- a/.github/workflows/test_on_ubuntu.yml
+++ b/.github/workflows/test_on_ubuntu.yml
@@ -58,7 +58,7 @@ jobs:
       env:
         DUCKDB_VERSION: ${{ matrix.duckdb }}
       run: |
-        bundle exec rake test
+        rake test
 
   post-test:
     name: All tests passed on Ubuntu

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,6 @@ source "https://rubygems.org"
 
 # Specify your gem's dependencies in duckdb.gemspec
 gemspec
+
+gem 'benchmark-ips'
+gem 'stackprof'

--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,7 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in duckdb.gemspec
 gemspec
 
-gem 'benchmark-ips'
-gem 'stackprof'
+if /linux/ =~ RUBY_PLATFORM || /darwin/ =~ RUBY_PLATFORM
+  gem 'benchmark-ips'
+  gem 'stackprof'
+end

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in duckdb.gemspec
 gemspec
 
-if /linux/ =~ RUBY_PLATFORM || /darwin/ =~ RUBY_PLATFORM
+if /(linux|darwin)/ =~ RUBY_PLATFORM
   gem 'benchmark-ips'
   gem 'stackprof'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,6 +24,3 @@ DEPENDENCIES
   rake (~> 13.0)
   rake-compiler
   stackprof
-
-BUNDLED WITH
-   2.4.8

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,4 +27,4 @@ DEPENDENCIES
   stackprof
 
 BUNDLED WITH
-   2.4.8
+   2.4.9

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,21 +6,24 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    benchmark-ips (2.12.0)
     minitest (5.18.0)
     rake (13.0.6)
     rake-compiler (1.2.1)
       rake
+    stackprof (0.2.24)
 
 PLATFORMS
-  ruby
   x86_64-linux
 
 DEPENDENCIES
+  benchmark-ips
   bundler (~> 2.3)
   duckdb!
   minitest (~> 5.0)
   rake (~> 13.0)
   rake-compiler
+  stackprof
 
 BUNDLED WITH
    2.4.8

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,3 +24,6 @@ DEPENDENCIES
   rake (~> 13.0)
   rake-compiler
   stackprof
+
+BUNDLED WITH
+   2.4.9

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,6 +14,7 @@ GEM
     stackprof (0.2.24)
 
 PLATFORMS
+  ruby
   x86_64-linux
 
 DEPENDENCIES
@@ -26,4 +27,4 @@ DEPENDENCIES
   stackprof
 
 BUNDLED WITH
-   2.4.9
+   2.4.8

--- a/benchmark/to_hugeint_ips.rb
+++ b/benchmark/to_hugeint_ips.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'bundler/setup'
+require 'duckdb'
+require 'benchmark/ips'
+
+db = DuckDB::Database.open
+con = db.connect
+con.query('CREATE TABLE hugeints (hugeint_value HUGEINT)')
+con.query('INSERT INTO hugeints VALUES (123456789012345678901234567890123456789)')
+result = con.query('SELECT hugeint_value FROM hugeints')
+
+Benchmark.ips do |x|
+  x.report('_to_hugeint') { result.send(:_to_hugeint, 0, 0) }
+  x.report('_to_hugeint_internal') { result.send(:_to_hugeint_internal, 0, 0) }
+end

--- a/benchmark/to_hugeint_profile.rb
+++ b/benchmark/to_hugeint_profile.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'bundler/setup'
+require 'duckdb'
+require 'stackprof'
+
+db = DuckDB::Database.open
+con = db.connect
+con.query('CREATE TABLE hugeints (hugeint_value HUGEINT)')
+con.query('INSERT INTO hugeints VALUES (123456789012345678901234567890123456789)')
+result = con.query('SELECT hugeint_value FROM hugeints')
+
+def profile(name, &block)
+  profile = StackProf.run(mode: :wall, interval: 1_000) do
+    2_000_000.times(&block)
+  end
+
+  result = StackProf::Report.new(profile)
+  puts
+  puts "=== #{name} ==="
+  result.print_text
+  puts
+end
+
+profile(:_to_hugeint) { result.send(:_to_hugeint, 0, 0) }
+profile(:_to_hugeint_internal) { result.send(:_to_hugeint_internal, 0, 0) }

--- a/lib/duckdb/result.rb
+++ b/lib/duckdb/result.rb
@@ -28,7 +28,7 @@ module DuckDB
       5 => :_to_bigint,
       10 => :_to_float,
       11 => :_to_double,
-      16 => :_to_hugeint,
+      16 => :_to_hugeint_internal,
       18 => :_to_blob,
     }
 
@@ -69,6 +69,11 @@ module DuckDB
 
     def _to_hugeint(row, col)
       _to_string(row, col).to_i
+    end
+
+    def _to_hugeint_internal(row, col)
+      lower, upper = __to_hugeint_internal(row, col)
+      upper * Converter::HALF_HUGEINT + lower
     end
   end
 end


### PR DESCRIPTION
refs #443 

use `_to_hugeint_internal` to convert hugeint column value.

```
$ ruby benchmark/to_hugeint_ips.rb
Warming up --------------------------------------
         _to_hugeint    72.649k i/100ms
_to_hugeint_internal   211.847k i/100ms
Calculating -------------------------------------
         _to_hugeint    728.915k (± 0.3%) i/s -      3.705M in   5.083096s
_to_hugeint_internal      2.064M (± 1.4%) i/s -     10.381M in   5.029377s
```