### PR TITLE
add require 'test_helper' 

### DIFF
--- a/test/duckdb_test/pending_result_test.rb
+++ b/test/duckdb_test/pending_result_test.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'test_helper'
+
 module DuckDBTest
   class PendingResultTest < Minitest::Test
     def setup


### PR DESCRIPTION
fix error when testing pending_result_test.rb only.