### PR TITLE
always use duckdb_fetch_chunk

### DIFF
--- a/ext/duckdb/extconf.rb
+++ b/ext/duckdb/extconf.rb
@@ -61,9 +61,6 @@ check_duckdb_library('duckdb', 'duckdb_appender_column_count', DUCKDB_REQUIRED_V
 # check duckdb >= 1.0.0
 have_func('duckdb_fetch_chunk', 'duckdb.h')
 
-# check duckdb >= 1.0.0
-have_func('duckdb_fetch_chunk', 'duckdb.h')
-
 # check duckdb >= 1.1.0
 have_func('duckdb_result_error_type', 'duckdb.h')
 

--- a/ext/duckdb/result.c
+++ b/ext/duckdb/result.c
@@ -239,11 +239,7 @@ static VALUE duckdb_result__chunk_stream(VALUE oDuckDBResult) {
 
     arg.col_count = duckdb_column_count(&(ctx->result));
 
-#ifdef HAVE_DUCKDB_H_GE_V1_0_0
     while((arg.chunk = duckdb_fetch_chunk(ctx->result)) != NULL) {
-#else
-    while((arg.chunk = duckdb_stream_fetch_chunk(ctx->result)) != NULL) {
-#endif
         rb_ensure(yield_rows, (VALUE)&arg, destroy_data_chunk, (VALUE)&arg);
     }
     return Qnil;


### PR DESCRIPTION
use duckdb_fetch_chunk because ruby-duckdb supports duckdb >= 1.0.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Streamlined configuration by removing redundant verification steps.
	- Simplified the data streaming mechanism for a clearer, more efficient internal process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->