### PR TITLE
add DuckDB::Appender#error_message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 # Unreleased
+- add 'DuckDB::Appender#error_message'.
+- fix error message when DuckDB::Appender#flush failed.
+
 # 1.1.3.1 - 2024-11-27
 - fix to `DuckDB::Connection#query` with multiple SQL statements. Calling PreparedStatement#destroy after each statement executed.
 - install valgrind in docker development environment.

--- a/test/duckdb_test/appender_test.rb
+++ b/test/duckdb_test/appender_test.rb
@@ -88,6 +88,25 @@ module DuckDBTest
       teardown
     end
 
+    def test_flush
+      appender = create_appender('col BOOLEAN')
+      appender
+        .begin_row
+        .append_bool(true)
+        .end_row
+      assert_equal(appender.__id__, appender.flush.__id__)
+    end
+
+    def test_flush_with_exception
+      appender = create_appender('col BOOLEAN NOT NULL')
+      appender
+        .begin_row
+        .append_null
+        .end_row
+      exception = assert_raises(DuckDB::Error) { appender.flush }
+      assert_match(/NOT NULL constraint failed/, exception.message)
+    end
+
     def test_append_bool
       assert_duckdb_appender(true, 'BOOLEAN') { |a| a.append_bool(true) }
       assert_duckdb_appender(false, 'BOOLEAN') { |a| a.append_bool(false) }


### PR DESCRIPTION
- add 'DuckDB::Appender#error_message'.
- fix error message when DuckDB::Appender#flush failed.