### PR TITLE
fix DuckDB::Config.set_config error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # ChangeLog
 
+## Breaking Change
+
+- DuckDB::Config.set_config does not raise exception when invalid key specified.
+  Instead, DuckDB::Database.open raises DuckDB::Error with invalid key configuration.
+
 # 0.8.0
 - bump duckdb to 0.8.0
 - add DuckDB::Result#_to_decimal_internal

--- a/test/duckdb_test/config_test.rb
+++ b/test/duckdb_test/config_test.rb
@@ -39,14 +39,24 @@ module DuckDBTest
 
     def test_set_config
       config = DuckDB::Config.new
-      config.set_config('access_mode', 'READ_ONLY')
+      assert_instance_of(DuckDB::Config, config.set_config('access_mode', 'READ_ONLY'))
 
       assert_raises(DuckDB::Error) do
         config.set_config('access_mode', 'INVALID_VALUE')
       end
+    end
 
-      assert_raises(DuckDB::Error) do
-        config.set_config('invalid-key', 'READ_ONLY')
+    def test_set_invalid_option
+      config = DuckDB::Config.new
+      if Gem::Version.new('0.8.1') <= DuckDB::LIBRARY_VERSION
+        assert_instance_of(DuckDB::Config, config.set_config('aaa_invalid_option', 'READ_ONLY'))
+        assert_raises(DuckDB::Error) do
+          DuckDB::Database.open(nil, config)
+        end
+      else
+        assert_raises(DuckDB::Error) do
+          config.set_config('aaa_invalid_option', 'READ_ONLY')
+        end
       end
     end
   end

--- a/test/duckdb_test/config_test.rb
+++ b/test/duckdb_test/config_test.rb
@@ -48,7 +48,7 @@ module DuckDBTest
 
     def test_set_invalid_option
       config = DuckDB::Config.new
-      if Gem::Version.new('0.8.1') <= DuckDB::LIBRARY_VERSION
+      if Gem::Version.new('0.8.1') <= Gem::Version.new(DuckDB::LIBRARY_VERSION)
         assert_instance_of(DuckDB::Config, config.set_config('aaa_invalid_option', 'READ_ONLY'))
         assert_raises(DuckDB::Error) do
           DuckDB::Database.open(nil, config)


### PR DESCRIPTION
In duckdb >= 0.8.1, duckdb_set_config does not return error with invalid configuration key.

Instead, duckdb_open_ext returns error with configuration having invalid configuration.