### PR TITLE
Add DuckDB::PreparedStatement#destroy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 # Unreleased
+- add `DuckDB::PreparedStatement#destroy`.
 
 # 1.1.1.0 - 2024-10-06
 - bump duckdb 1.1.1.

--- a/lib/duckdb/connection.rb
+++ b/lib/duckdb/connection.rb
@@ -31,6 +31,8 @@ module DuckDB
       stmt = PreparedStatement.new(self, sql)
       stmt.bind_args(*args, **kwargs)
       stmt.execute
+    ensure
+      stmt&.destroy
     end
 
     #
@@ -53,6 +55,8 @@ module DuckDB
       stmt = PreparedStatement.new(self, sql)
       stmt.bind_args(*args, **kwargs)
       stmt.pending_prepared
+    ensure
+      stmt&.destroy
     end
 
     #
@@ -76,6 +80,8 @@ module DuckDB
       stmt = PreparedStatement.new(self, sql)
       stmt.bind_args(*args, **kwargs)
       stmt.pending_prepared_stream
+    ensure
+      stmt&.destroy
     end
 
     #


### PR DESCRIPTION
ensure to call DuckDB::PreparedStatement#destroy in:
- DuckDB::Connection#query
- DuckDB::Connection#async_query
- DuckDB::Connection#async_query_stream

related to #775, #781.