### PR TITLE
support interfaces for Decimal logical type in DuckDB::LogicalType

### DIFF
--- a/ext/duckdb/logical_type.c
+++ b/ext/duckdb/logical_type.c
@@ -5,6 +5,7 @@ static VALUE cDuckDBLogicalType;
 static void deallocate(void *ctx);
 static VALUE allocate(VALUE klass);
 static size_t memsize(const void *p);
+static VALUE duckdb_logical_type_width(VALUE self);
 
 static const rb_data_type_t logical_type_data_type = {
     "DuckDB/LogicalType",
@@ -31,6 +32,19 @@ static size_t memsize(const void *p) {
     return sizeof(rubyDuckDBLogicalType);
 }
 
+/*
+ *  call-seq:
+ *    decimal_col.logical_type.width -> Integer
+ *
+ *  Returns the width of the decimal column.
+ *
+ */
+static VALUE duckdb_logical_type_width(VALUE self) {
+    rubyDuckDBLogicalType *ctx;
+    TypedData_Get_Struct(self, rubyDuckDBLogicalType, &logical_type_data_type, ctx);
+    return INT2FIX(duckdb_decimal_width(ctx->logical_type));
+}
+
 VALUE rbduckdb_create_logical_type(duckdb_logical_type logical_type) {
     VALUE obj;
     rubyDuckDBLogicalType *ctx;
@@ -49,4 +63,6 @@ void rbduckdb_init_duckdb_logical_type(void) {
 #endif
     cDuckDBLogicalType = rb_define_class_under(mDuckDB, "LogicalType", rb_cObject);
     rb_define_alloc_func(cDuckDBLogicalType, allocate);
+
+    rb_define_method(cDuckDBLogicalType, "width", duckdb_logical_type_width, 0);
 }

--- a/ext/duckdb/logical_type.c
+++ b/ext/duckdb/logical_type.c
@@ -6,6 +6,7 @@ static void deallocate(void *ctx);
 static VALUE allocate(VALUE klass);
 static size_t memsize(const void *p);
 static VALUE duckdb_logical_type_width(VALUE self);
+static VALUE duckdb_logical_type_scale(VALUE self);
 
 static const rb_data_type_t logical_type_data_type = {
     "DuckDB/LogicalType",
@@ -45,6 +46,19 @@ static VALUE duckdb_logical_type_width(VALUE self) {
     return INT2FIX(duckdb_decimal_width(ctx->logical_type));
 }
 
+/*
+ *  call-seq:
+ *    decimal_col.logical_type.scale -> Integer
+ *
+ *  Returns the scale of the decimal column.
+ *
+ */
+static VALUE duckdb_logical_type_scale(VALUE self) {
+    rubyDuckDBLogicalType *ctx;
+    TypedData_Get_Struct(self, rubyDuckDBLogicalType, &logical_type_data_type, ctx);
+    return INT2FIX(duckdb_decimal_scale(ctx->logical_type));
+}
+
 VALUE rbduckdb_create_logical_type(duckdb_logical_type logical_type) {
     VALUE obj;
     rubyDuckDBLogicalType *ctx;
@@ -65,4 +79,5 @@ void rbduckdb_init_duckdb_logical_type(void) {
     rb_define_alloc_func(cDuckDBLogicalType, allocate);
 
     rb_define_method(cDuckDBLogicalType, "width", duckdb_logical_type_width, 0);
+    rb_define_method(cDuckDBLogicalType, "scale", duckdb_logical_type_scale, 0);
 }

--- a/test/duckdb_test/logical_type_test.rb
+++ b/test/duckdb_test/logical_type_test.rb
@@ -37,6 +37,11 @@ module DuckDBTest
       assert_equal(9, decimal_column.logical_type.width)
     end
 
+    def test_decimal_scale
+      decimal_column = @columns.find { |column| column.type == :decimal }
+      assert_equal(6, decimal_column.logical_type.scale)
+    end
+
     private
 
     def create_data(con)

--- a/test/duckdb_test/logical_type_test.rb
+++ b/test/duckdb_test/logical_type_test.rb
@@ -4,8 +4,44 @@ require 'test_helper'
 
 module DuckDBTest
   class LogicalTypeTest < Minitest::Test
+    CREATE_TABLE_SQL = <<~SQL
+      CREATE TABLE table1
+      (
+        decimal_col DECIMAL(9, 6)
+      );
+    SQL
+
+    INSERT_SQL = <<~SQL
+      INSERT INTO table1 VALUES
+      (
+        123.456789
+      )
+    SQL
+
+    SELECT_SQL = 'SELECT * FROM table1'
+
+    def setup
+      @db = DuckDB::Database.open
+      @con = @db.connect
+      create_data(@con)
+      result = @con.query(SELECT_SQL)
+      @columns = result.columns
+    end
+
     def test_defined_klass
       assert(DuckDB.const_defined?(:LogicalType))
+    end
+
+    def test_decimal_width
+      decimal_column = @columns.find { |column| column.type == :decimal }
+      assert_equal(9, decimal_column.logical_type.width)
+    end
+
+    private
+
+    def create_data(con)
+      con.query(CREATE_TABLE_SQL)
+      con.query(INSERT_SQL)
     end
   end
 end


### PR DESCRIPTION
refs: GH-690

In this PR, we support interfaces for Decimal logical type in DuckDB::Column#logical_type about the following.
- [uint8_t duckdb_decimal_width(duckdb_logical_type type);](https://duckdb.org/docs/api/c/api.html#duckdb_decimal_width)
- [uint8_t duckdb_decimal_scale(duckdb_logical_type type);](https://duckdb.org/docs/api/c/api.html#duckdb_decimal_scale)

This is one of the steps for supporting duckdb_logical_column_type C API.