### PR TITLE
bundle update to bump nokogiri from 1.16.0 to 1.16.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 - fix Decimal type conversion.
+- bundle update to bump nokogiri from 1.16.0 to 1.16.2.
 
 # 0.9.2.3 - 2023-12-29
 - fix bigdecimal warning with Ruby 3.3.0.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,21 +8,21 @@ GEM
   remote: https://rubygems.org/
   specs:
     benchmark-ips (2.13.0)
-    bigdecimal (3.1.5)
+    bigdecimal (3.1.6)
     mini_portile2 (2.8.5)
-    minitest (5.20.0)
-    nokogiri (1.16.0)
+    minitest (5.22.2)
+    nokogiri (1.16.2)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
-    nokogiri (1.16.0-x86_64-linux)
+    nokogiri (1.16.2-x86_64-linux)
       racc (~> 1.4)
     racc (1.7.3)
     rake (13.1.0)
-    rake-compiler (1.2.5)
+    rake-compiler (1.2.7)
       rake
     ruby_memcheck (2.3.0)
       nokogiri
-    stackprof (0.2.25)
+    stackprof (0.2.26)
 
 PLATFORMS
   ruby


### PR DESCRIPTION
nokogiri used for development ruby-duckdb only.