### PR TITLE
Use chunk data for DuckDB::Result.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # ChangeLog
 
+- add `DuckDB::Result#chunk_each`, `DuckDB::Result.use_chunk_each=`, `DuckDB::Result#use_chunk_each?`
+  The current behavior of `DuckDB::Result#each` is same as older version.
+  But `DuckDB::Result#each` behavior will be changed like as `DuckDB::Result#chunk_each` in near future release.
+  And there are some breaking changes.
+  Write `DuckdDB::Result.use_chunk_each = true` if you want to try new behavior.
+    ```
+    DuckDB::Result.use_chunk_each = true
+
+    result = con.query('SELECT ....')
+    result.each do |record| # <= each method behavior is same as DuckDB::Result#chunk_each
+      ...
+    end
+    ```
+- support enum type in DuckDB::Result#chunk_each.
+- support uuid type in DuckDB::Result#chunk_each.
+
 ## Breaking Change
 
 - DuckDB::Config.set_config does not raise exception when invalid key specified.

--- a/ext/duckdb/result.c
+++ b/ext/duckdb/result.c
@@ -584,7 +584,7 @@ static VALUE vector_uuid(void* vector_data, idx_t row_idx) {
     VALUE mConverter = rb_const_get(mDuckDB, rb_intern("Converter"));
     return rb_funcall(mConverter, rb_intern("_to_uuid_from_vector"), 2,
             ULL2NUM(hugeint.lower),
-            LL2NUM(hugeint.upper ^ ((int64_t)1 << 63))
+            LL2NUM(hugeint.upper)
             );
 }
 

--- a/ext/duckdb/result.c
+++ b/ext/duckdb/result.c
@@ -448,9 +448,9 @@ static VALUE vector_blob(void* vector_data, idx_t row_idx) {
 static VALUE vector_varchar(void* vector_data, idx_t row_idx) {
     duckdb_string_t s = (((duckdb_string_t *)vector_data)[row_idx]);
     if(duckdb_string_is_inlined(s)) {
-        return rb_str_new(s.value.inlined.inlined, s.value.inlined.length);
+        return rb_utf8_str_new(s.value.inlined.inlined, s.value.inlined.length);
     } else {
-        return rb_str_new(s.value.pointer.ptr, s.value.pointer.length);
+        return rb_utf8_str_new(s.value.pointer.ptr, s.value.pointer.length);
     }
 }
 

--- a/ext/duckdb/result.c
+++ b/ext/duckdb/result.c
@@ -428,7 +428,7 @@ static VALUE vector_value(duckdb_vector vector, idx_t row_idx) {
     return obj;
 }
 
-static VALUE duckdb_result_stream_each(VALUE oDuckDBResult) {
+static VALUE duckdb_result_chunk_each(VALUE oDuckDBResult) {
     rubyDuckDBResult *ctx;
     VALUE row;
     idx_t col_count;
@@ -493,5 +493,5 @@ void init_duckdb_result(void) {
     rb_define_private_method(cDuckDBResult, "_enum_internal_type", duckdb_result__enum_internal_type, 1);
     rb_define_private_method(cDuckDBResult, "_enum_dictionary_size", duckdb_result__enum_dictionary_size, 1);
     rb_define_private_method(cDuckDBResult, "_enum_dictionary_value", duckdb_result__enum_dictionary_value, 2);
-    rb_define_method(cDuckDBResult, "stream_each", duckdb_result_stream_each, 0);
+    rb_define_method(cDuckDBResult, "chunk_each", duckdb_result_chunk_each, 0);
 }

--- a/ext/duckdb/result.c
+++ b/ext/duckdb/result.c
@@ -473,7 +473,7 @@ static VALUE vector_decimal(duckdb_logical_type ty, void* vector_data, idx_t row
             INT2FIX(width),
             INT2FIX(scale),
             ULL2NUM(value.lower),
-            LL2NUM(value.upper),
+            LL2NUM(value.upper)
             );
 }
 

--- a/ext/duckdb/result.c
+++ b/ext/duckdb/result.c
@@ -38,6 +38,16 @@ static VALUE duckdb_result__enum_dictionary_size(VALUE oDuckDBResult, VALUE col_
 static VALUE duckdb_result__enum_dictionary_value(VALUE oDuckDBResult, VALUE col_idx, VALUE idx);
 
 #ifdef HAVE_DUCKDB_H_GE_V080
+static VALUE vector_date(void *vector_data, idx_t row_idx);
+static VALUE vector_timestamp(void* vector_data, idx_t row_idx);
+static VALUE vector_interval(void* vector_data, idx_t row_idx);
+static VALUE vector_blob(void* vector_data, idx_t row_idx);
+static VALUE vector_varchar(void* vector_data, idx_t row_idx);
+static VALUE vector_hugeint(void* vector_data, idx_t row_idx);
+static VALUE vector_decimal(duckdb_logical_type ty, void* vector_data, idx_t row_idx);
+static VALUE vector_enum(duckdb_logical_type ty, void* vector_data, idx_t row_idx);
+static VALUE vector_list(duckdb_vector vector, idx_t row_idx);
+static VALUE vector_struct(duckdb_logical_type ty, duckdb_vector vector, idx_t row_idx);
 static VALUE vector_value(duckdb_vector vector, idx_t row_idx);
 static VALUE duckdb_result_chunk_each(VALUE oDuckDBResult);
 #endif
@@ -487,8 +497,10 @@ static VALUE vector_enum(duckdb_logical_type ty, void* vector_data, idx_t row_id
         case DUCKDB_TYPE_UTINYINT:
             index = ((uint8_t *) vector_data)[row_idx];
             p = duckdb_enum_dictionary_value(ty, index);
-            value = rb_utf8_str_new_cstr(p);
-            duckdb_free(p);
+            if (p) {
+                value = rb_utf8_str_new_cstr(p);
+                duckdb_free(p);
+            }
             break;
         default:
             rb_warn("Unknown enum internal type %d", type);

--- a/lib/duckdb/converter.rb
+++ b/lib/duckdb/converter.rb
@@ -37,7 +37,7 @@ module DuckDB
     end
 
     def _to_uuid_from_vector(lower, upper)
-      str = ((upper * Converter::HALF_HUGEINT) + lower).to_s(16).rjust(32, '0')
+      str = _to_hugeint_from_vector(lower, upper).to_s(16).rjust(32, '0')
       "#{str[0, 8]}-#{str[8, 4]}-#{str[12, 4]}-#{str[16, 4]}-#{str[20, 12]}"
     end
 

--- a/lib/duckdb/converter.rb
+++ b/lib/duckdb/converter.rb
@@ -29,11 +29,16 @@ module DuckDB
       hash[:year] = months / 12
       hash[:month] = months % 12
       hash[:day] = days
-      hash[:hour] = micros / 3600_000_000
-      hash[:min] = (micros % 3600_000_000) / 60_000_000
+      hash[:hour] = micros / 3_600_000_000
+      hash[:min] = (micros % 3_600_000_000) / 60_000_000
       hash[:sec] = (micros % 60_000_000) / 1_000_000
       hash[:usec] = micros % 1_000_000
       hash
+    end
+
+    def _to_uuid_from_vector(lower, upper)
+      str = ((upper * Converter::HALF_HUGEINT) + lower).to_s(16).rjust(32, '0')
+      "#{str[0, 8]}-#{str[8, 4]}-#{str[12, 4]}-#{str[16, 4]}-#{str[20, 12]}"
     end
 
     private

--- a/lib/duckdb/converter.rb
+++ b/lib/duckdb/converter.rb
@@ -4,6 +4,38 @@ module DuckDB
   module Converter
     HALF_HUGEINT = 1 << 64
 
+    module_function
+
+    def _to_date(year, month, day)
+      Time.new(year, month, day)
+    end
+
+    def _to_time(year, month, day, hour, minute, second, microsecond)
+      Time.local(year, month, day, hour, minute, second, microsecond)
+    end
+
+    def _to_hugeint_from_vector(lower, upper)
+      upper * Converter::HALF_HUGEINT + lower
+    end
+
+    def _to_decimal_from_vector(width, scale, lower, upper)
+      v = (upper * Converter::HALF_HUGEINT + lower).to_s
+      v[-scale, 0] = '.'
+      BigDecimal(v)
+    end
+
+    def _to_interval_from_vector(months, days, micros)
+      hash = { year: 0, month: 0, day: 0, hour: 0, min: 0, sec: 0, usec: 0 }
+      hash[:year] = months / 12
+      hash[:month] = months % 12
+      hash[:day] = days
+      hash[:hour] = micros / 3600_000_000
+      hash[:min] = (micros % 3600_000_000) / 60_000_000
+      hash[:sec] = (micros % 60_000_000) / 1_000_000
+      hash[:usec] = micros % 1_000_000
+      hash
+    end
+
     private
 
     def integer_to_hugeint(value)

--- a/lib/duckdb/converter.rb
+++ b/lib/duckdb/converter.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'date'
+
 module DuckDB
   module Converter
     HALF_HUGEINT = 1 << 64
@@ -8,7 +10,7 @@ module DuckDB
     module_function
 
     def _to_date(year, month, day)
-      Time.new(year, month, day)
+      Date.new(year, month, day)
     end
 
     def _to_time(year, month, day, hour, minute, second, microsecond)

--- a/lib/duckdb/result.rb
+++ b/lib/duckdb/result.rb
@@ -54,6 +54,8 @@ module DuckDB
 
     def each
       if self.class.use_chunk_each?
+        return chunk_each unless block_given?
+
         chunk_each { |row| yield row }
       else
         return to_enum { row_size } unless block_given?

--- a/lib/duckdb/result.rb
+++ b/lib/duckdb/result.rb
@@ -43,7 +43,7 @@ module DuckDB
     alias row_size row_count
 
     def self.use_chunk_each=(val)
-      raise DuckDB::Error, 'chunk_each is not available. Try to rebuild ruby-duckdb with duckdb >= 0.8.0.' unless instance_methods.include?(:chunk_each)
+      raise DuckDB::Error, 'chunk_each is not available. Install duckdb >= 0.8.0 and rerun `gem install duckdb`.' unless instance_methods.include?(:chunk_each)
 
       @use_chunk_each = val
     end

--- a/test/duckdb_test/result_chunk_each_test.rb
+++ b/test/duckdb_test/result_chunk_each_test.rb
@@ -3,56 +3,58 @@
 require 'test_helper'
 require 'securerandom'
 
-module DuckDBTest
-  class ResultChunkEach < Minitest::Test
-    def setup
-      DuckDB::Result.use_chunk_each = true
-      @db = DuckDB::Database.open
-      @con = @db.connect
-    end
+if DuckDB::Result.instance_methods.include?(:chunk_each)
+  module DuckDBTest
+    class ResultChunkEach < Minitest::Test
+      def setup
+        DuckDB::Result.use_chunk_each = true
+        @db = DuckDB::Database.open
+        @con = @db.connect
+      end
 
-    def teardown
-      DuckDB::Result.use_chunk_each = false
-      @db.close
-    end
+      def teardown
+        DuckDB::Result.use_chunk_each = false
+        @db.close
+      end
 
-    UUID = SecureRandom.uuid
-    ENUM_SQL = "CREATE TYPE mood AS ENUM ('sad', 'ok', 'happy');"
-    TEST_TABLES = [
-      #      DB Type  ,  DB declartion                 String Rep                                  Ruby Type             Ruby Value
-      [:ok, 'BOOLEAN' , 'BOOLEAN',                     'true',                                     TrueClass,            true                                                ],
-      [:ok, 'TINYINT' , 'TINYINT',                     1,                                          Integer,              1                                                   ],
-      [:ok, 'SMALLINT', 'SMALLINT',                    32767,                                      Integer,              32_767                                              ],
-      [:ok, 'INTEGER',  'INTEGER',                     2147483647,                                 Integer,              2_147_483_647                                       ],
-      [:ok, 'BIGINT',   'BIGINT',                      9223372036854775807,                        Integer,              9_223_372_036_854_775_807                           ],
-      [:ok, 'HUGEINT',  'HUGEINT',                     170141183460469231731687303715884105727,    Integer,              170_141_183_460_469_231_731_687_303_715_884_105_727 ],
-      [:ok, 'FLOAT',    'FLOAT',                       12345.375,                                  Float,                12_345.375                                          ],
-      [:ok, 'DOUBLE',   'DOUBLE',                      123.456789,                                 Float,                123.456789                                          ],
-      [:ok, 'TIMESTAMP','TIMESTAMP',                   "'2019-11-03 12:34:56'",                    Time,                 Time.new(2019,11,3,12,34,56)                        ],
-      [:ok, 'DATE',     'DATE',                        "'2019-11-03'",                             Date,                 Date.new(2019,11,3)                                 ],
-      [:ok, 'NTERVAL',  'INTERVAL',                    "'2 days ago'",                             Hash,                 { year: 0, month: 0, day: -2, hour: 0, min: 0, sec: 0, usec: 0 } ],
-      [:ok, 'VARCHAR',  'VARCHAR',                     "'hello'",                                  String,               'hello'                                             ],
-      [:ok, 'VARCHAR',  'VARCHAR',                     "'𝘶ñîҫȫ𝘥ẹ 𝖘ţ𝗋ⅰɲ𝓰 😃'",                      String,               '𝘶ñîҫȫ𝘥ẹ 𝖘ţ𝗋ⅰɲ𝓰 😃'                                 ],
-      [:ok, 'BLOB',     'BLOB',                        "'blob'",                                   String,               String.new('blob', encoding: 'ASCII-8BIT')          ],
-      [:ok, 'ENUM',     'mood',                        "'happy'",                                  String,               'happy'                                             ],
-      [:ok, 'UUID',     'UUID',                        "'#{UUID}'",                                String,               UUID                                                ],
-      # FIXME: LIST, MAP STRUCT values are always nil
-      [:ng, 'LIST',     'INTEGER[]',                   '[1, 2]',                                   Array,                [1, 2]                                              ],
-      [:ng, 'LIST',     'INTEGER[][]',                 '[[1, 2], [3, 4]]',                         Array,                [[1, 2], [3, 4]]                                    ],
-      [:ng, 'MAP',      'MAP(INTEGER, INTEGER)',       'map {1: 2, 3: 4}',                         Hash,                 {1 => 2, 3 => 4}                                    ],
-      [:ng, 'STRUCT',   'STRUCT(a INTEGER, b INTEGER)', "{'a': 1, 'b': 2}",                        Hash,                 {"a" => 1, "b" => 2 }                               ],
-    ].freeze
+      UUID = SecureRandom.uuid
+      ENUM_SQL = "CREATE TYPE mood AS ENUM ('sad', 'ok', 'happy');"
+      TEST_TABLES = [
+        #      DB Type  ,  DB declartion                 String Rep                                  Ruby Type             Ruby Value
+        [:ok, 'BOOLEAN' , 'BOOLEAN',                     'true',                                     TrueClass,            true                                                ],
+        [:ok, 'TINYINT' , 'TINYINT',                     1,                                          Integer,              1                                                   ],
+        [:ok, 'SMALLINT', 'SMALLINT',                    32767,                                      Integer,              32_767                                              ],
+        [:ok, 'INTEGER',  'INTEGER',                     2147483647,                                 Integer,              2_147_483_647                                       ],
+        [:ok, 'BIGINT',   'BIGINT',                      9223372036854775807,                        Integer,              9_223_372_036_854_775_807                           ],
+        [:ok, 'HUGEINT',  'HUGEINT',                     170141183460469231731687303715884105727,    Integer,              170_141_183_460_469_231_731_687_303_715_884_105_727 ],
+        [:ok, 'FLOAT',    'FLOAT',                       12345.375,                                  Float,                12_345.375                                          ],
+        [:ok, 'DOUBLE',   'DOUBLE',                      123.456789,                                 Float,                123.456789                                          ],
+        [:ok, 'TIMESTAMP','TIMESTAMP',                   "'2019-11-03 12:34:56'",                    Time,                 Time.new(2019,11,3,12,34,56)                        ],
+        [:ok, 'DATE',     'DATE',                        "'2019-11-03'",                             Date,                 Date.new(2019,11,3)                                 ],
+        [:ok, 'NTERVAL',  'INTERVAL',                    "'2 days ago'",                             Hash,                 { year: 0, month: 0, day: -2, hour: 0, min: 0, sec: 0, usec: 0 } ],
+        [:ok, 'VARCHAR',  'VARCHAR',                     "'hello'",                                  String,               'hello'                                             ],
+        [:ok, 'VARCHAR',  'VARCHAR',                     "'𝘶ñîҫȫ𝘥ẹ 𝖘ţ𝗋ⅰɲ𝓰 😃'",                      String,               '𝘶ñîҫȫ𝘥ẹ 𝖘ţ𝗋ⅰɲ𝓰 😃'                                 ],
+        [:ok, 'BLOB',     'BLOB',                        "'blob'",                                   String,               String.new('blob', encoding: 'ASCII-8BIT')          ],
+        [:ok, 'ENUM',     'mood',                        "'happy'",                                  String,               'happy'                                             ],
+        [:ok, 'UUID',     'UUID',                        "'#{UUID}'",                                String,               UUID                                                ],
+        # FIXME: LIST, MAP STRUCT values are always nil
+        [:ng, 'LIST',     'INTEGER[]',                   '[1, 2]',                                   Array,                [1, 2]                                              ],
+        [:ng, 'LIST',     'INTEGER[][]',                 '[[1, 2], [3, 4]]',                         Array,                [[1, 2], [3, 4]]                                    ],
+        [:ng, 'MAP',      'MAP(INTEGER, INTEGER)',       'map {1: 2, 3: 4}',                         Hash,                 {1 => 2, 3 => 4}                                    ],
+        [:ng, 'STRUCT',   'STRUCT(a INTEGER, b INTEGER)', "{'a': 1, 'b': 2}",                        Hash,                 {"a" => 1, "b" => 2 }                               ],
+      ].freeze
 
-    TEST_TABLES.each_with_index do |spec, i|
-      do_test, db_type, db_declaration, string_rep, klass, ruby_val = *spec
-      define_method :"test_#{db_type}_type#{i}" do
-        skip if do_test == :ng
-        @con.query(ENUM_SQL)
-        @con.query("CREATE TABLE tests (col #{db_declaration})")
-        @con.query("INSERT INTO tests VALUES ( #{string_rep} )")
-        res = @con.query('SELECT * FROM tests').to_a[0][0]
-        assert_equal(ruby_val, res)
-        assert_equal(klass, res.class)
+      TEST_TABLES.each_with_index do |spec, i|
+        do_test, db_type, db_declaration, string_rep, klass, ruby_val = *spec
+        define_method :"test_#{db_type}_type#{i}" do
+          skip if do_test == :ng
+          @con.query(ENUM_SQL)
+          @con.query("CREATE TABLE tests (col #{db_declaration})")
+          @con.query("INSERT INTO tests VALUES ( #{string_rep} )")
+          res = @con.query('SELECT * FROM tests').to_a[0][0]
+          assert_equal(ruby_val, res)
+          assert_equal(klass, res.class)
+        end
       end
     end
   end

--- a/test/duckdb_test/result_chunk_each_test.rb
+++ b/test/duckdb_test/result_chunk_each_test.rb
@@ -1,42 +1,59 @@
 # frozen_string_literal: true
 
-#
-# require 'test_helper'
-#
-#   module DuckDBTest
-#     class ResultChunkEach < Minitest::Test
-#     test_table = <<~TABLE
-#     | DB Type   | DB declartion                  | String Rep                                | Ruby Type             |Ruby Value                                          |
-#     | BOOLEAN   | BOOLEAN                        | true                                      | TrueClass             |true                                                |
-#     | TINYINT   | TINYINT                        | 1                                         | Integer               |1                                                   |
-#     | SMALLINT  | SMALLINT                       | 32767                                     | Integer               |32_767                                              |
-#     | INTEGER   | INTEGER                        | 2147483647                                | Integer               |2_147_483_647                                       |
-#     | BIGINT    | BIGINT                         | 9223372036854775807                       | Integer               |9_223_372_036_854_775_807                           |
-#     | HUGEINT   | HUGEINT                        | 170141183460469231731687303715884105727   | Integer               |170_141_183_460_469_231_731_687_303_715_884_105_727 |
-#     | FLOAT     | FLOAT                          | 12345.375                                 | Float                 |12_345.375                                          |
-#     | DOUBLE    | DOUBLE                         | 123.456789                                | Float                 |123.456789                                          |
-#     | TIMESTAMP | TIMESTAMP                      | '2019-11-03 12:34:56'                     | Time                  |Time.new(2019,11,3,12,34,56)                        |
-#     | DATE      | DATE                           | '2019-11-03'                              | Date                  |Date.new(2019,11,3)                                 |
-#     | INTERVAL  | INTERVAL                       | '2 days ago'                              | Integer               |86400                                               |
-#     | VARCHAR   | VARCHAR                        | 'hello'                                   | String                |'hello'                                             |
-#     | VARCHAR   | VARCHAR                        | '𝘶ñîҫȫ𝘥ẹ 𝖘ţ𝗋ⅰɲ𝓰 😃'                       | String                |'𝘶ñîҫȫ𝘥ẹ 𝖘ţ𝗋ⅰɲ𝓰 😃'                                 |
-#     | BLOB      | BLOB                           | 'blob'                                    | String                |'blob'.force_encoding('ASCII-8BIT')                 |
-#     | LIST      | INTEGER[]                      | [1, 2]                                    | Array                 |[1, 2]                                              |
-#     | LIST      | INTEGER[][]                    | [[1, 2], [3, 4]]                          | Array                 |[[1, 2], [3, 4]]                                    |
-#     | MAP       | MAP(INTEGER, INTEGER)          | map {1: 2, 3: 4}                          | Hash                  |{1 => 2, 3 => 4}                                    |
-#     | STRUCT    | STRUCT(a INTEGER, b INTEGER)   | {'a': 1, 'b': 2}                          | Hash                  |{a: 1, b: 2 }                                       |
-#     TABLE
-#
-#     test_table.lines[1..-1].each do |spec|
-#       db_type, db_declaration, string_rep, klass, ruby_val = *(spec.split('|')[1..-1].map(&:strip))
-#       define_method :"test_#{db_type}_type" do
-#         con = DuckDB::Database.open.connect
-#         con.query("CREATE TABLE test_#{db_type} (col #{db_declaration})")
-#         con.query("INSERT INTO test_#{db_type} VALUES ( #{string_rep} )")
-#         res = con.query("SELECT * FROM test_#{db_type}").to_a[0][0]
-#         puts res.inspect
-#         assert_equal(eval(ruby_val), res)
-#         assert_equal(eval(klass), res.class)
-#       end
-#     end
-#     end
+require 'test_helper'
+require 'securerandom'
+
+module DuckDBTest
+  class ResultChunkEach < Minitest::Test
+    def setup
+      DuckDB::Result.use_chunk_each = true
+      @db = DuckDB::Database.open
+      @con = @db.connect
+    end
+
+    def teardown
+      DuckDB::Result.use_chunk_each = false
+      @db.close
+    end
+
+    UUID = SecureRandom.uuid
+    ENUM_SQL = "CREATE TYPE mood AS ENUM ('sad', 'ok', 'happy');"
+    TEST_TABLES = [
+      #      DB Type  ,  DB declartion                 String Rep                                  Ruby Type             Ruby Value
+      [:ok, 'BOOLEAN' , 'BOOLEAN',                     'true',                                     TrueClass,            true                                                ],
+      [:ok, 'TINYINT' , 'TINYINT',                     1,                                          Integer,              1                                                   ],
+      [:ok, 'SMALLINT', 'SMALLINT',                    32767,                                      Integer,              32_767                                              ],
+      [:ok, 'INTEGER',  'INTEGER',                     2147483647,                                 Integer,              2_147_483_647                                       ],
+      [:ok, 'BIGINT',   'BIGINT',                      9223372036854775807,                        Integer,              9_223_372_036_854_775_807                           ],
+      [:ok, 'HUGEINT',  'HUGEINT',                     170141183460469231731687303715884105727,    Integer,              170_141_183_460_469_231_731_687_303_715_884_105_727 ],
+      [:ok, 'FLOAT',    'FLOAT',                       12345.375,                                  Float,                12_345.375                                          ],
+      [:ok, 'DOUBLE',   'DOUBLE',                      123.456789,                                 Float,                123.456789                                          ],
+      [:ok, 'TIMESTAMP','TIMESTAMP',                   "'2019-11-03 12:34:56'",                    Time,                 Time.new(2019,11,3,12,34,56)                        ],
+      [:ok, 'DATE',     'DATE',                        "'2019-11-03'",                             Date,                 Date.new(2019,11,3)                                 ],
+      [:ok, 'NTERVAL',  'INTERVAL',                    "'2 days ago'",                             Hash,                 { year: 0, month: 0, day: -2, hour: 0, min: 0, sec: 0, usec: 0 } ],
+      [:ok, 'VARCHAR',  'VARCHAR',                     "'hello'",                                  String,               'hello'                                             ],
+      [:ok, 'VARCHAR',  'VARCHAR',                     "'𝘶ñîҫȫ𝘥ẹ 𝖘ţ𝗋ⅰɲ𝓰 😃'",                      String,               '𝘶ñîҫȫ𝘥ẹ 𝖘ţ𝗋ⅰɲ𝓰 😃'                                 ],
+      [:ok, 'BLOB',     'BLOB',                        "'blob'",                                   String,               String.new('blob', encoding: 'ASCII-8BIT')          ],
+      [:ok, 'ENUM',     'mood',                        "'happy'",                                  String,               'happy'                                             ],
+      [:ok, 'UUID',     'UUID',                        "'#{UUID}'",                                String,               UUID                                                ],
+      # FIXME: LIST, MAP STRUCT values are always nil
+      [:ng, 'LIST',     'INTEGER[]',                   '[1, 2]',                                   Array,                [1, 2]                                              ],
+      [:ng, 'LIST',     'INTEGER[][]',                 '[[1, 2], [3, 4]]',                         Array,                [[1, 2], [3, 4]]                                    ],
+      [:ng, 'MAP',      'MAP(INTEGER, INTEGER)',       'map {1: 2, 3: 4}',                         Hash,                 {1 => 2, 3 => 4}                                    ],
+      [:ng, 'STRUCT',   'STRUCT(a INTEGER, b INTEGER)', "{'a': 1, 'b': 2}",                        Hash,                 {"a" => 1, "b" => 2 }                               ],
+    ].freeze
+
+    TEST_TABLES.each_with_index do |spec, i|
+      do_test, db_type, db_declaration, string_rep, klass, ruby_val = *spec
+      define_method :"test_#{db_type}_type#{i}" do
+        skip if do_test == :ng
+        @con.query(ENUM_SQL)
+        @con.query("CREATE TABLE tests (col #{db_declaration})")
+        @con.query("INSERT INTO tests VALUES ( #{string_rep} )")
+        res = @con.query('SELECT * FROM tests').to_a[0][0]
+        assert_equal(ruby_val, res)
+        assert_equal(klass, res.class)
+      end
+    end
+  end
+end

--- a/test/duckdb_test/result_chunk_each_test.rb
+++ b/test/duckdb_test/result_chunk_each_test.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+#
+# require 'test_helper'
+#
+#   module DuckDBTest
+#     class ResultChunkEach < Minitest::Test
+#     test_table = <<~TABLE
+#     | DB Type   | DB declartion                  | String Rep                                | Ruby Type             |Ruby Value                                          |
+#     | BOOLEAN   | BOOLEAN                        | true                                      | TrueClass             |true                                                |
+#     | TINYINT   | TINYINT                        | 1                                         | Integer               |1                                                   |
+#     | SMALLINT  | SMALLINT                       | 32767                                     | Integer               |32_767                                              |
+#     | INTEGER   | INTEGER                        | 2147483647                                | Integer               |2_147_483_647                                       |
+#     | BIGINT    | BIGINT                         | 9223372036854775807                       | Integer               |9_223_372_036_854_775_807                           |
+#     | HUGEINT   | HUGEINT                        | 170141183460469231731687303715884105727   | Integer               |170_141_183_460_469_231_731_687_303_715_884_105_727 |
+#     | FLOAT     | FLOAT                          | 12345.375                                 | Float                 |12_345.375                                          |
+#     | DOUBLE    | DOUBLE                         | 123.456789                                | Float                 |123.456789                                          |
+#     | TIMESTAMP | TIMESTAMP                      | '2019-11-03 12:34:56'                     | Time                  |Time.new(2019,11,3,12,34,56)                        |
+#     | DATE      | DATE                           | '2019-11-03'                              | Date                  |Date.new(2019,11,3)                                 |
+#     | INTERVAL  | INTERVAL                       | '2 days ago'                              | Integer               |86400                                               |
+#     | VARCHAR   | VARCHAR                        | 'hello'                                   | String                |'hello'                                             |
+#     | VARCHAR   | VARCHAR                        | '𝘶ñîҫȫ𝘥ẹ 𝖘ţ𝗋ⅰɲ𝓰 😃'                       | String                |'𝘶ñîҫȫ𝘥ẹ 𝖘ţ𝗋ⅰɲ𝓰 😃'                                 |
+#     | BLOB      | BLOB                           | 'blob'                                    | String                |'blob'.force_encoding('ASCII-8BIT')                 |
+#     | LIST      | INTEGER[]                      | [1, 2]                                    | Array                 |[1, 2]                                              |
+#     | LIST      | INTEGER[][]                    | [[1, 2], [3, 4]]                          | Array                 |[[1, 2], [3, 4]]                                    |
+#     | MAP       | MAP(INTEGER, INTEGER)          | map {1: 2, 3: 4}                          | Hash                  |{1 => 2, 3 => 4}                                    |
+#     | STRUCT    | STRUCT(a INTEGER, b INTEGER)   | {'a': 1, 'b': 2}                          | Hash                  |{a: 1, b: 2 }                                       |
+#     TABLE
+#
+#     test_table.lines[1..-1].each do |spec|
+#       db_type, db_declaration, string_rep, klass, ruby_val = *(spec.split('|')[1..-1].map(&:strip))
+#       define_method :"test_#{db_type}_type" do
+#         con = DuckDB::Database.open.connect
+#         con.query("CREATE TABLE test_#{db_type} (col #{db_declaration})")
+#         con.query("INSERT INTO test_#{db_type} VALUES ( #{string_rep} )")
+#         res = con.query("SELECT * FROM test_#{db_type}").to_a[0][0]
+#         puts res.inspect
+#         assert_equal(eval(ruby_val), res)
+#         assert_equal(eval(klass), res.class)
+#       end
+#     end
+#     end


### PR DESCRIPTION
refactoring of #495.

add `DuckDB::Result#chunk_each` method.
It is only available with duckdb >= 0.8.0.

Set `DuckDB::Result.use_chunk_each` to true If you try to use chunk_each.

```ruby
DuckDB::Result.use_chunk_each = true
...
result = conn.query('SELECT * from TABLES');
result.each do # <= result.each works like as result.chunk_each
  p row
end
``` 

## TODO
- [x] test
- [ ] ~~fix list~~ pending. #492, #493
- [x] enum type
