### PR TITLE
DuckDB::Appender#begin_row returns self only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 # Unreleased
 - add 'DuckDB::Appender#error_message'.
 - fix error message when DuckDB::Appender#flush failed.
+- 'DuckDB::Appender#begin_row' does nothing. Only returns self. 'DuckDB::Appender#end_row' is only required.
 
 # 1.1.3.1 - 2024-11-27
 - fix to `DuckDB::Connection#query` with multiple SQL statements. Calling PreparedStatement#destroy after each statement executed.

--- a/README.md
+++ b/README.md
@@ -218,7 +218,6 @@ def append
       appender = con.appender('users')
 
       10000.times do
-        appender.begin_row
         appender.append(1)
         appender.append('Alice')
         appender.end_row

--- a/ext/duckdb/appender.c
+++ b/ext/duckdb/appender.c
@@ -7,7 +7,6 @@ static VALUE allocate(VALUE klass);
 static size_t memsize(const void *p);
 static VALUE appender_initialize(VALUE klass, VALUE con, VALUE schema, VALUE table);
 static VALUE appender_error_message(VALUE self);
-static VALUE appender_begin_row(VALUE self);
 static VALUE appender_end_row(VALUE self);
 static VALUE appender_append_bool(VALUE self, VALUE val);
 static VALUE appender_append_int8(VALUE self, VALUE val);
@@ -105,33 +104,6 @@ static VALUE appender_error_message(VALUE self) {
         return Qnil;
     }
     return rb_str_new2(msg);
-}
-
-/* call-seq:
- *   appender.begin_row -> self
- *
- * Begins a new row in the appender. This must be called before appending any values to the row.
- *
- *   require 'duckdb'
- *   db = DuckDB::Database.open
- *   con = db.connect
- *   con.query('CREATE TABLE users (id INTEGER, name VARCHAR)')
- *   appender = con.appender('users')
- *   appender
- *     .begin_row
- *     .append_int32(1)
- *     .append_varchar('Alice')
- *     .end_row
- *     .flush
- */
-static VALUE appender_begin_row(VALUE self) {
-    rubyDuckDBAppender *ctx;
-    TypedData_Get_Struct(self, rubyDuckDBAppender, &appender_data_type, ctx);
-
-    if (duckdb_appender_begin_row(ctx->appender) == DuckDBError) {
-        rb_raise(eDuckDBError, "failed to begin row");
-    }
-    return self;
 }
 
 /* call-seq:
@@ -561,7 +533,6 @@ void rbduckdb_init_duckdb_appender(void) {
     rb_define_alloc_func(cDuckDBAppender, allocate);
     rb_define_method(cDuckDBAppender, "initialize", appender_initialize, 3);
     rb_define_method(cDuckDBAppender, "error_message", appender_error_message, 0);
-    rb_define_method(cDuckDBAppender, "begin_row", appender_begin_row, 0);
     rb_define_method(cDuckDBAppender, "end_row", appender_end_row, 0);
     rb_define_method(cDuckDBAppender, "append_bool", appender_append_bool, 1);
     rb_define_method(cDuckDBAppender, "append_int8", appender_append_int8, 1);

--- a/ext/duckdb/appender.c
+++ b/ext/duckdb/appender.c
@@ -117,7 +117,6 @@ static VALUE appender_error_message(VALUE self) {
  *   con.query('CREATE TABLE users (id INTEGER, name VARCHAR)')
  *   appender = con.appender('users')
  *   appender
- *     .begin_row
  *     .append_int32(1)
  *     .append_varchar('Alice')
  *     .end_row
@@ -144,7 +143,6 @@ static VALUE appender_end_row(VALUE self) {
  *   con.query('CREATE TABLE users (id INTEGER, active BOOLEAN)')
  *   appender = con.appender('users')
  *   appender
- *     .begin_row
  *     .append_int32(1)
  *     .append_bool(true)
  *     .end_row
@@ -175,7 +173,6 @@ static VALUE appender_append_bool(VALUE self, VALUE val) {
  *   con.query('CREATE TABLE users (id INTEGER, age TINYINT)')
  *   appender = con.appender('users')
  *   appender
- *     .begin_row
  *     .append_int32(1)
  *     .append_int8(20)
  *     .end_row
@@ -204,7 +201,6 @@ static VALUE appender_append_int8(VALUE self, VALUE val) {
  *   con.query('CREATE TABLE users (id INTEGER, age SMALLINT)')
  *   appender = con.appender('users')
  *   appender
- *     .begin_row
  *     .append_int32(1)
  *     .append_int16(20)
  *     .end_row
@@ -233,7 +229,6 @@ static VALUE appender_append_int16(VALUE self, VALUE val) {
  *   con.query('CREATE TABLE users (id INTEGER, age INTEGER)')
  *   appender = con.appender('users')
  *   appender
- *     .begin_row
  *     .append_int32(1)
  *     .append_int32(20)
  *     .end_row
@@ -262,7 +257,6 @@ static VALUE appender_append_int32(VALUE self, VALUE val) {
  *   con.query('CREATE TABLE users (id INTEGER, age BIGINT)')
  *   appender = con.appender('users')
  *   appender
- *     .begin_row
  *     .append_int32(1)
  *     .append_int64(20)
  *     .end_row

--- a/lib/duckdb/appender.rb
+++ b/lib/duckdb/appender.rb
@@ -24,6 +24,14 @@ module DuckDB
     # :startdoc:
 
     # :call-seq:
+    #   appender.begin_row -> self
+    # A nop method, provided for backwards compatibility reasons.
+    # Does nothing. Only `end_row` is required.
+    def begin_row
+      self
+    end
+
+    # :call-seq:
     #  flush -> self
     #
     # Flushes the appender to the table, forcing the cache of the appender to be cleared.

--- a/lib/duckdb/appender.rb
+++ b/lib/duckdb/appender.rb
@@ -44,7 +44,6 @@ module DuckDB
     #   con.query('CREATE TABLE users (id INTEGER, name VARCHAR)')
     #   appender = con.appender('users')
     #   appender
-    #     .begin_row
     #     .append_int32(1)
     #     .append_varchar('Alice')
     #     .end_row
@@ -63,7 +62,6 @@ module DuckDB
     #   con.query('CREATE TABLE numbers (num HUGEINT)')
     #   appender = con.appender('numbers')
     #   appender
-    #     .begin_row
     #     .append_hugeint(-170_141_183_460_469_231_731_687_303_715_884_105_727)
     #     .end_row
     def append_hugeint(value)
@@ -79,7 +77,6 @@ module DuckDB
     #   con.query('CREATE TABLE numbers (num UHUGEINT)')
     #   appender = con.appender('numbers')
     #   appender
-    #     .begin_row
     #     .append_hugeint(340_282_366_920_938_463_463_374_607_431_768_211_455)
     #     .end_row
     def append_uhugeint(value)
@@ -94,7 +91,6 @@ module DuckDB
     #   con = db.connect
     #   con.query('CREATE TABLE dates (date_value DATE)')
     #   appender = con.appender('dates')
-    #   appender.begin_row
     #   appender.append_date(Date.today)
     #   # or
     #   # appender.append_date(Time.now)
@@ -114,7 +110,6 @@ module DuckDB
     #   con = db.connect
     #   con.query('CREATE TABLE times (time_value TIME)')
     #   appender = con.appender('times')
-    #   appender.begin_row
     #   appender.append_time(Time.now)
     #   # or
     #   # appender.append_time('01:01:01')
@@ -133,7 +128,6 @@ module DuckDB
     #   con = db.connect
     #   con.query('CREATE TABLE timestamps (timestamp_value TIMESTAMP)')
     #   appender = con.appender('timestamps')
-    #   appender.begin_row
     #   appender.append_time(Time.now)
     #   # or
     #   # appender.append_time(Date.today)
@@ -156,7 +150,6 @@ module DuckDB
     #   con.query('CREATE TABLE intervals (interval_value INTERVAL)')
     #   appender = con.appender('intervals')
     #   appender
-    #     .begin_row
     #     .append_interval('P1Y2D') # => append 1 year 2 days interval.
     #     .end_row
     #     .flush
@@ -172,7 +165,6 @@ module DuckDB
     #   con = db.connect
     #   con.query('CREATE TABLE users (id INTEGER, name VARCHAR)')
     #   appender = con.appender('users')
-    #   appender.begin_row
     #   appender.append(1)
     #   appender.append('Alice')
     #   appender.end_row
@@ -214,12 +206,10 @@ module DuckDB
     #
     # is same as:
     #
-    #   appender.begin_row
-    #   appender.append(1)
+    #   appender.append(2)
     #   appender.append('Alice')
     #   appender.end_row
     def append_row(*args)
-      begin_row
       args.each do |arg|
         append(arg)
       end

--- a/lib/duckdb/interval.rb
+++ b/lib/duckdb/interval.rb
@@ -24,7 +24,6 @@ module DuckDB
   #   con.query('CREATE TABLE intervals (interval_value INTERVAL)')
   #   appender = con.appender('intervals')
   #   appender
-  #     .begin_row
   #     .append_interval(interval)
   #     .end_row
   #     .flush

--- a/test/duckdb_test/appender_test.rb
+++ b/test/duckdb_test/appender_test.rb
@@ -51,7 +51,6 @@ module DuckDBTest
 
     def sub_test_append_column2(method, type, values:, expected:)
       create_appender("col #{type}")
-      @appender.begin_row
       @appender.send(method, *values)
       @appender.end_row
       @appender.flush
@@ -72,8 +71,6 @@ module DuckDBTest
     def assert_duckdb_appender(expected, type, &block)
       create_appender("col #{type}")
 
-      @appender.begin_row
-
       block.call(@appender) if block_given?
 
       @appender.end_row
@@ -88,10 +85,14 @@ module DuckDBTest
       teardown
     end
 
+    def test_begin_row
+      appender = create_appender('col BOOLEAN')
+      assert_equal(appender.__id__, appender.begin_row.__id__)
+    end
+
     def test_flush
       appender = create_appender('col BOOLEAN')
       appender
-        .begin_row
         .append_bool(true)
         .end_row
       assert_equal(appender.__id__, appender.flush.__id__)
@@ -100,7 +101,6 @@ module DuckDBTest
     def test_flush_with_exception
       appender = create_appender('col BOOLEAN NOT NULL')
       appender
-        .begin_row
         .append_null
         .end_row
       exception = assert_raises(DuckDB::Error) { appender.flush }


### PR DESCRIPTION
duckdb_appender_begin_row now only returns DuckDBSuccess and does nothing. The function exists because of backwards compatibility.

So DuckDB::Appender#begin_row returns self only.