### PR TITLE
implement DuckDB::ExtractedStatements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this project will be documented in this file.
 
 ## Unreleased
+- add `DuckDB::ExtractedStatements` class.
+- add `DuckDB::ExtractedStatements#size`.
+- raise error when `DuckDB::ExtractedStatements#new` is called with invalid SQL.
 
 # 0.10.3.0 - 2024-05-25
 - bump to duckdb v0.10.3.

--- a/test/duckdb_test/extracted_statements_test.rb
+++ b/test/duckdb_test/extracted_statements_test.rb
@@ -24,7 +24,7 @@ module DuckDBTest
       ex = assert_raises DuckDB::Error do
         DuckDB::ExtractedStatements.new(@con, 'SELECT 1; INVALID STATEMENT; SELECT 3')
       end
-      assert_equal('Parser Error: syntax error at or near "INVALID"', ex.message)
+      assert_match(/\AParser Error: syntax error at or near "INVALID"/, ex.message)
     end
 
     def test_size

--- a/test/duckdb_test/extracted_statements_test.rb
+++ b/test/duckdb_test/extracted_statements_test.rb
@@ -20,6 +20,18 @@ module DuckDBTest
       end
     end
 
+    def test_s_new_with_invalid_sql
+      ex = assert_raises DuckDB::Error do
+        DuckDB::ExtractedStatements.new(@con, 'SELECT 1; INVALID STATEMENT; SELECT 3')
+      end
+      assert_equal('Parser Error: syntax error at or near "INVALID"', ex.message)
+    end
+
+    def test_size
+      stmts = DuckDB::ExtractedStatements.new(@con, 'SELECT 1; SELECT 2; SELECT 3')
+      assert_equal 3, stmts.size
+    end
+
     def teardown
       @con.close
       @db.close


### PR DESCRIPTION
- raise error when `DuckDB::ExtractedStatements#new` is called with invalid SQL.
- add `DuckDB::ExtractedStatements#size`.