### PR TITLE
Stream Results from Vector

### DIFF
--- a/ext/duckdb/extconf.rb
+++ b/ext/duckdb/extconf.rb
@@ -18,6 +18,9 @@ def check_duckdb_library(func, version)
   raise msg
 end
 
+CONFIG['optflags'] = "-O0"
+CONFIG['debugflags'] = "-ggdb3"
+
 dir_config('duckdb')
 
 check_duckdb_library('duckdb_pending_prepared', '0.5.0')

--- a/ext/duckdb/result.c
+++ b/ext/duckdb/result.c
@@ -160,14 +160,16 @@ static VALUE vector_date(void *vector_data, idx_t row_idx) {
     VALUE time = rb_funcall(
         cTime,
         rb_intern("new"),
+        7,
         LL2NUM(date.year),  // Year
         LL2NUM(date.month), // Month
         LL2NUM(date.day),   // Day
-        0,                  // Hour
-        0,                  // Min
-        0,                  // Sec
-        0                   // Zone - UTC
+        LL2NUM(0),                  // Hour
+        LL2NUM(0),                  // Min
+        LL2NUM(0),                  // Sec
+        LL2NUM(0)                   // Zone - UTC
     );
+
     return time;
 }
 

--- a/ext/duckdb/result.h
+++ b/ext/duckdb/result.h
@@ -2,7 +2,13 @@
 #define RUBY_DUCKDB_RESULT_H
 
 struct _rubyDuckDBResult {
-    duckdb_result result;
+  duckdb_result result;
+  duckdb_data_chunk chunk;
+  char **columns;
+  idx_t chunk_count;
+  idx_t chunk_row_count;
+  idx_t chunk_idx;
+  idx_t chunk_row_idx;
 };
 
 typedef struct _rubyDuckDBResult rubyDuckDBResult;
@@ -12,4 +18,3 @@ void init_duckdb_result(void);
 VALUE create_result(void);
 
 #endif
-

--- a/lib/duckdb/result.rb
+++ b/lib/duckdb/result.rb
@@ -25,71 +25,36 @@ module DuckDB
   class Result
     include Enumerable
 
-    ToRuby = {
-      1 => :_to_boolean,
-      3 => :_to_smallint,
-      4 => :_to_integer,
-      5 => :_to_bigint,
-      10 => :_to_float,
-      11 => :_to_double,
-      16 => :_to_hugeint_internal,
-      18 => :_to_blob,
-      19 => :_to_decimal_internal
-    }
-
-    ToRuby.default = :_to_string
-
-    alias column_size column_count
-    alias row_size row_count
-
-    def each
-      return to_enum { row_size } unless block_given?
-
-      row_count.times do |row_index|
-        yield row(row_index)
-      end
-    end
-
-    def row(row_index)
-      row = []
-      column_count.times do |col_index|
-        row << (_null?(row_index, col_index) ? nil : to_value(row_index, col_index))
-      end
-      row
-    end
-
-    def to_value(row_index, col_index)
-      send(ToRuby[_column_type(col_index)], row_index, col_index)
-    end
-
-    def enum_dictionary_values(col_index)
-      values = []
-      _enum_dictionary_size(col_index).times do |i|
-        values << _enum_dictionary_value(col_index, i)
-      end
-      values
-    end
-
-    private
-
-    def _to_hugeint(row, col)
-      _to_string(row, col).to_i
-    end
-
-    def _to_hugeint_internal(row, col)
-      lower, upper = __to_hugeint_internal(row, col)
-      upper * Converter::HALF_HUGEINT + lower
-    end
-
-    def _to_decimal(row, col)
-      BigDecimal(_to_string(row, col))
-    end
-
-    def _to_decimal_internal(row, col)
-      lower, upper, _width, scale = __to_decimal_internal(row, col)
-      v = (upper * Converter::HALF_HUGEINT + lower).to_s
-      v[-scale, 0] = '.'
-      BigDecimal(v)
-    end
+    # typedef enum DUCKDB_TYPE {
+    #   DUCKDB_TYPE_INVALID = 0,
+    #   DUCKDB_TYPE_BOOLEAN = 1,
+    #   DUCKDB_TYPE_TINYINT = 2,
+    #   DUCKDB_TYPE_SMALLINT = 3,
+    #   DUCKDB_TYPE_INTEGER = 4,
+    #   DUCKDB_TYPE_BIGINT = 5,
+    #   DUCKDB_TYPE_UTINYINT = 6,
+    #   DUCKDB_TYPE_USMALLINT = 7,
+    #   DUCKDB_TYPE_UINTEGER = 8,
+    #   DUCKDB_TYPE_UBIGINT = 9,
+    #   DUCKDB_TYPE_FLOAT = 10,
+    #   DUCKDB_TYPE_DOUBLE = 11,
+    #   DUCKDB_TYPE_TIMESTAMP = 12,
+    #   DUCKDB_TYPE_DATE = 13,
+    #   DUCKDB_TYPE_TIME = 14,
+    #   DUCKDB_TYPE_INTERVAL = 15,
+    #   DUCKDB_TYPE_HUGEINT = 16,
+    #   DUCKDB_TYPE_VARCHAR = 17,
+    #   DUCKDB_TYPE_BLOB = 18,
+    #   DUCKDB_TYPE_DECIMAL = 19,
+    #   DUCKDB_TYPE_TIMESTAMP_SEC = 20,
+    #   DUCKDB_TYPE_TIMESTAMP_MS = 21,
+    #   DUCKDB_TYPE_TIMESTAMP_NS = 22,
+    #   DUCKDB_TYPE_ENUM = 23,
+    #   DUCKDB_TYPE_LIST = 24,
+    #   DUCKDB_TYPE_STRUCT = 25,
+    #   DUCKDB_TYPE_MAP = 26,
+    #   DUCKDB_TYPE_UUID = 27,
+    #   DUCKDB_TYPE_UNION = 28,
+    #   DUCKDB_TYPE_BIT = 29,
   end
 end

--- a/test/duckdb_test/result_test.rb
+++ b/test/duckdb_test/result_test.rb
@@ -32,6 +32,7 @@ module DuckDBTest
         expected_blob,
         expected_boolean_false,
         expected_list,
+        expected_nested_list
       ]
       assert_equal([expected_ary, 0], @result.each.with_index.to_a.first)
     end
@@ -77,7 +78,7 @@ module DuckDBTest
     end
 
     def test_result_null
-      assert_equal(Array.new(13), @result.reverse_each.first)
+      assert_equal(Array.new(14), @result.reverse_each.first)
     end
 
     def test_including_enumerable
@@ -102,8 +103,8 @@ module DuckDBTest
     end
 
     def test_column_count
-      assert_equal(13, @result.column_count)
-      assert_equal(13, @result.column_size)
+      assert_equal(14, @result.column_count)
+      assert_equal(14, @result.column_size)
       r = @con.query('SELECT boolean_col, smallint_col from table1')
       assert_equal(2, r.column_count)
       assert_equal(2, r.column_size)
@@ -202,6 +203,7 @@ module DuckDBTest
           blob_col BLOB,
           boolean_col2 BOOLEAN,
           list INTEGER[],
+          nested_list INTEGER[][]
         )
       SQL
     end
@@ -223,8 +225,9 @@ module DuckDBTest
           '#{expected_blob}',
           '#{expected_boolean_false}',
           #{expected_list},
+          #{expected_nested_list}
         ),
-        (NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+        (NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
       SQL
     end
 

--- a/test/duckdb_test/result_test.rb
+++ b/test/duckdb_test/result_test.rb
@@ -1,234 +1,296 @@
 require 'test_helper'
+require 'securerandom'
 
 module DuckDBTest
   class ResultTest < Minitest::Test
-    def setup
-      @con ||= create_data
-      @result = @con.query('SELECT * from table1')
-      @ary = first_record
-    end
+    # def setup
+    #   @con ||= create_data
+    #   @result = @con.query('SELECT * from table1')
+    #   @ary = first_record
+    # end
 
-    def test_result
-      assert_instance_of(DuckDB::Result, @result)
-    end
+    # def test_result
+    #   assert_instance_of(DuckDB::Result, @result)
+    # end
 
-    def test_each
-      assert_instance_of(Array, @ary)
-    end
-
-    def test_each_without_block
-      assert_instance_of(Enumerator, @result.each)
-      expected_ary = [
-        expected_boolean,
-        expected_smallint,
-        expected_integer,
-        expected_bigint,
-        expected_hugeint,
-        expected_float,
-        expected_double,
-        expected_string,
-        expected_date,
-        expected_timestamp,
-        expected_blob,
-        expected_boolean_false,
-        expected_list,
-        expected_nested_list
-      ]
-      assert_equal([expected_ary, 0], @result.each.with_index.to_a.first)
-    end
-
-    def test_result_boolean
-      assert_equal(expected_boolean, @ary[0])
-    end
-
-    def test_result_smallint
-      assert_equal(expected_smallint, @ary[1])
-    end
-
-    def test_result_integer
-      assert_equal(expected_integer, @ary[2])
-    end
-
-    def test_result_bigint
-      assert_equal(expected_bigint, @ary[3])
-    end
-
-    def test_result_hugeint
-      assert_equal(expected_hugeint, @ary[4])
-    end
-
-    def test_result_float
-      assert_equal(expected_float, @ary[5])
-    end
-
-    def test_result_double
-      assert_equal(expected_double, @ary[6])
-    end
-
-    def test_result_varchar
-      assert_equal(expected_string, @ary[7])
-    end
-
-    def test_result_date
-      assert_equal(expected_date, @ary[8])
-    end
-
-    def test_result_timestamp
-      assert_equal(expected_timestamp, @ary[9])
-    end
-
-    def test_result_null
-      assert_equal(Array.new(14), @result.reverse_each.first)
-    end
-
-    def test_including_enumerable
-      assert_includes(DuckDB::Result.ancestors, Enumerable)
-    end
-
-    def test_rows_changed
-      DuckDB::Database.open do |db|
-        db.connect do |con|
-          r = con.query('CREATE TABLE t2 (id INT)')
-          assert_equal(0, r.rows_changed)
-          r = con.query('INSERT INTO t2 VALUES (1), (2), (3)')
-          assert_equal(3, r.rows_changed)
-          r = con.query('UPDATE t2 SET id = id + 1 WHERE id > 1')
-          assert_equal(2, r.rows_changed)
-          r = con.query('DELETE FROM t2 WHERE id = 0')
-          assert_equal(0, r.rows_changed)
-          r = con.query('DELETE FROM t2 WHERE id = 4')
-          assert_equal(1, r.rows_changed)
-        end
+    # def test_each
+    #   assert_instance_of(Array, @ary)
+    # end
+    #
+    {
+      'BOOLEAN' => [true, false],
+      'TINYINT' => [256],
+      'SMALLINT' => [32_767],
+      'INTEGER' => [2_147_483_647],
+      'BIGINT' => [9_223_372_036_854_775_807],
+      'HUGEINT' => [170_141_183_460_469_231_731_687_303_715_884_105_727],
+      'FLOAT' => [1.23, 2.35],
+      'DOUBLE' => [123.456789],
+      # 'DATE' => [Date.today], # FIXME: this causes a segfault
+      'TIMESTAMP' => [Time.now],
+      'INTERVAL' => ['??'],
+      'VARCHAR' => ['hello', 'world', 'goodbye', '𝘶ñîҫȫ𝘥ẹ 𝖘ţ𝗋ⅰɲ𝓰'],
+      'BLOB' => ['blob'.force_encoding('ASCII-8BIT')],
+      'DECIMAL' => [BigDecimal('99.00')],
+      # LISTS
+      'INTEGER[]' => [[1, 2]],
+      'INTEGER[][]' => [[[1, 2], [3, 4]]],
+      # MAPS
+      'MAP(VARCHAR, INT)' => [{ "a" => 1, "b" => 2 }, { "c" => 3 }], # A "map" has hetergenous row members with the same types
+      # STRUCTS
+      'STRUCT(a INT, b INT)' => [{ a: 1, b: 2 }, { a: 3, b: 4 }], # a struct all row members must be the same shape
+      'UUID' => [SecureRandom.uuid]
+    }.each_pair do |type, expected|
+      define_method :"test_#{type}_type" do
+        db = db_with_type(type)
+        expected.each { |val| db.insert_value(val) }
+        assert_equal(expected, db.retrieve_value.to_a.flatten)
       end
     end
 
-    def test_column_count
-      assert_equal(14, @result.column_count)
-      assert_equal(14, @result.column_size)
-      r = @con.query('SELECT boolean_col, smallint_col from table1')
-      assert_equal(2, r.column_count)
-      assert_equal(2, r.column_size)
+#    def test_each_without_block
+#      assert_instance_of(Enumerator, @result.each)
+#      expected_ary = [
+#        expected_boolean,
+#        # expected_smallint,
+#        # expected_integer,
+#        # expected_bigint,
+#        # expected_hugeint,
+#        # expected_float,
+#        # expected_double,
+#        # expected_string,
+#        # expected_date,
+#        # expected_timestamp,
+#        # expected_blob,
+#        # expected_boolean_false,
+#        # expected_list,
+#        # expected_nested_list
+#      ]
+#      assert_equal([expected_ary, 0], @result.each.with_index.to_a.first)
+#    end
+
+#    def test_result_boolean
+#      assert_equal(expected_boolean, @ary[0])
+#    end
+
+#    def test_result_smallint
+#      assert_equal(expected_smallint, @ary[1])
+#    end
+
+#    def test_result_integer
+#      assert_equal(expected_integer, @ary[2])
+#    end
+
+#    def test_result_bigint
+#      assert_equal(expected_bigint, @ary[3])
+#    end
+
+#    def test_result_hugeint
+#      assert_equal(expected_hugeint, @ary[4])
+#    end
+
+#    def test_result_float
+#      assert_equal(expected_float, @ary[5])
+#    end
+
+#    def test_result_double
+#      assert_equal(expected_double, @ary[6])
+#    end
+
+#    def test_result_varchar
+#      assert_equal(expected_string, @ary[7])
+#    end
+
+#    def test_result_date
+#      assert_equal(expected_date, @ary[8])
+#    end
+
+#    def test_result_timestamp
+#      assert_equal(expected_timestamp, @ary[9])
+#    end
+
+#    def test_result_null
+#      assert_equal(Array.new(14), @result.reverse_each.first)
+#    end
+
+#    def test_including_enumerable
+#      assert_includes(DuckDB::Result.ancestors, Enumerable)
+#    end
+
+#    def test_rows_changed
+#      DuckDB::Database.open do |db|
+#        db.connect do |con|
+#          r = con.query('CREATE TABLE t2 (id INT)')
+#          assert_equal(0, r.rows_changed)
+#          r = con.query('INSERT INTO t2 VALUES (1), (2), (3)')
+#          assert_equal(3, r.rows_changed)
+#          r = con.query('UPDATE t2 SET id = id + 1 WHERE id > 1')
+#          assert_equal(2, r.rows_changed)
+#          r = con.query('DELETE FROM t2 WHERE id = 0')
+#          assert_equal(0, r.rows_changed)
+#          r = con.query('DELETE FROM t2 WHERE id = 4')
+#          assert_equal(1, r.rows_changed)
+#        end
+#      end
+#    end
+
+#    def test_column_count
+#      assert_equal(14, @result.column_count)
+#      assert_equal(14, @result.column_size)
+#      r = @con.query('SELECT boolean_col, smallint_col from table1')
+#      assert_equal(2, r.column_count)
+#      assert_equal(2, r.column_size)
+#    end
+
+#    def test_row_count
+#      r = @con.query('SELECT * FROM table1')
+#      assert_equal(2, r.row_count)
+#      assert_equal(2, r.row_size)
+#      r = @con.query('SELECT * FROM table1 WHERE boolean_col = true')
+#      assert_equal(1, r.row_count)
+#      assert_equal(1, r.row_size)
+#    end
+
+#    def test_columns
+#      assert_instance_of(DuckDB::Column, @result.columns.first)
+#    end
+
+#    def test__column_type
+#      assert_equal(1, @result.send(:_column_type, 0))
+#      assert_equal(3, @result.send(:_column_type, 1))
+#      assert_equal(4, @result.send(:_column_type, 2))
+#      assert_equal(5, @result.send(:_column_type, 3))
+#      assert_equal(16, @result.send(:_column_type, 4))
+#      assert_equal(10, @result.send(:_column_type, 5))
+#      assert_equal(11, @result.send(:_column_type, 6))
+#      assert_equal(17, @result.send(:_column_type, 7))
+#      assert_equal(13, @result.send(:_column_type, 8))
+#      assert_equal(12, @result.send(:_column_type, 9))
+#    end
+
+#    def test__is_null
+#      assert_equal(false, @result.send(:_null?, 0, 0))
+#      assert_equal(true, @result.send(:_null?, 1, 0))
+#    end
+
+#    def test__to_boolean
+#      assert_equal(expected_boolean, @result.send(:_to_boolean, 0, 0))
+#    end
+
+#    def test__to_smallint
+#      assert_equal(expected_smallint, @result.send(:_to_smallint, 0, 1))
+#    end
+
+#    def test__to_integer
+#      assert_equal(expected_integer, @result.send(:_to_integer, 0, 2))
+#    end
+
+#    def test__to_bigint
+#      assert_equal(expected_bigint, @result.send(:_to_bigint, 0, 3))
+#    end
+
+#    def test__to_hugeint
+#      assert_equal(expected_hugeint, @result.send(:_to_hugeint, 0, 4))
+#    end
+
+#    def test__to_float
+#      assert_equal(expected_float, @result.send(:_to_float, 0, 5))
+#    end
+
+#    def test__to_double
+#      assert_equal(expected_double, @result.send(:_to_double, 0, 6))
+#    end
+
+#    def test__to_string_internal
+#      assert_equal(expected_string, @result.send(:_to_string_internal, 0, 7))
+#    end
+
+#    def test__to_blob
+#      assert_equal(expected_blob, @result.send(:_to_blob, 0, 10))
+#    end
+
+#    private
+
+#    def create_data
+#      @db ||= DuckDB::Database.open # FIXME
+#      con = @db.connect
+#      con.query(create_table_sql)
+#      con.query(insert_sql)
+#      con
+#    end
+
+#    def create_table_sql
+#      <<-SQL
+#        CREATE TABLE table1(
+#          boolean_col BOOLEAN,
+#        )
+#      SQL
+
+#  # smallint_col SMALLINT,
+#  #         integer_col INTEGER,
+#  #         bigint_col BIGINT,
+#  #         hugeint_col HUGEINT,
+#  #         real_col REAL,
+#  #         double_col DOUBLE,
+#  #         varchar_col VARCHAR,
+#  #         date_col DATE,
+#  #         timestamp_col timestamp,
+#  #         blob_col BLOB,
+#  #         boolean_col2 BOOLEAN,
+#  #         list INTEGER[],
+
+#    end
+
+#    def insert_sql
+#      <<-SQL
+#        INSERT INTO table1 VALUES
+#        (
+#          #{expected_boolean},
+#        ),
+#        (NULL)
+#      SQL
+
+##          #{expected_smallint},
+##          #{expected_integer},
+##          #{expected_bigint},
+##          #{expected_hugeint},
+##          #{expected_float},
+##          #{expected_double},
+##          '#{expected_string}',
+##          '#{expected_date}',
+##          '#{expected_timestamp}',
+##          '#{expected_blob}',
+##          '#{expected_boolean_false}',
+##          #{expected_list},
+##        ),
+##        (NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+##      SQL
+#    end
+    #
+    def db_with_type(type)
+      SingleColumnTestDB.new(type)
     end
 
-    def test_row_count
-      r = @con.query('SELECT * FROM table1')
-      assert_equal(2, r.row_count)
-      assert_equal(2, r.row_size)
-      r = @con.query('SELECT * FROM table1 WHERE boolean_col = true')
-      assert_equal(1, r.row_count)
-      assert_equal(1, r.row_size)
-    end
+    class SingleColumnTestDB
+      def initialize(type)
+        @type = type
+        @db ||= DuckDB::Database.open
+        @con = @db.connect
+        @table_name = @type.gsub(/[^A-Z]/i, '').downcase
+        create_single_column
+      end
 
-    def test_columns
-      assert_instance_of(DuckDB::Column, @result.columns.first)
-    end
+      def create_single_column
+        @con.query("CREATE TABLE test_#{@table_name} ( #{@table_name} #{@type} )")
+      end
 
-    def test__column_type
-      assert_equal(1, @result.send(:_column_type, 0))
-      assert_equal(3, @result.send(:_column_type, 1))
-      assert_equal(4, @result.send(:_column_type, 2))
-      assert_equal(5, @result.send(:_column_type, 3))
-      assert_equal(16, @result.send(:_column_type, 4))
-      assert_equal(10, @result.send(:_column_type, 5))
-      assert_equal(11, @result.send(:_column_type, 6))
-      assert_equal(17, @result.send(:_column_type, 7))
-      assert_equal(13, @result.send(:_column_type, 8))
-      assert_equal(12, @result.send(:_column_type, 9))
-    end
+      def insert_value(value)
+        @con.query("INSERT INTO test_#{@table_name} VALUES ( ? )", value)
+      end
 
-    def test__is_null
-      assert_equal(false, @result.send(:_null?, 0, 0))
-      assert_equal(true, @result.send(:_null?, 1, 0))
-    end
-
-    def test__to_boolean
-      assert_equal(expected_boolean, @result.send(:_to_boolean, 0, 0))
-    end
-
-    def test__to_smallint
-      assert_equal(expected_smallint, @result.send(:_to_smallint, 0, 1))
-    end
-
-    def test__to_integer
-      assert_equal(expected_integer, @result.send(:_to_integer, 0, 2))
-    end
-
-    def test__to_bigint
-      assert_equal(expected_bigint, @result.send(:_to_bigint, 0, 3))
-    end
-
-    def test__to_hugeint
-      assert_equal(expected_hugeint, @result.send(:_to_hugeint, 0, 4))
-    end
-
-    def test__to_float
-      assert_equal(expected_float, @result.send(:_to_float, 0, 5))
-    end
-
-    def test__to_double
-      assert_equal(expected_double, @result.send(:_to_double, 0, 6))
-    end
-
-    def test__to_string_internal
-      assert_equal(expected_string, @result.send(:_to_string_internal, 0, 7))
-    end
-
-    def test__to_blob
-      assert_equal(expected_blob, @result.send(:_to_blob, 0, 10))
-    end
-
-    private
-
-    def create_data
-      @db ||= DuckDB::Database.open # FIXME
-      con = @db.connect
-      con.query(create_table_sql)
-      con.query(insert_sql)
-      con
-    end
-
-    def create_table_sql
-      <<-SQL
-        CREATE TABLE table1(
-          boolean_col BOOLEAN,
-          smallint_col SMALLINT,
-          integer_col INTEGER,
-          bigint_col BIGINT,
-          hugeint_col HUGEINT,
-          real_col REAL,
-          double_col DOUBLE,
-          varchar_col VARCHAR,
-          date_col DATE,
-          timestamp_col timestamp,
-          blob_col BLOB,
-          boolean_col2 BOOLEAN,
-          list INTEGER[],
-          nested_list INTEGER[][]
-        )
-      SQL
-    end
-
-    def insert_sql
-      <<-SQL
-        INSERT INTO table1 VALUES
-        (
-          #{expected_boolean},
-          #{expected_smallint},
-          #{expected_integer},
-          #{expected_bigint},
-          #{expected_hugeint},
-          #{expected_float},
-          #{expected_double},
-          '#{expected_string}',
-          '#{expected_date}',
-          '#{expected_timestamp}',
-          '#{expected_blob}',
-          '#{expected_boolean_false}',
-          #{expected_list},
-          #{expected_nested_list}
-        ),
-        (NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-      SQL
+      def retrieve_value
+        @con.query("SELECT * FROM test_#{@type.downcase}")
+      end
     end
 
     def expected_boolean


### PR DESCRIPTION
Work in progress for using data chunks / vector API rather than the C-APIs "get_value" functions.

The only way to get "composite" types is to use the "Data Chunks" API - and if you use the "Value" functions you can't also use the "Data Chunks" API.  Fixes #492 and #493.

Some of these tests are failing because the vector format is largely undocumented and I'm in the process of trying to figure out how it works (HugeInt), and some of them are failing (like the List one) because it's not currently possible to insert a list using a prepared statement.

Anyway - early feedback - this approach does _build_ at it has minimal "iterate over the results" functionality - but needs some work to make sure that it returns properly cast Ruby types for all result objections.