### PR TITLE
make rdoc parse C files.

### DIFF
--- a/ext/duckdb/appender.c
+++ b/ext/duckdb/appender.c
@@ -403,6 +403,9 @@ static VALUE appender_close(VALUE self) {
 }
 
 void rbduckdb_init_duckdb_appender(void) {
+#if 0
+    VALUE mDuckDB = rb_define_module("DuckDB");
+#endif
     cDuckDBAppender = rb_define_class_under(mDuckDB, "Appender", rb_cObject);
     rb_define_alloc_func(cDuckDBAppender, allocate);
     rb_define_method(cDuckDBAppender, "initialize", appender_initialize, 3);

--- a/ext/duckdb/blob.c
+++ b/ext/duckdb/blob.c
@@ -3,5 +3,8 @@
 VALUE cDuckDBBlob;
 
 void rbduckdb_init_duckdb_blob(void) {
+#if 0
+    VALUE mDuckDB = rb_define_module("DuckDB");
+#endif
     cDuckDBBlob = rb_define_class_under(mDuckDB, "Blob", rb_cString);
 }

--- a/ext/duckdb/column.c
+++ b/ext/duckdb/column.c
@@ -82,6 +82,9 @@ VALUE rbduckdb_create_column(VALUE oDuckDBResult, idx_t col) {
 }
 
 void rbduckdb_init_duckdb_column(void) {
+#if 0
+    VALUE mDuckDB = rb_define_module("DuckDB");
+#endif
     cDuckDBColumn = rb_define_class_under(mDuckDB, "Column", rb_cObject);
     rb_define_alloc_func(cDuckDBColumn, allocate);
 

--- a/ext/duckdb/config.c
+++ b/ext/duckdb/config.c
@@ -80,6 +80,9 @@ static VALUE config_set_config(VALUE self, VALUE key, VALUE value) {
 }
 
 void rbduckdb_init_duckdb_config(void) {
+#if 0
+    VALUE mDuckDB = rb_define_module("DuckDB");
+#endif
     cDuckDBConfig = rb_define_class_under(mDuckDB, "Config", rb_cObject);
     rb_define_alloc_func(cDuckDBConfig, allocate);
     rb_define_singleton_method(cDuckDBConfig, "size", config_s_size, 0);

--- a/ext/duckdb/connection.c
+++ b/ext/duckdb/connection.c
@@ -151,6 +151,9 @@ static VALUE duckdb_connection_query_sql(VALUE self, VALUE str) {
 }
 
 void rbduckdb_init_duckdb_connection(void) {
+#if 0
+    VALUE mDuckDB = rb_define_module("DuckDB");
+#endif
     cDuckDBConnection = rb_define_class_under(mDuckDB, "Connection", rb_cObject);
     rb_define_alloc_func(cDuckDBConnection, allocate);
 

--- a/ext/duckdb/database.c
+++ b/ext/duckdb/database.c
@@ -116,6 +116,9 @@ static VALUE duckdb_database_close(VALUE self) {
 }
 
 void rbduckdb_init_duckdb_database(void) {
+#if 0
+    VALUE mDuckDB = rb_define_module("DuckDB");
+#endif
     cDuckDBDatabase = rb_define_class_under(mDuckDB, "Database", rb_cObject);
     rb_define_alloc_func(cDuckDBDatabase, allocate);
     rb_define_singleton_method(cDuckDBDatabase, "_open", duckdb_database_s_open, -1);

--- a/ext/duckdb/error.c
+++ b/ext/duckdb/error.c
@@ -3,5 +3,8 @@
 VALUE eDuckDBError;
 
 void rbduckdb_init_duckdb_error(void) {
+#if 0
+    VALUE mDuckDB = rb_define_module("DuckDB");
+#endif
     eDuckDBError = rb_define_class_under(mDuckDB, "Error", rb_eStandardError);
 }

--- a/ext/duckdb/extracted_statements.c
+++ b/ext/duckdb/extracted_statements.c
@@ -95,6 +95,9 @@ static VALUE duckdb_extracted_statements_prepared_statement(VALUE self, VALUE co
 }
 
 void rbduckdb_init_duckdb_extracted_statements(void) {
+#if 0
+    VALUE mDuckDB = rb_define_module("DuckDB");
+#endif
     cDuckDBExtractedStatements = rb_define_class_under(mDuckDB, "ExtractedStatementsImpl", rb_cObject);
 
     rb_define_alloc_func(cDuckDBExtractedStatements, allocate);

--- a/ext/duckdb/pending_result.c
+++ b/ext/duckdb/pending_result.c
@@ -141,6 +141,9 @@ rubyDuckDBPendingResult *get_struct_pending_result(VALUE obj) {
 }
 
 void rbduckdb_init_duckdb_pending_result(void) {
+#if 0
+    VALUE mDuckDB = rb_define_module("DuckDB");
+#endif
     cDuckDBPendingResult = rb_define_class_under(mDuckDB, "PendingResult", rb_cObject);
     rb_define_alloc_func(cDuckDBPendingResult, allocate);
 

--- a/ext/duckdb/prepared_statement.c
+++ b/ext/duckdb/prepared_statement.c
@@ -433,6 +433,9 @@ rubyDuckDBPreparedStatement *get_struct_prepared_statement(VALUE self) {
 }
 
 void rbduckdb_init_duckdb_prepared_statement(void) {
+#if 0
+    VALUE mDuckDB = rb_define_module("DuckDB");
+#endif
     cDuckDBPreparedStatement = rb_define_class_under(mDuckDB, "PreparedStatement", rb_cObject);
 
     rb_define_alloc_func(cDuckDBPreparedStatement, allocate);

--- a/ext/duckdb/result.c
+++ b/ext/duckdb/result.c
@@ -884,6 +884,9 @@ static VALUE vector_value(duckdb_vector vector, idx_t row_idx) {
 }
 
 void rbduckdb_init_duckdb_result(void) {
+#if 0
+    VALUE mDuckDB = rb_define_module("DuckDB");
+#endif
     cDuckDBResult = rb_define_class_under(mDuckDB, "Result", rb_cObject);
     id__to_date = rb_intern("_to_date");
     id__to_time = rb_intern("_to_time");


### PR DESCRIPTION
rdoc does not parse C files in some cases.
Add rb_define_module("DuckDB") to fix it.