### PR TITLE
remove #ifdef HAVE_DUCKDB_H_GE_V0_10_0.

### DIFF
--- a/ext/duckdb/connection.c
+++ b/ext/duckdb/connection.c
@@ -106,20 +106,12 @@ static VALUE duckdb_connection_interrupt(VALUE self) {
  */
 static VALUE duckdb_connection_query_progress(VALUE self) {
     rubyDuckDBConnection *ctx;
-#ifdef HAVE_DUCKDB_H_GE_V0_10_0
     duckdb_query_progress_type progress;
-#else
-    double progress;
-#endif
 
     TypedData_Get_Struct(self, rubyDuckDBConnection, &connection_data_type, ctx);
     progress = duckdb_query_progress(ctx->con);
 
-#ifdef HAVE_DUCKDB_H_GE_V0_10_0
     return rb_funcall(mDuckDBConverter, rb_intern("_to_query_progress"), 3, DBL2NUM(progress.percentage), ULL2NUM(progress.rows_processed), ULL2NUM(progress.total_rows_to_process));
-#else
-    return DBL2NUM(progress);
-#endif
 }
 
 static VALUE duckdb_connection_connect(VALUE self, VALUE oDuckDBDatabase) {

--- a/test/duckdb_test/connection_test.rb
+++ b/test/duckdb_test/connection_test.rb
@@ -9,9 +9,6 @@ module DuckDBTest
       @con = @db.connect
     end
 
-    def teardown
-    end
-
     def test_query
       assert_instance_of(DuckDB::Result, @con.query('CREATE TABLE table1 (id INTEGER)'))
     end
@@ -137,7 +134,6 @@ module DuckDBTest
       result = pending_result.execute_pending
       assert_equal([1, 'a'], result.each.first)
     end
-
 
     def test_execute
       @con.execute('CREATE TABLE t (col1 INTEGER, col2 STRING)')


### PR DESCRIPTION
extconf.rb checks duckdb >= 0.10.0. So we don't need to write `#ifdef HAVE_DUCKDB_H_GE_V0_10_0`