### PR TITLE
logical_type: define DuckDB::LogicalType class

### DIFF
--- a/ext/duckdb/duckdb.c
+++ b/ext/duckdb/duckdb.c
@@ -31,6 +31,7 @@ Init_duckdb_native(void) {
     rbduckdb_init_duckdb_connection();
     rbduckdb_init_duckdb_result();
     rbduckdb_init_duckdb_column();
+    rbduckdb_init_duckdb_logical_type();
     rbduckdb_init_duckdb_prepared_statement();
     rbduckdb_init_duckdb_pending_result();
     rbduckdb_init_duckdb_blob();

--- a/ext/duckdb/logical_type.c
+++ b/ext/duckdb/logical_type.c
@@ -1,0 +1,40 @@
+#include "ruby-duckdb.h"
+
+static VALUE cDuckDBLogicalType;
+
+static void deallocate(void *ctx);
+static VALUE allocate(VALUE klass);
+static size_t memsize(const void *p);
+
+static const rb_data_type_t logical_type_data_type = {
+    "DuckDB/LogicalType",
+    {NULL, deallocate, memsize,},
+    0, 0, RUBY_TYPED_FREE_IMMEDIATELY
+};
+
+static void deallocate(void *ctx) {
+    rubyDuckDBLogicalType *p = (rubyDuckDBLogicalType *)ctx;
+
+    if (p->logical_type) {
+        duckdb_destroy_logical_type(&(p->logical_type));
+    }
+
+    xfree(p);
+}
+
+static VALUE allocate(VALUE klass) {
+    rubyDuckDBLogicalType *ctx = xcalloc((size_t)1, sizeof(rubyDuckDBLogicalType));
+    return TypedData_Wrap_Struct(klass, &logical_type_data_type, ctx);
+}
+
+static size_t memsize(const void *p) {
+    return sizeof(rubyDuckDBLogicalType);
+}
+
+void rbduckdb_init_duckdb_logical_type(void) {
+#if 0
+    VALUE mDuckDB = rb_define_module("DuckDB");
+#endif
+    cDuckDBLogicalType = rb_define_class_under(mDuckDB, "LogicalType", rb_cObject);
+    rb_define_alloc_func(cDuckDBLogicalType, allocate);
+}

--- a/ext/duckdb/logical_type.h
+++ b/ext/duckdb/logical_type.h
@@ -1,0 +1,11 @@
+#ifndef RUBY_DUCKDB_LOGICAL_TYPE_H
+#define RUBY_DUCKDB_LOGICAL_TYPE_H
+
+struct _rubyDuckDBLogicalType {
+    duckdb_logical_type logical_type;
+};
+
+typedef struct _rubyDuckDBLogicalType rubyDuckDBLogicalType;
+
+void rbduckdb_init_duckdb_logical_type(void);
+#endif

--- a/ext/duckdb/ruby-duckdb.h
+++ b/ext/duckdb/ruby-duckdb.h
@@ -24,6 +24,7 @@
 #include "./connection.h"
 #include "./result.h"
 #include "./column.h"
+#include "./logical_type.h"
 #include "./prepared_statement.h"
 #include "./extracted_statements.h"
 #include "./pending_result.h"

--- a/test/duckdb_test/logical_type_test.rb
+++ b/test/duckdb_test/logical_type_test.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module DuckDBTest
+  class LogicalTypeTest < Minitest::Test
+    def test_defined_klass
+      assert(DuckDB.const_defined?(:LogicalType))
+    end
+  end
+end


### PR DESCRIPTION
GitHub: GH-690

This PR is the first step to support duckdb_logical_column_type C API. At the following PRs, we will implement it step by step.

In this PR, we adds `DuckDB::LogicalType` class which will handle duckdb_logical_column_type C API.