### PR TITLE
add `DuckDB::Connection#prepare`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+# Unreleased
+- add `DuckDB::Connection#prepare`. `DuckDB::Connection#prepare` is an alias of `DuckDB::Connection#prepared_statement`.
+
 # 1.1.0.0 - 2024-09-15
 - drop ruby 3.0.x.
 - bump duckdb to 1.1.0.

--- a/lib/duckdb/connection.rb
+++ b/lib/duckdb/connection.rb
@@ -108,7 +108,6 @@ module DuckDB
     def prepared_statement(str)
       PreparedStatement.new(self, str)
     end
-    alias prepare prepared_statement
 
     #
     # returns Appender object.
@@ -135,5 +134,6 @@ module DuckDB
     alias async_execute async_query
     alias open connect
     alias close disconnect
+    alias prepare prepared_statement
   end
 end

--- a/lib/duckdb/connection.rb
+++ b/lib/duckdb/connection.rb
@@ -97,9 +97,18 @@ module DuckDB
     # returns PreparedStatement object.
     # The first argument is SQL string.
     #
+    #   require 'duckdb'
+    #   db = DuckDB::Database.open('duckdb_file')
+    #   con = db.connect
+    #
+    #   sql = 'SELECT * FROM users WHERE name = $name AND email = $email'
+    #   stmt = con.prepared_statement(sql)
+    #   stmt.bind_args(name: 'Dave', email: 'dave@example.com')
+    #   result = stmt.execute
     def prepared_statement(str)
       PreparedStatement.new(self, str)
     end
+    alias prepare prepared_statement
 
     #
     # returns Appender object.

--- a/test/duckdb_test/connection_test.rb
+++ b/test/duckdb_test/connection_test.rb
@@ -241,6 +241,11 @@ module DuckDBTest
       assert_instance_of(DuckDB::PreparedStatement, @con.prepared_statement('SELECT * FROM t WHERE col1 = $1'))
     end
 
+    def test_prepare
+      @con.execute('CREATE TABLE t (col1 INTEGER, col2 STRING)')
+      assert_instance_of(DuckDB::PreparedStatement, @con.prepare('SELECT * FROM t WHERE col1 = $1'))
+    end
+
     def test_appender
       @con.execute('CREATE TABLE t (col1 INTEGER, col2 STRING)')
       assert_instance_of(DuckDB::Appender, @con.appender('t'))


### PR DESCRIPTION
`DuckDB::Connection#prepare` is an alias of `DuckDB::Connection#prepared_statement`.