### PR TITLE
logical_type: add `DuckDB::LogicalType#child_type`

### DIFF
--- a/ext/duckdb/logical_type.c
+++ b/ext/duckdb/logical_type.c
@@ -74,6 +74,13 @@ static VALUE duckdb_logical_type_scale(VALUE self) {
     return INT2FIX(duckdb_decimal_scale(ctx->logical_type));
 }
 
+/*
+ *  call-seq:
+ *    list_col.logical_type.child_type -> DuckDB::LogicalType
+ *
+ *  Returns the child logical type for list and map types, otherwise nil.
+ *
+ */
 static VALUE duckdb_logical_type_child_type(VALUE self) {
     rubyDuckDBLogicalType *ctx;
     duckdb_type type_id;

--- a/ext/duckdb/logical_type.c
+++ b/ext/duckdb/logical_type.c
@@ -8,6 +8,7 @@ static size_t memsize(const void *p);
 static VALUE duckdb_logical_type__type(VALUE self);
 static VALUE duckdb_logical_type_width(VALUE self);
 static VALUE duckdb_logical_type_scale(VALUE self);
+static VALUE duckdb_logical_type_child_type(VALUE self);
 
 static const rb_data_type_t logical_type_data_type = {
     "DuckDB/LogicalType",
@@ -73,6 +74,27 @@ static VALUE duckdb_logical_type_scale(VALUE self) {
     return INT2FIX(duckdb_decimal_scale(ctx->logical_type));
 }
 
+static VALUE duckdb_logical_type_child_type(VALUE self) {
+    rubyDuckDBLogicalType *ctx;
+    duckdb_type type_id;
+    duckdb_logical_type child_logical_type;
+    VALUE logical_type = Qnil;
+
+    TypedData_Get_Struct(self, rubyDuckDBLogicalType, &logical_type_data_type, ctx);
+    type_id = duckdb_get_type_id(ctx->logical_type);
+
+    switch(type_id) {
+        case DUCKDB_TYPE_LIST:
+        case DUCKDB_TYPE_MAP:
+            child_logical_type = duckdb_list_type_child_type(ctx->logical_type);
+            logical_type = rbduckdb_create_logical_type(child_logical_type);
+            break;
+        default:
+            logical_type = Qnil;
+    }
+    return logical_type;
+}
+
 VALUE rbduckdb_create_logical_type(duckdb_logical_type logical_type) {
     VALUE obj;
     rubyDuckDBLogicalType *ctx;
@@ -95,4 +117,5 @@ void rbduckdb_init_duckdb_logical_type(void) {
     rb_define_private_method(cDuckDBLogicalType, "_type", duckdb_logical_type__type, 0);
     rb_define_method(cDuckDBLogicalType, "width", duckdb_logical_type_width, 0);
     rb_define_method(cDuckDBLogicalType, "scale", duckdb_logical_type_scale, 0);
+    rb_define_method(cDuckDBLogicalType, "child_type", duckdb_logical_type_child_type, 0);
 }

--- a/test/duckdb_test/logical_type_test.rb
+++ b/test/duckdb_test/logical_type_test.rb
@@ -119,6 +119,22 @@ module DuckDBTest
       assert_equal(6, decimal_column.logical_type.scale)
     end
 
+    def test_list_child_type
+      list_columns = @columns.select { |column| column.type == :list }
+      child_types = list_columns.map do |list_column|
+        list_column.logical_type.child_type
+      end
+      assert(child_types.all? { |child_type| child_type.is_a?(DuckDB::LogicalType) })
+      assert_equal([:integer, :varchar], child_types.map(&:type))
+    end
+
+    def test_map_child_type
+      map_column = @columns.detect { |column| column.type == :map }
+      child_type = map_column.logical_type.child_type
+      assert(child_type.is_a?(DuckDB::LogicalType))
+      assert_equal(:struct, child_type.type)
+    end
+
     private
 
     def create_data(con)


### PR DESCRIPTION
refs: GH-690

In this PR, we add `DuckDB::LogicalType#child_type` which is the binding method for the following method.

```c
duckdb_logical_type duckdb_list_type_child_type(duckdb_logical_type type);
```

ref: https://duckdb.org/docs/api/c/api.html#duckdb_list_type_child_type
ref: https://github.com/duckdb/duckdb/blob/main/src/main/capi/logical_types-c.cpp#L226-L236

This is one of the steps for supporting duckdb_logical_column_type C API.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added functionality to retrieve child types for list and map logical types.

- **Tests**
  - Introduced tests to verify the behavior and accuracy of child type retrieval for list and map structures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->