### PR TITLE
add DuckDB::PreparedStatement#bind_decimal

### DIFF
--- a/lib/duckdb/converter.rb
+++ b/lib/duckdb/converter.rb
@@ -155,6 +155,19 @@ module DuckDB
       end
     end
 
+    def _parse_deciaml(value)
+      case value
+      when BigDecimal
+        value
+      else
+        begin
+          BigDecimal(value.to_s)
+        rescue StandardError => e
+          raise(ArgumentError, "Cannot parse `#{value.inspect}` to BigDecimal object. #{e.message}")
+        end
+      end
+    end
+
     def _to_query_progress(percentage, rows_processed, total_rows_to_process)
       DuckDB::QueryProgress.new(percentage, rows_processed, total_rows_to_process).freeze
     end
@@ -170,6 +183,13 @@ module DuckDB
       else
         raise(ArgumentError, "The argument `#{value.inspect}` must be Integer.")
       end
+    end
+
+    def decimal_to_hugeint(value)
+      integer_value = (value * (10 ** value.scale)).to_i
+      integer_to_hugeint(integer_value)
+    rescue FloatDomainError => e
+      raise(ArgumentError, "The argument `#{value.inspect}` must be converted to Integer. #{e.message}")
     end
   end
 end

--- a/test/duckdb_test/prepared_statement_test.rb
+++ b/test/duckdb_test/prepared_statement_test.rb
@@ -370,6 +370,25 @@ module DuckDBTest
       assert_equal(expected_row, stmt.execute.each.first)
     end
 
+    def test_bind_decimal
+      con = PreparedStatementTest.con
+      stmt = DuckDB::PreparedStatement.new(con, 'SELECT * FROM a WHERE col_decimal = $1')
+
+      assert_raises(ArgumentError) { stmt.bind_decimal(0, BigDecimal('98765.4321')) }
+      assert_raises(DuckDB::Error) { stmt.bind_decimal(2, BigDecimal('98765.4321')) }
+
+      e = assert_raises(ArgumentError) { stmt.bind_decimal(1, 'parse_error') }
+      assert_equal('Cannot parse `"parse_error"` to BigDecimal object. invalid value for BigDecimal(): "parse_error"', e.message)
+      e = assert_raises(ArgumentError) { stmt.bind_decimal(1, BigDecimal('Infinity')) }
+      assert_equal('The argument `Infinity` must be converted to Integer. Computation results in \'Infinity\'', e.message)
+
+      stmt.bind_decimal(1, 98765.4321)
+      assert_equal(expected_row, stmt.execute.each.first)
+
+      stmt.bind_decimal(1, BigDecimal('98765.4321'))
+      assert_equal(expected_row, stmt.execute.each.first)
+    end
+
     def test_bind_varchar
       con = PreparedStatementTest.con
       stmt = DuckDB::PreparedStatement.new(con, 'SELECT * FROM a WHERE col_varchar = $1')


### PR DESCRIPTION
fix GH-407

This change allows us to use `DuckDB::PreparedStatement#_bind_decimal` internally instead of `DuckDB::PreparedStatement#bind_varchar`.