### PR TITLE
deprecate DuckDB::Result.use_chunk_each, DuckDB::Result.use_chunk_each?

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 
 ## Breaking changes
 - `DuckDB::Result#row_count`, `DuckDB::Result#row_size` are deprecated.
+- `DuckDB::Result#use_chunk_each?`, `DuckDB::Result#use_chunk_each=` are deprecated.
 
 # 1.1.3.1 - 2024-11-27
 - fix to `DuckDB::Connection#query` with multiple SQL statements. Calling PreparedStatement#destroy after each statement executed.

--- a/lib/duckdb/result.rb
+++ b/lib/duckdb/result.rb
@@ -32,19 +32,6 @@ module DuckDB
       def new
         raise DuckDB::Error, 'DuckDB::Result cannot be instantiated directly.'
       end
-
-      def use_chunk_each=(value) # :nodoc:
-        raise('`changing DuckDB::Result.use_chunk_each to false` was deprecated.') unless value
-
-        warn('`DuckDB::Result.use_chunk_each=` will be deprecated.')
-
-        true
-      end
-
-      def use_chunk_each? # :nodoc:
-        warn('`DuckDB::Result.use_chunk_each?` will be deprecated.')
-        true
-      end
     end
 
     def each(&)


### PR DESCRIPTION
Thease methods don't effect any behavior changes of ruby-duckdb.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features  
  - Introduced a new default appending option that streamlines data insertion processes.

- Refactor  
  - Simplified row handling by consolidating multiple steps into a single, more consistent operation.  
  - Removed legacy chunk processing functionality to modernize the API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->