### PR TITLE
support STRUCT column with DuckDB::Result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## Unreleased
+- DuckDB::Result supports STRUCT column type (only when DuckDB::Result.use_chunk_each is true).
 
 # 1.0.0.1 - 2024-06-16
 - support fetch the value from UHUGEINT type column.

--- a/ext/duckdb/result.c
+++ b/ext/duckdb/result.c
@@ -909,7 +909,7 @@ static VALUE vector_struct(duckdb_logical_type ty, duckdb_vector vector, idx_t r
     for (idx_t i = 0; i < child_count; ++i) {
         p = duckdb_struct_type_child_name(ty, i);
         if (p) {
-            key = rb_str_new2(p);
+            key = ID2SYM(rb_intern_const(p));
             child = duckdb_struct_vector_get_child(vector, i);
             child_type = duckdb_struct_type_child_type(ty, i);
             value = vector_value_at(child, child_type, row_idx);

--- a/test/duckdb_test/result_struct_test.rb
+++ b/test/duckdb_test/result_struct_test.rb
@@ -7,7 +7,7 @@ module DuckDBTest
       @conn = @db.connect
     end
 
-    def test_result_list
+    def test_result_struct
       @conn.execute('CREATE TABLE test (s STRUCT(v VARCHAR, i INTEGER));')
       @conn.execute("INSERT INTO test VALUES (ROW('abc', 12));")
       @conn.execute("INSERT INTO test VALUES (ROW('de', 5));")
@@ -15,6 +15,32 @@ module DuckDBTest
       ary = result.each.to_a
       assert_equal({ v: 'abc', i: 12 }, ary.first[0])
       assert_equal({ v: 'de', i: 5 }, ary.last[0])
+    end
+
+    def test_result_struct_with_nil
+      @conn.execute('CREATE TABLE test (s STRUCT(v VARCHAR, i INTEGER));')
+      @conn.execute("INSERT INTO test VALUES (ROW('abc', 12));")
+      @conn.execute('INSERT INTO test VALUES (ROW(NULL, 5));')
+      result = @conn.execute('SELECT * FROM test;')
+      ary = result.each.to_a
+      assert_equal({ v: 'abc', i: 12 }, ary.first[0])
+      assert_equal({ v: nil, i: 5 }, ary.last[0])
+    end
+
+    def test_result_struct_with_key_having_space
+      @conn.execute('CREATE TABLE test (s STRUCT("v 1" VARCHAR, i INTEGER));')
+      @conn.execute("INSERT INTO test VALUES (ROW('abc', 12));")
+      result = @conn.execute('SELECT * FROM test;')
+      ary = result.each.to_a
+      assert_equal({ 'v 1': 'abc', i: 12 }, ary.first[0])
+    end
+
+    def test_result_struct_struct
+      @conn.execute('CREATE TABLE test (s STRUCT(v STRUCT(a VARCHAR, b INTEGER), i INTEGER));')
+      @conn.execute("INSERT INTO test VALUES (ROW(ROW('abc', 12), 34));")
+      result = @conn.execute('SELECT * FROM test;')
+      ary = result.each.to_a
+      assert_equal({ v: { a: 'abc', b: 12 }, i: 34 }, ary.first[0])
     end
 
     def teardown

--- a/test/duckdb_test/result_struct_test.rb
+++ b/test/duckdb_test/result_struct_test.rb
@@ -13,8 +13,8 @@ module DuckDBTest
       @conn.execute("INSERT INTO test VALUES (ROW('de', 5));")
       result = @conn.execute('SELECT * FROM test;')
       ary = result.each.to_a
-      assert_equal({"v"=>"abc", "i"=>12}, ary.first[0])
-      assert_equal({"v"=>"de", "i"=>5}, ary.last[0])
+      assert_equal({ v: 'abc', i: 12 }, ary.first[0])
+      assert_equal({ v: 'de', i: 5 }, ary.last[0])
     end
 
     def teardown

--- a/test/duckdb_test/result_struct_test.rb
+++ b/test/duckdb_test/result_struct_test.rb
@@ -1,0 +1,26 @@
+require 'test_helper'
+
+module DuckDBTest
+  class ResultListTest < Minitest::Test
+    def setup
+      @db = DuckDB::Database.open
+      @conn = @db.connect
+    end
+
+    def test_result_list
+      @conn.execute('CREATE TABLE test (s STRUCT(v VARCHAR, i INTEGER));')
+      @conn.execute("INSERT INTO test VALUES (ROW('abc', 12));")
+      @conn.execute("INSERT INTO test VALUES (ROW('de', 5));")
+      result = @conn.execute('SELECT * FROM test;')
+      ary = result.each.to_a
+      assert_equal({"v"=>"abc", "i"=>12}, ary.first[0])
+      assert_equal({"v"=>"de", "i"=>5}, ary.last[0])
+    end
+
+    def teardown
+      @conn.execute('DROP TABLE test;')
+      @conn.close
+      @db.close
+    end
+  end
+end


### PR DESCRIPTION
refs #502 

- [x] retrieve struct element name and it's value.
- [x] convert element name to symbol.
- [x] more test.