### PR TITLE
skip temporary ruby head test on Mac CI.

### DIFF
--- a/.github/workflows/test_on_macos.yml
+++ b/.github/workflows/test_on_macos.yml
@@ -15,7 +15,8 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        ruby: ['3.1.6', '3.2.6', '3.3.6', '3.4.0-preview2', 'head']
+        # ruby: ['3.1.6', '3.2.6', '3.3.6', '3.4.0-preview2', 'head']
+        ruby: ['3.1.6', '3.2.6', '3.3.6', '3.4.0-preview2']
         duckdb: ['1.1.3', '1.1.1', '1.0.0']
 
     steps:


### PR DESCRIPTION
skip CI test because of the failure on head of ruby
https://github.com/suketa/ruby-duckdb/actions/runs/11866047410/job/33072199954?pr=805