### PR TITLE
change error handling of DuckDB::Appender#append_uint8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 - add `DuckDB::Appender#error_message`.
 - fix error message when `DuckDB::Appender#flush`, `DuckDB::Appender#close`, `DuckDB::Appender#end_row`,
   `DuckDB::Appender#append_bool`, `DuckDB::Appender#append_int8`, `DuckDB::Appender#append_int16`,
-  `DuckDB::Appender#append_int32`, `DuckDB::Appender#append_int64` failed.
+  `DuckDB::Appender#append_int32`, `DuckDB::Appender#append_int64`, `DuckDB::Appender#append_uint8` failed.
 - `DuckDB::Appender#begin_row` does nothing. Only returns self. `DuckDB::Appender#end_row` is only required.
 
 # 1.1.3.1 - 2024-11-27

--- a/ext/duckdb/appender.c
+++ b/ext/duckdb/appender.c
@@ -170,7 +170,7 @@ static VALUE appender__append_int64(VALUE self, VALUE val) {
 /* :nodoc: */
 static VALUE appender__append_uint8(VALUE self, VALUE val) {
     rubyDuckDBAppender *ctx;
-    int8_t ui8val = (uint8_t)NUM2UINT(val);
+    uint8_t ui8val = (uint8_t)NUM2UINT(val);
 
     TypedData_Get_Struct(self, rubyDuckDBAppender, &appender_data_type, ctx);
 

--- a/ext/duckdb/appender.c
+++ b/ext/duckdb/appender.c
@@ -12,7 +12,7 @@ static VALUE appender__append_int8(VALUE self, VALUE val);
 static VALUE appender__append_int16(VALUE self, VALUE val);
 static VALUE appender__append_int32(VALUE self, VALUE val);
 static VALUE appender__append_int64(VALUE self, VALUE val);
-static VALUE appender_append_uint8(VALUE self, VALUE val);
+static VALUE appender__append_uint8(VALUE self, VALUE val);
 static VALUE appender_append_uint16(VALUE self, VALUE val);
 static VALUE appender_append_uint32(VALUE self, VALUE val);
 static VALUE appender_append_uint64(VALUE self, VALUE val);
@@ -167,16 +167,14 @@ static VALUE appender__append_int64(VALUE self, VALUE val) {
     return duckdb_state_to_bool_value(duckdb_append_int64(ctx->appender, i64val));
 }
 
-static VALUE appender_append_uint8(VALUE self, VALUE val) {
+/* :nodoc: */
+static VALUE appender__append_uint8(VALUE self, VALUE val) {
     rubyDuckDBAppender *ctx;
     int8_t ui8val = (uint8_t)NUM2UINT(val);
 
     TypedData_Get_Struct(self, rubyDuckDBAppender, &appender_data_type, ctx);
 
-    if (duckdb_append_uint8(ctx->appender, ui8val) == DuckDBError) {
-        rb_raise(eDuckDBError, "failed to append uint8");
-    }
-    return self;
+    return duckdb_state_to_bool_value(duckdb_append_uint8(ctx->appender, ui8val));
 }
 
 static VALUE appender_append_uint16(VALUE self, VALUE val) {
@@ -422,7 +420,6 @@ void rbduckdb_init_duckdb_appender(void) {
     rb_define_alloc_func(cDuckDBAppender, allocate);
     rb_define_method(cDuckDBAppender, "initialize", appender_initialize, 3);
     rb_define_method(cDuckDBAppender, "error_message", appender_error_message, 0);
-    rb_define_method(cDuckDBAppender, "append_uint8", appender_append_uint8, 1);
     rb_define_method(cDuckDBAppender, "append_uint16", appender_append_uint16, 1);
     rb_define_method(cDuckDBAppender, "append_uint32", appender_append_uint32, 1);
     rb_define_method(cDuckDBAppender, "append_uint64", appender_append_uint64, 1);
@@ -445,6 +442,7 @@ void rbduckdb_init_duckdb_appender(void) {
     rb_define_private_method(cDuckDBAppender, "_append_int16", appender__append_int16, 1);
     rb_define_private_method(cDuckDBAppender, "_append_int32", appender__append_int32, 1);
     rb_define_private_method(cDuckDBAppender, "_append_int64", appender__append_int64, 1);
+    rb_define_private_method(cDuckDBAppender, "_append_uint8", appender__append_uint8, 1);
     rb_define_private_method(cDuckDBAppender, "_append_date", appender__append_date, 3);
     rb_define_private_method(cDuckDBAppender, "_append_interval", appender__append_interval, 3);
     rb_define_private_method(cDuckDBAppender, "_append_time", appender__append_time, 4);

--- a/lib/duckdb/appender.rb
+++ b/lib/duckdb/appender.rb
@@ -202,6 +202,28 @@ module DuckDB
       raise_appender_error('failed to append_int64')
     end
 
+    # call-seq:
+    #  appender.append_uint8(val) -> self
+    #
+    # Appends an uint8 value to the current row in the appender.
+    # The value must be in the range of 0 to 255.
+    #
+    #  require 'duckdb'
+    #  db = DuckDB::Database.open
+    #  con = db.connect
+    #  con.query('CREATE TABLE users (id INTEGER, age UTINYINT)')
+    #  appender = con.appender('users')
+    #  appender
+    #    .append_int32(1)
+    #    .append_uint8(20)
+    #    .end_row
+    #    .flush
+    def append_uint8(value)
+      return self if _append_uint8(value)
+
+      raise_appender_error('failed to append_uint8')
+    end
+
     # appends huge int value.
     #
     #   require 'duckdb'

--- a/lib/duckdb/appender.rb
+++ b/lib/duckdb/appender.rb
@@ -206,7 +206,6 @@ module DuckDB
     #  appender.append_uint8(val) -> self
     #
     # Appends an uint8 value to the current row in the appender.
-    # The value must be in the range of 0 to 255.
     #
     #  require 'duckdb'
     #  db = DuckDB::Database.open


### PR DESCRIPTION
get error message from duckdb when DuckDB::Appender#append_uint8 failed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling for appending data in the DuckDB Appender
	- Enhanced error messaging for several append methods

- **New Features**
	- Introduced `append_uint8` method to support appending unsigned 8-bit integers

- **Refactor**
	- Adjusted method visibility and naming for internal append methods
<!-- end of auto-generated comment: release notes by coderabbit.ai -->