### PR TITLE
implement DuckDB::Result#_to_decimal_internal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # ChangeLog
 
 - add DuckDB::Result#_to_decimal_internal
-- add DuckDB::Result#__to_hugeint_internal
+- add DuckDB::Result#_to_hugeint_internal
 
 ## Breaking Change
 - DuckDB::Result returns BigDecimal object instead of String object if the column type is DECIMAL.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # ChangeLog
 
+- add DuckDB::Result#_to_decimal_internal
+- add DuckDB::Result#__to_hugeint_internal
+
+## Breaking Change
+- DuckDB::Result returns BigDecimal object instead of String object if the column type is DECIMAL.
+
 # 0.7.1
 - bump duckdb to 0.7.1
 - fix docker build error on M1 Mac

--- a/benchmark/to_bigdecimal_ips.rb
+++ b/benchmark/to_bigdecimal_ips.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'bundler/setup'
+require 'duckdb'
+require 'benchmark/ips'
+
+db = DuckDB::Database.open
+con = db.connect
+con.query('CREATE TABLE decimals (decimal_value DECIMAL(38, 3))')
+con.query('INSERT INTO decimals VALUES (1234567890123.456)')
+result = con.query('SELECT decimal_value FROM decimals')
+
+Benchmark.ips do |x|
+  x.report('_to_decimal') { result.send(:_to_decimal, 0, 0) }
+  x.report('_to_decimal_internal') { result.send(:_to_decimal_internal, 0, 0) }
+end

--- a/lib/duckdb/result.rb
+++ b/lib/duckdb/result.rb
@@ -1,3 +1,7 @@
+# frozen_string_literal: true
+
+require 'bigdecimal'
+
 module DuckDB
   # The Result class encapsulates a execute result of DuckDB database.
   #
@@ -30,6 +34,7 @@ module DuckDB
       11 => :_to_double,
       16 => :_to_hugeint_internal,
       18 => :_to_blob,
+      19 => :_to_decimal_internal
     }
 
     ToRuby.default = :_to_string
@@ -74,6 +79,17 @@ module DuckDB
     def _to_hugeint_internal(row, col)
       lower, upper = __to_hugeint_internal(row, col)
       upper * Converter::HALF_HUGEINT + lower
+    end
+
+    def _to_decimal(row, col)
+      BigDecimal(_to_string(row, col))
+    end
+
+    def _to_decimal_internal(row, col)
+      lower, upper, _width, scale = __to_decimal_internal(row, col)
+      v = (upper * Converter::HALF_HUGEINT + lower).to_s
+      v[-scale, 0] = '.'
+      BigDecimal(v)
     end
   end
 end

--- a/test/duckdb_test/result_to_decimal_test.rb
+++ b/test/duckdb_test/result_to_decimal_test.rb
@@ -28,5 +28,13 @@ module DuckDBTest
     def test_result_to_decimal_positive1
       do_result_to_decimal_test(1.23456789)
     end
+
+    def test_result_to_decimal_positive2
+      do_result_to_decimal_test(123.456789)
+    end
+
+    def test_result_to_decimal_positive3
+      do_result_to_decimal_test(123_456_789)
+    end
   end
 end

--- a/test/duckdb_test/result_to_decimal_test.rb
+++ b/test/duckdb_test/result_to_decimal_test.rb
@@ -22,10 +22,10 @@ module DuckDBTest
       prepare_test_value(value)
       result = @con.query('SELECT decimal_value FROM decimals')
       assert_equal(value, result.first.first)
+      assert_instance_of(BigDecimal, result.first.first)
     end
 
-    # FIXME: Expected: 1.23456789, but Actual: "1.23456789"
-    def NG_test_result_to_decimal_positive1
+    def test_result_to_decimal_positive1
       do_result_to_decimal_test(1.23456789)
     end
   end


### PR DESCRIPTION
refs #470, #448

Benchmark

```
$ ruby benchmark/to_bigdecimal_ips.rb
Warming up --------------------------------------
         _to_decimal    73.478k i/100ms
_to_decimal_internal   122.871k i/100ms
Calculating -------------------------------------
         _to_decimal    705.637k (± 2.7%) i/s -      3.600M in   5.106288s
_to_decimal_internal      1.161M (± 2.4%) i/s -      5.898M in   5.084870s
```