### PR TITLE
fix error message of appender_int64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 - add `DuckDB::Appender#error_message`.
 - fix error message when `DuckDB::Appender#flush`, `DuckDB::Appender#close`, `DuckDB::Appender#end_row`,
   `DuckDB::Appender#append_bool`, `DuckDB::Appender#append_int8`, `DuckDB::Appender#append_int16`,
-  `DuckDB::Appender#append_int32`  failed.
+  `DuckDB::Appender#append_int32`, `DuckDB::Appender#append_int64` failed.
 - `DuckDB::Appender#begin_row` does nothing. Only returns self. `DuckDB::Appender#end_row` is only required.
 
 # 1.1.3.1 - 2024-11-27

--- a/ext/duckdb/appender.c
+++ b/ext/duckdb/appender.c
@@ -11,7 +11,7 @@ static VALUE appender__append_bool(VALUE self, VALUE val);
 static VALUE appender__append_int8(VALUE self, VALUE val);
 static VALUE appender__apend_int16(VALUE self, VALUE val);
 static VALUE appender__append_int32(VALUE self, VALUE val);
-static VALUE appender__apend_int64(VALUE self, VALUE val);
+static VALUE appender__append_int64(VALUE self, VALUE val);
 static VALUE appender_append_uint8(VALUE self, VALUE val);
 static VALUE appender_append_uint16(VALUE self, VALUE val);
 static VALUE appender_append_uint32(VALUE self, VALUE val);
@@ -158,7 +158,7 @@ static VALUE appender__append_int32(VALUE self, VALUE val) {
 }
 
 /* :nodoc: */
-static VALUE appender__apend_int64(VALUE self, VALUE val) {
+static VALUE appender__append_int64(VALUE self, VALUE val) {
     rubyDuckDBAppender *ctx;
     int64_t i64val = (int64_t)NUM2LL(val);
 
@@ -444,7 +444,7 @@ void rbduckdb_init_duckdb_appender(void) {
     rb_define_private_method(cDuckDBAppender, "_append_int8", appender__append_int8, 1);
     rb_define_private_method(cDuckDBAppender, "_append_int16", appender__apend_int16, 1);
     rb_define_private_method(cDuckDBAppender, "_append_int32", appender__append_int32, 1);
-    rb_define_private_method(cDuckDBAppender, "_append_int64", appender__apend_int64, 1);
+    rb_define_private_method(cDuckDBAppender, "_append_int64", appender__append_int64, 1);
     rb_define_private_method(cDuckDBAppender, "_append_date", appender__append_date, 3);
     rb_define_private_method(cDuckDBAppender, "_append_interval", appender__append_interval, 3);
     rb_define_private_method(cDuckDBAppender, "_append_time", appender__append_time, 4);

--- a/ext/duckdb/appender.c
+++ b/ext/duckdb/appender.c
@@ -11,7 +11,7 @@ static VALUE appender__append_bool(VALUE self, VALUE val);
 static VALUE appender__append_int8(VALUE self, VALUE val);
 static VALUE appender__apend_int16(VALUE self, VALUE val);
 static VALUE appender__append_int32(VALUE self, VALUE val);
-static VALUE appender_append_int64(VALUE self, VALUE val);
+static VALUE appender__apend_int64(VALUE self, VALUE val);
 static VALUE appender_append_uint8(VALUE self, VALUE val);
 static VALUE appender_append_uint16(VALUE self, VALUE val);
 static VALUE appender_append_uint32(VALUE self, VALUE val);
@@ -157,32 +157,14 @@ static VALUE appender__append_int32(VALUE self, VALUE val) {
     return duckdb_state_to_bool_value(duckdb_append_int32(ctx->appender, i32val));
 }
 
-/* call-seq:
- *   appender.append_int64(val) -> self
- *
- * Appends an int64(BIGINT) value to the current row in the appender.
- *
- *   require 'duckdb'
- *   db = DuckDB::Database.open
- *   con = db.connect
- *   con.query('CREATE TABLE users (id INTEGER, age BIGINT)')
- *   appender = con.appender('users')
- *   appender
- *     .append_int32(1)
- *     .append_int64(20)
- *     .end_row
- *     .flush
- */
-static VALUE appender_append_int64(VALUE self, VALUE val) {
+/* :nodoc: */
+static VALUE appender__apend_int64(VALUE self, VALUE val) {
     rubyDuckDBAppender *ctx;
     int64_t i64val = (int64_t)NUM2LL(val);
 
     TypedData_Get_Struct(self, rubyDuckDBAppender, &appender_data_type, ctx);
 
-    if (duckdb_append_int64(ctx->appender, i64val) == DuckDBError) {
-        rb_raise(eDuckDBError, "failed to append int64");
-    }
-    return self;
+    return duckdb_state_to_bool_value(duckdb_append_int64(ctx->appender, i64val));
 }
 
 static VALUE appender_append_uint8(VALUE self, VALUE val) {
@@ -440,7 +422,6 @@ void rbduckdb_init_duckdb_appender(void) {
     rb_define_alloc_func(cDuckDBAppender, allocate);
     rb_define_method(cDuckDBAppender, "initialize", appender_initialize, 3);
     rb_define_method(cDuckDBAppender, "error_message", appender_error_message, 0);
-    rb_define_method(cDuckDBAppender, "append_int64", appender_append_int64, 1);
     rb_define_method(cDuckDBAppender, "append_uint8", appender_append_uint8, 1);
     rb_define_method(cDuckDBAppender, "append_uint16", appender_append_uint16, 1);
     rb_define_method(cDuckDBAppender, "append_uint32", appender_append_uint32, 1);
@@ -463,6 +444,7 @@ void rbduckdb_init_duckdb_appender(void) {
     rb_define_private_method(cDuckDBAppender, "_append_int8", appender__append_int8, 1);
     rb_define_private_method(cDuckDBAppender, "_append_int16", appender__apend_int16, 1);
     rb_define_private_method(cDuckDBAppender, "_append_int32", appender__append_int32, 1);
+    rb_define_private_method(cDuckDBAppender, "_append_int64", appender__apend_int64, 1);
     rb_define_private_method(cDuckDBAppender, "_append_date", appender__append_date, 3);
     rb_define_private_method(cDuckDBAppender, "_append_interval", appender__append_interval, 3);
     rb_define_private_method(cDuckDBAppender, "_append_time", appender__append_time, 4);

--- a/lib/duckdb/appender.rb
+++ b/lib/duckdb/appender.rb
@@ -181,6 +181,27 @@ module DuckDB
       raise_appender_error('failed to append_int32')
     end
 
+    # call-seq:
+    #   appender.append_int64(val) -> self
+    #
+    # Appends an int64(BIGINT) value to the current row in the appender.
+    #
+    #   require 'duckdb'
+    #   db = DuckDB::Database.open
+    #   con = db.connect
+    #   con.query('CREATE TABLE users (id INTEGER, age BIGINT)')
+    #   appender = con.appender('users')
+    #   appender
+    #     .append_int32(1)
+    #     .append_int64(20)
+    #     .end_row
+    #     .flush
+    def append_int64(value)
+      return self if _append_int64(value)
+
+      raise_appender_error('failed to append_int64')
+    end
+
     # appends huge int value.
     #
     #   require 'duckdb'


### PR DESCRIPTION
get error message from duckdb when appender_int64 failed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `append_int64` method to DuckDB Appender for appending 64-bit integer values.
  - Introduced error message handling for int64 appending operations.

- **Bug Fixes**
  - Corrected method naming for internal int64 append functionality.

- **Documentation**
  - Updated changelog with detailed method error handling information.
  - Added documentation for new `append_int64` method.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->