### PR TITLE
add DuckDB::LogicalType#type

### DIFF
--- a/ext/duckdb/logical_type.c
+++ b/ext/duckdb/logical_type.c
@@ -5,6 +5,7 @@ static VALUE cDuckDBLogicalType;
 static void deallocate(void *ctx);
 static VALUE allocate(VALUE klass);
 static size_t memsize(const void *p);
+static VALUE duckdb_logical_type__type(VALUE self);
 static VALUE duckdb_logical_type_width(VALUE self);
 static VALUE duckdb_logical_type_scale(VALUE self);
 
@@ -31,6 +32,19 @@ static VALUE allocate(VALUE klass) {
 
 static size_t memsize(const void *p) {
     return sizeof(rubyDuckDBLogicalType);
+}
+
+/*
+ *  call-seq:
+ *    decimal_col.logical_type.type -> Symbol
+ *
+ *  Returns the logical type's type symbol.
+ *
+ */
+static VALUE duckdb_logical_type__type(VALUE self) {
+    rubyDuckDBLogicalType *ctx;
+    TypedData_Get_Struct(self, rubyDuckDBLogicalType, &logical_type_data_type, ctx);
+    return INT2FIX(duckdb_get_type_id(ctx->logical_type));
 }
 
 /*
@@ -78,6 +92,7 @@ void rbduckdb_init_duckdb_logical_type(void) {
     cDuckDBLogicalType = rb_define_class_under(mDuckDB, "LogicalType", rb_cObject);
     rb_define_alloc_func(cDuckDBLogicalType, allocate);
 
+    rb_define_private_method(cDuckDBLogicalType, "_type", duckdb_logical_type__type, 0);
     rb_define_method(cDuckDBLogicalType, "width", duckdb_logical_type_width, 0);
     rb_define_method(cDuckDBLogicalType, "scale", duckdb_logical_type_scale, 0);
 }

--- a/lib/duckdb.rb
+++ b/lib/duckdb.rb
@@ -13,6 +13,7 @@ require 'duckdb/pending_result'
 require 'duckdb/appender'
 require 'duckdb/config'
 require 'duckdb/column'
+require 'duckdb/logical_type'
 require 'duckdb/infinity'
 
 # DuckDB provides Ruby interface of DuckDB.

--- a/lib/duckdb/logical_type.rb
+++ b/lib/duckdb/logical_type.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module DuckDB
+  class LogicalType
+    # returns logical type's type symbol
+    # `:unknown` means that the logical type's type is unknown/unsupported by ruby-duckdb.
+    # `:invalid` means that the logical type's type is invalid in duckdb.
+    #
+    #   require 'duckdb'
+    #   db = DuckDB::Database.open
+    #   con = db.connect
+    #   con.query('CREATE TABLE climates (id INTEGER, temperature DECIMAIL)')
+    #
+    #   users = con.query('SELECT * FROM climates')
+    #   columns = users.columns
+    #   columns.second.logical_type.type #=> :decimal
+    def type
+      type_id = _type
+      DuckDB::Converter::IntToSym.type_to_sym(type_id)
+    end
+  end
+end

--- a/test/duckdb_test/logical_type_test.rb
+++ b/test/duckdb_test/logical_type_test.rb
@@ -4,21 +4,97 @@ require 'test_helper'
 
 module DuckDBTest
   class LogicalTypeTest < Minitest::Test
+    CREATE_TYPE_ENUM_SQL = <<~SQL
+      CREATE TYPE mood AS ENUM ('sad', 'ok', 'happy', '𝘾𝝾օɭ 😎');
+    SQL
+
     CREATE_TABLE_SQL = <<~SQL
-      CREATE TABLE table1
-      (
-        decimal_col DECIMAL(9, 6)
+      CREATE TABLE table1(
+        boolean_col BOOLEAN,
+        tinyint_col TINYINT,
+        smallint_col SMALLINT,
+        integer_col INTEGER,
+        bigint_col BIGINT,
+        utinyint_col UTINYINT,
+        usmallint_col USMALLINT,
+        uinteger_col UINTEGER,
+        ubigint_col UBIGINT,
+        real_col REAL,
+        double_col DOUBLE,
+        date_col DATE,
+        time_col TIME,
+        timestamp_col timestamp,
+        interval_col INTERVAL,
+        hugeint_col HUGEINT,
+        varchar_col VARCHAR,
+        decimal_col DECIMAL(9, 6),
+        enum_col mood,
+        int_list_col INT[],
+        varchar_list_col VARCHAR[],
+        struct_col STRUCT(word VARCHAR, length INTEGER),
+        uuid_col UUID,
+        map_col MAP(INTEGER, VARCHAR)
       );
     SQL
 
     INSERT_SQL = <<~SQL
       INSERT INTO table1 VALUES
       (
-        123.456789
+        true,
+        1,
+        32767,
+        2147483647,
+        9223372036854775807,
+        1,
+        32767,
+        2147483647,
+        9223372036854775807,
+        12345.375,
+        123.456789,
+        '2019-11-03',
+        '12:34:56',
+        '2019-11-03 12:34:56',
+        '1 day',
+        170141183460469231731687303715884105727,
+        'string',
+        123.456789,
+        'sad',
+        [1, 2, 3],
+        ['a', 'b', 'c'],
+        ROW('Ruby', 4),
+        '#{SecureRandom.uuid}',
+        MAP{1: 'foo'}
       )
     SQL
 
     SELECT_SQL = 'SELECT * FROM table1'
+
+    EXPECTED_TYPES = %i[
+      boolean
+      tinyint
+      smallint
+      integer
+      bigint
+      utinyint
+      usmallint
+      uinteger
+      ubigint
+      float
+      double
+      date
+      time
+      timestamp
+      interval
+      hugeint
+      varchar
+      decimal
+      enum
+      list
+      list
+      struct
+      uuid
+      map
+    ].freeze
 
     def setup
       @db = DuckDB::Database.open
@@ -30,6 +106,11 @@ module DuckDBTest
 
     def test_defined_klass
       assert(DuckDB.const_defined?(:LogicalType))
+    end
+
+    def test_type
+      logical_types = @columns.map(&:logical_type)
+      assert_equal(EXPECTED_TYPES, logical_types.map(&:type))
     end
 
     def test_decimal_width
@@ -45,6 +126,7 @@ module DuckDBTest
     private
 
     def create_data(con)
+      con.query(CREATE_TYPE_ENUM_SQL)
       con.query(CREATE_TABLE_SQL)
       con.query(INSERT_SQL)
     end

--- a/test/duckdb_test/logical_type_test.rb
+++ b/test/duckdb_test/logical_type_test.rb
@@ -104,10 +104,6 @@ module DuckDBTest
       @columns = result.columns
     end
 
-    def test_defined_klass
-      assert(DuckDB.const_defined?(:LogicalType))
-    end
-
     def test_type
       logical_types = @columns.map(&:logical_type)
       assert_equal(EXPECTED_TYPES, logical_types.map(&:type))


### PR DESCRIPTION
refs: GH-690

In this PR, we add DuckDB::LogicalType#type, which returns logical type's type.
- [duckdb_type duckdb_get_type_id(duckdb_logical_type type);](https://duckdb.org/docs/api/c/api.html#duckdb_get_type_id)

This is one of the steps for supporting duckdb_logical_column_type C API.