### PR TITLE
add DuckDB::Column#logical_type

### DIFF
--- a/ext/duckdb/column.c
+++ b/ext/duckdb/column.c
@@ -115,6 +115,6 @@ void rbduckdb_init_duckdb_column(void) {
     rb_define_alloc_func(cDuckDBColumn, allocate);
 
     rb_define_private_method(cDuckDBColumn, "_type", duckdb_column__type, 0);
-    rb_define_method(cDuckDBColumn, "_logical_type", duckdb_column__logical_type, 0);
+    rb_define_method(cDuckDBColumn, "logical_type", duckdb_column__logical_type, 0);
     rb_define_method(cDuckDBColumn, "name", duckdb_column_get_name, 0);
 }

--- a/ext/duckdb/column.c
+++ b/ext/duckdb/column.c
@@ -6,6 +6,7 @@ static void deallocate(void *ctx);
 static VALUE allocate(VALUE klass);
 static size_t memsize(const void *p);
 static VALUE duckdb_column__type(VALUE oDuckDBColumn);
+static VALUE duckdb_column__logical_type(VALUE oDuckDBColumn);
 static VALUE duckdb_column_get_name(VALUE oDuckDBColumn);
 
 static const rb_data_type_t column_data_type = {
@@ -43,6 +44,33 @@ VALUE duckdb_column__type(VALUE oDuckDBColumn) {
     type = duckdb_column_type(&(ctxresult->result), ctx->col);
 
     return INT2FIX(type);
+}
+
+/*
+ *  call-seq:
+ *    column.logical_type -> DuckDB::LogicalType
+ *
+ *  Returns the logical type class.
+ *
+ */
+VALUE duckdb_column__logical_type(VALUE oDuckDBColumn) {
+    rubyDuckDBColumn *ctx;
+    rubyDuckDBResult *ctxresult;
+    VALUE result;
+    duckdb_logical_type _logical_type;
+    VALUE logical_type = Qnil;
+
+    TypedData_Get_Struct(oDuckDBColumn, rubyDuckDBColumn, &column_data_type, ctx);
+
+    result = rb_ivar_get(oDuckDBColumn, rb_intern("result"));
+    ctxresult = get_struct_result(result);
+    _logical_type = duckdb_column_logical_type(&(ctxresult->result), ctx->col);
+
+    if (_logical_type) {
+        logical_type = rbduckdb_create_logical_type(_logical_type);
+    }
+
+    return logical_type;
 }
 
 /*
@@ -87,5 +115,6 @@ void rbduckdb_init_duckdb_column(void) {
     rb_define_alloc_func(cDuckDBColumn, allocate);
 
     rb_define_private_method(cDuckDBColumn, "_type", duckdb_column__type, 0);
+    rb_define_method(cDuckDBColumn, "_logical_type", duckdb_column__logical_type, 0);
     rb_define_method(cDuckDBColumn, "name", duckdb_column_get_name, 0);
 }

--- a/ext/duckdb/logical_type.c
+++ b/ext/duckdb/logical_type.c
@@ -31,6 +31,18 @@ static size_t memsize(const void *p) {
     return sizeof(rubyDuckDBLogicalType);
 }
 
+VALUE rbduckdb_create_logical_type(duckdb_logical_type logical_type) {
+    VALUE obj;
+    rubyDuckDBLogicalType *ctx;
+
+    obj = allocate(cDuckDBLogicalType);
+    TypedData_Get_Struct(obj, rubyDuckDBLogicalType, &logical_type_data_type, ctx);
+
+    ctx->logical_type = logical_type;
+
+    return obj;
+}
+
 void rbduckdb_init_duckdb_logical_type(void) {
 #if 0
     VALUE mDuckDB = rb_define_module("DuckDB");

--- a/ext/duckdb/logical_type.h
+++ b/ext/duckdb/logical_type.h
@@ -8,4 +8,6 @@ struct _rubyDuckDBLogicalType {
 typedef struct _rubyDuckDBLogicalType rubyDuckDBLogicalType;
 
 void rbduckdb_init_duckdb_logical_type(void);
+VALUE rbduckdb_create_logical_type(duckdb_logical_type logical_type);
+
 #endif

--- a/lib/duckdb/column.rb
+++ b/lib/duckdb/column.rb
@@ -18,5 +18,9 @@ module DuckDB
       type_id = _type
       DuckDB::Converter::IntToSym.type_to_sym(type_id)
     end
+
+    def logical_type
+      _logical_type
+    end
   end
 end

--- a/lib/duckdb/column.rb
+++ b/lib/duckdb/column.rb
@@ -18,9 +18,5 @@ module DuckDB
       type_id = _type
       DuckDB::Converter::IntToSym.type_to_sym(type_id)
     end
-
-    def logical_type
-      _logical_type
-    end
   end
 end

--- a/test/duckdb_test/column_test.rb
+++ b/test/duckdb_test/column_test.rb
@@ -140,6 +140,11 @@ module DuckDBTest
       assert_equal(EXPECTED_TYPES, @columns.map(&:type))
     end
 
+    def test_logical_type
+      logical_types = @columns.map(&:logical_type)
+      assert(logical_types.all? { |logical_type| logical_type.is_a?(DuckDB::LogicalType) })
+    end
+
     def test_name
       assert_equal(EXPECTED_NAMES, @columns.map(&:name))
     end


### PR DESCRIPTION
refs: GH-690

In this PR, we add DuckDB::Column#logical_type, which returns the `DuckDB::LogicalType` instance corresponding to the column.

This is one of the steps for supporting duckdb_logical_column_type C API.