### PR TITLE
DuckDB::Result#row_count is depreacted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ All notable changes to this project will be documented in this file.
   `DuckDB::Appender#append_int32`, `DuckDB::Appender#append_int64`, `DuckDB::Appender#append_uint8` failed.
 - `DuckDB::Appender#begin_row` does nothing. Only returns self. `DuckDB::Appender#end_row` is only required.
 
+## Breaking changes
+- `DuckDB::Result#row_count`, `DuckDB::Result#row_size` are deprecated.
+
 # 1.1.3.1 - 2024-11-27
 - fix to `DuckDB::Connection#query` with multiple SQL statements. Calling PreparedStatement#destroy after each statement executed.
 - install valgrind in docker development environment.

--- a/ext/duckdb/result.c
+++ b/ext/duckdb/result.c
@@ -24,7 +24,6 @@ static void deallocate(void *ctx);
 static VALUE allocate(VALUE klass);
 static size_t memsize(const void *p);
 static VALUE duckdb_result_column_count(VALUE oDuckDBResult);
-static VALUE duckdb_result_row_count(VALUE oDuckDBResult);
 static VALUE duckdb_result_rows_changed(VALUE oDuckDBResult);
 static VALUE duckdb_result_columns(VALUE oDuckDBResult);
 static VALUE duckdb_result_streaming_p(VALUE oDuckDBResult);
@@ -145,36 +144,6 @@ static VALUE duckdb_result_column_count(VALUE oDuckDBResult) {
     rubyDuckDBResult *ctx;
     TypedData_Get_Struct(oDuckDBResult, rubyDuckDBResult, &result_data_type, ctx);
     return LL2NUM(duckdb_column_count(&(ctx->result)));
-}
-
-/*
- *  call-seq:
- *    result.row_count -> Integer
- *
- *  Returns the column size of the result.
- *
- *    DuckDB::Database.open do |db|
- *      db.connect do |con|
- *        r = con.query('CREATE TABLE t2 (id INT, name VARCHAR(128))')
- *        r = con.query("INSERT INTO t2 VALUES (1, 'Alice'), (2, 'Bob'), (3, 'Catherine')")
- *        r = con.query('SELECT * FROM t2')
- *        r.row_count # => 3
- *        r = con.query('SELECT * FROM t2 where id = 1')
- *        r.row_count # => 1
- *      end
- *    end
- *
- */
-static VALUE duckdb_result_row_count(VALUE oDuckDBResult) {
-
-#ifdef DUCKDB_API_NO_DEPRECATED
-    return Qnil;
-#else
-    rubyDuckDBResult *ctx;
-    rb_warn("`row_count` will be deprecated in the future.");
-    TypedData_Get_Struct(oDuckDBResult, rubyDuckDBResult, &result_data_type, ctx);
-    return LL2NUM(duckdb_row_count(&(ctx->result)));
-#endif
 }
 
 /*
@@ -913,7 +882,6 @@ void rbduckdb_init_duckdb_result(void) {
     rb_define_alloc_func(cDuckDBResult, allocate);
 
     rb_define_method(cDuckDBResult, "column_count", duckdb_result_column_count, 0);
-    rb_define_method(cDuckDBResult, "row_count", duckdb_result_row_count, 0); /* deprecated */
     rb_define_method(cDuckDBResult, "rows_changed", duckdb_result_rows_changed, 0);
     rb_define_method(cDuckDBResult, "columns", duckdb_result_columns, 0);
     rb_define_method(cDuckDBResult, "streaming?", duckdb_result_streaming_p, 0);

--- a/lib/duckdb/result.rb
+++ b/lib/duckdb/result.rb
@@ -27,7 +27,6 @@ module DuckDB
     RETURN_TYPES = %i[invalid changed_rows nothing query_result].freeze
 
     alias column_size column_count
-    alias row_size row_count
 
     class << self
       def new

--- a/test/duckdb_test/result_test.rb
+++ b/test/duckdb_test/result_test.rb
@@ -135,15 +135,6 @@ module DuckDBTest
       assert_equal(2, r.column_size)
     end
 
-    def test_row_count
-      r = @@con.query('SELECT * FROM table1')
-      assert_equal(2, r.row_count)
-      assert_equal(2, r.row_size)
-      r = @@con.query('SELECT * FROM table1 WHERE boolean_col = true')
-      assert_equal(1, r.row_count)
-      assert_equal(1, r.row_size)
-    end
-
     def test_columns
       assert_instance_of(DuckDB::Column, @result.columns.first)
     end


### PR DESCRIPTION
DuckDB::Result#row_count, DuckDB::Result#row_size are deprecated. 
Because duckdb_row_count C-API of duckdb has been deprecated and may be removed in future versions of DuckDB.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Streamlined the API by deprecating and removing older methods for retrieving result row information, including removal of redundant aliases.
- **Bug Fixes**
	- Enhanced error handling in data append operations to improve overall reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->