### PR TITLE
#341 - Add uuid column test

### DIFF
--- a/test/duckdb_test/column_test.rb
+++ b/test/duckdb_test/column_test.rb
@@ -36,6 +36,7 @@ module DuckDBTest
       expected.push(:list)
       expected.push(:list)
       expected.push(:struct)
+      expected.push(:uuid)
       assert_equal(
         expected,
         @columns.map(&:type)
@@ -68,6 +69,7 @@ module DuckDBTest
       expected.push('int_list_col')
       expected.push('varchar_list_col')
       expected.push('struct_col')
+      expected.push('enum_col')
       assert_equal(
         expected,
         @columns.map(&:name)
@@ -117,6 +119,7 @@ module DuckDBTest
       sql += ', int_list_col INT[]'
       sql += ', varchar_list_col VARCHAR[]'
       sql += ', struct_col STRUCT(word VARCHAR, length INTEGER)'
+      sql += ', uuid_col UUID'
       sql += ')'
       sql
     end
@@ -150,6 +153,7 @@ module DuckDBTest
       sql += ', [1, 2, 3]'
       sql += ", ['a', 'b', 'c']"
       sql += ", ROW('Ruby', 4)"
+      sql += ", '550e8400-e29b-41d4-a716-446655440000'"
       sql += ')'
       sql
     end


### PR DESCRIPTION
This pull request includes updates to the `test/duckdb_test/column_test.rb` file to add support for the `uuid` type and corresponding tests. The most important changes include adding the `uuid` type to test methods and updating SQL statements to handle the new type.

Enhancements to test cases:

* [`test/duckdb_test/column_test.rb`](diffhunk://#diff-b4e09c21035333b755f900fd453374a969fb95642ddd57b2691058fc5571657cR39): Added `:uuid` to the list of expected types in the `test_type` method.
* [`test/duckdb_test/column_test.rb`](diffhunk://#diff-b4e09c21035333b755f900fd453374a969fb95642ddd57b2691058fc5571657cR72): Added `enum_col` to the list of expected column names in the `test_name` method.

Updates to SQL statements:

* [`test/duckdb_test/column_test.rb`](diffhunk://#diff-b4e09c21035333b755f900fd453374a969fb95642ddd57b2691058fc5571657cR122): Included `uuid_col UUID` in the `create_table_sql` method to define a new UUID column in the table creation SQL.
* [`test/duckdb_test/column_test.rb`](diffhunk://#diff-b4e09c21035333b755f900fd453374a969fb95642ddd57b2691058fc5571657cR156): Added a UUID value to the `insert_sql` method for inserting data into the new UUID column.