### PR TITLE
fix error message of DuckDB::Appender#close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 # Unreleased
 - add 'DuckDB::Appender#error_message'.
-- fix error message when DuckDB::Appender#flush failed.
+- fix error message when DuckDB::Appender#flush, DuckDB::Appender#close failed.
 - 'DuckDB::Appender#begin_row' does nothing. Only returns self. 'DuckDB::Appender#end_row' is only required.
 
 # 1.1.3.1 - 2024-11-27

--- a/ext/duckdb/appender.c
+++ b/ext/duckdb/appender.c
@@ -35,7 +35,7 @@ static VALUE appender__append_timestamp(VALUE self, VALUE year, VALUE month, VAL
 static VALUE appender__append_hugeint(VALUE self, VALUE lower, VALUE upper);
 static VALUE appender__append_uhugeint(VALUE self, VALUE lower, VALUE upper);
 static VALUE appender__flush(VALUE self);
-static VALUE appender_close(VALUE self);
+static VALUE appender__close(VALUE self);
 
 static const rb_data_type_t appender_data_type = {
     "DuckDB/Appender",
@@ -509,14 +509,15 @@ static VALUE appender__flush(VALUE self) {
     return Qtrue;
 }
 
-static VALUE appender_close(VALUE self) {
+/* :nodoc: */
+static VALUE appender__close(VALUE self) {
     rubyDuckDBAppender *ctx;
     TypedData_Get_Struct(self, rubyDuckDBAppender, &appender_data_type, ctx);
 
     if (duckdb_appender_close(ctx->appender) == DuckDBError) {
-        rb_raise(eDuckDBError, "failed to close");
+        return Qfalse;
     }
-    return self;
+    return Qtrue;
 }
 
 void rbduckdb_init_duckdb_appender(void) {
@@ -543,13 +544,13 @@ void rbduckdb_init_duckdb_appender(void) {
     rb_define_method(cDuckDBAppender, "append_varchar_length", appender_append_varchar_length, 2);
     rb_define_method(cDuckDBAppender, "append_blob", appender_append_blob, 1);
     rb_define_method(cDuckDBAppender, "append_null", appender_append_null, 0);
-    rb_define_method(cDuckDBAppender, "close", appender_close, 0);
 
 #ifdef HAVE_DUCKDB_H_GE_V1_1_0
     rb_define_method(cDuckDBAppender, "append_default", appender_append_default, 0);
 #endif
 
     rb_define_private_method(cDuckDBAppender, "_flush", appender__flush, 0);
+    rb_define_private_method(cDuckDBAppender, "_close", appender__close, 0);
     rb_define_private_method(cDuckDBAppender, "_append_date", appender__append_date, 3);
     rb_define_private_method(cDuckDBAppender, "_append_interval", appender__append_interval, 3);
     rb_define_private_method(cDuckDBAppender, "_append_time", appender__append_time, 4);

--- a/ext/duckdb/appender.c
+++ b/ext/duckdb/appender.c
@@ -36,6 +36,7 @@ static VALUE appender__append_hugeint(VALUE self, VALUE lower, VALUE upper);
 static VALUE appender__append_uhugeint(VALUE self, VALUE lower, VALUE upper);
 static VALUE appender__flush(VALUE self);
 static VALUE appender__close(VALUE self);
+static VALUE duckdb_state_to_bool_value(duckdb_state state);
 
 static const rb_data_type_t appender_data_type = {
     "DuckDB/Appender",
@@ -503,10 +504,7 @@ static VALUE appender__flush(VALUE self) {
     rubyDuckDBAppender *ctx;
     TypedData_Get_Struct(self, rubyDuckDBAppender, &appender_data_type, ctx);
 
-    if (duckdb_appender_flush(ctx->appender) == DuckDBError) {
-        return Qfalse;
-    }
-    return Qtrue;
+    return duckdb_state_to_bool_value(duckdb_appender_flush(ctx->appender));
 }
 
 /* :nodoc: */
@@ -514,10 +512,14 @@ static VALUE appender__close(VALUE self) {
     rubyDuckDBAppender *ctx;
     TypedData_Get_Struct(self, rubyDuckDBAppender, &appender_data_type, ctx);
 
-    if (duckdb_appender_close(ctx->appender) == DuckDBError) {
-        return Qfalse;
+    return duckdb_state_to_bool_value(duckdb_appender_close(ctx->appender));
+}
+
+static VALUE duckdb_state_to_bool_value(duckdb_state state) {
+    if (state == DuckDBSuccess) {
+        return Qtrue;
     }
-    return Qtrue;
+    return Qfalse;
 }
 
 void rbduckdb_init_duckdb_appender(void) {

--- a/lib/duckdb/appender.rb
+++ b/lib/duckdb/appender.rb
@@ -54,6 +54,29 @@ module DuckDB
       raise_appender_error('failed to flush')
     end
 
+    # :call-seq:
+    #   close -> self
+    #
+    # Closes the appender by flushing all intermediate states and closing it for further appends.
+    # If flushing the data triggers a constraint violation or any other error, then all data is
+    # invalidated, and this method raises DuckDB::Error.
+    #
+    #   require 'duckdb'
+    #   db = DuckDB::Database.open
+    #   con = db.connect
+    #   con.query('CREATE TABLE users (id INTEGER, name VARCHAR)')
+    #   appender = con.appender('users')
+    #   appender
+    #     .append_int32(1)
+    #     .append_varchar('Alice')
+    #     .end_row
+    #     .close
+    def close
+      return self if _close
+
+      raise_appender_error('failed to close')
+    end
+
     # appends huge int value.
     #
     #   require 'duckdb'

--- a/test/duckdb_test/appender_test.rb
+++ b/test/duckdb_test/appender_test.rb
@@ -107,6 +107,23 @@ module DuckDBTest
       assert_match(/NOT NULL constraint failed/, exception.message)
     end
 
+    def test_close
+      appender = create_appender('col BOOLEAN')
+      appender
+        .append_bool(true)
+        .end_row
+      assert_equal(appender.__id__, appender.close.__id__)
+    end
+
+    def test_close_with_exception
+      appender = create_appender('col BOOLEAN NOT NULL')
+      appender
+        .append_null
+        .end_row
+      exception = assert_raises(DuckDB::Error) { appender.close }
+      assert_match(/NOT NULL constraint failed/, exception.message)
+    end
+
     def test_append_bool
       assert_duckdb_appender(true, 'BOOLEAN') { |a| a.append_bool(true) }
       assert_duckdb_appender(false, 'BOOLEAN') { |a| a.append_bool(false) }


### PR DESCRIPTION
try to retrieve error message from duckdb when close method failed.