### PR TITLE
support interfaces for Array logical type in DuckDB::LogicalType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 - bump duckdb to 1.2.0.
 - add `DuckDB::LogicalType` class(Thanks to @otegami).
   - `DuckDB::LogicalType` class is under construction. `DuckDB::LogicalType#type`, `DuckDB::LogicalType#width`,
-    `DuckDB::LogicalType#scale`, `DuckDB::LogicalType#child_type` are available.
+    `DuckDB::LogicalType#scale`, `DuckDB::LogicalType#child_type`, `DuckDB::LogicalType#size` are available.
 - add `DuckDB::Appender#error_message`.
 - fix error message when `DuckDB::Appender#flush`, `DuckDB::Appender#close`, `DuckDB::Appender#end_row`,
   `DuckDB::Appender#append_bool`, `DuckDB::Appender#append_int8`, `DuckDB::Appender#append_int16`,

--- a/ext/duckdb/logical_type.c
+++ b/ext/duckdb/logical_type.c
@@ -9,6 +9,7 @@ static VALUE duckdb_logical_type__type(VALUE self);
 static VALUE duckdb_logical_type_width(VALUE self);
 static VALUE duckdb_logical_type_scale(VALUE self);
 static VALUE duckdb_logical_type_child_type(VALUE self);
+static VALUE duckdb_logical_type_size(VALUE self);
 
 static const rb_data_type_t logical_type_data_type = {
     "DuckDB/LogicalType",
@@ -106,6 +107,19 @@ static VALUE duckdb_logical_type_child_type(VALUE self) {
     return logical_type;
 }
 
+/*
+ *  call-seq:
+ *    list_col.logical_type.size -> Integer
+ *
+ *  Returns the size of the array column, otherwise 0.
+ *
+ */
+static VALUE duckdb_logical_type_size(VALUE self) {
+    rubyDuckDBLogicalType *ctx;
+    TypedData_Get_Struct(self, rubyDuckDBLogicalType, &logical_type_data_type, ctx);
+    return INT2FIX(duckdb_array_type_array_size(ctx->logical_type));
+}
+
 VALUE rbduckdb_create_logical_type(duckdb_logical_type logical_type) {
     VALUE obj;
     rubyDuckDBLogicalType *ctx;
@@ -129,4 +143,5 @@ void rbduckdb_init_duckdb_logical_type(void) {
     rb_define_method(cDuckDBLogicalType, "width", duckdb_logical_type_width, 0);
     rb_define_method(cDuckDBLogicalType, "scale", duckdb_logical_type_scale, 0);
     rb_define_method(cDuckDBLogicalType, "child_type", duckdb_logical_type_child_type, 0);
+    rb_define_method(cDuckDBLogicalType, "size", duckdb_logical_type_size, 0);
 }

--- a/ext/duckdb/logical_type.c
+++ b/ext/duckdb/logical_type.c
@@ -96,6 +96,10 @@ static VALUE duckdb_logical_type_child_type(VALUE self) {
             child_logical_type = duckdb_list_type_child_type(ctx->logical_type);
             logical_type = rbduckdb_create_logical_type(child_logical_type);
             break;
+        case DUCKDB_TYPE_ARRAY:
+            child_logical_type = duckdb_array_type_child_type(ctx->logical_type);
+            logical_type = rbduckdb_create_logical_type(child_logical_type);
+            break;
         default:
             logical_type = Qnil;
     }

--- a/test/duckdb_test/logical_type_test.rb
+++ b/test/duckdb_test/logical_type_test.rb
@@ -150,6 +150,14 @@ module DuckDBTest
       assert_equal([:integer, :varchar], child_types.map(&:type))
     end
 
+    def test_array_size
+      array_columns = @columns.select { |column| column.type == :array }
+      array_sizes = array_columns.map do |array_column|
+        array_column.logical_type.size
+      end
+      assert_equal([3, 2], array_sizes)
+    end
+
     private
 
     def create_data(con)

--- a/test/duckdb_test/logical_type_test.rb
+++ b/test/duckdb_test/logical_type_test.rb
@@ -31,6 +31,8 @@ module DuckDBTest
         enum_col mood,
         int_list_col INT[],
         varchar_list_col VARCHAR[],
+        int_array_col INT[3],
+        varchar_list_array_col VARCHAR[2],
         struct_col STRUCT(word VARCHAR, length INTEGER),
         uuid_col UUID,
         map_col MAP(INTEGER, VARCHAR)
@@ -61,6 +63,8 @@ module DuckDBTest
         'sad',
         [1, 2, 3],
         ['a', 'b', 'c'],
+        [1, 2, 3],
+        [['a', 'b'], ['c', 'd']],
         ROW('Ruby', 4),
         '#{SecureRandom.uuid}',
         MAP{1: 'foo'}
@@ -91,6 +95,8 @@ module DuckDBTest
       enum
       list
       list
+      array
+      array
       struct
       uuid
       map
@@ -133,6 +139,15 @@ module DuckDBTest
       child_type = map_column.logical_type.child_type
       assert(child_type.is_a?(DuckDB::LogicalType))
       assert_equal(:struct, child_type.type)
+    end
+
+    def test_array_child_type
+      array_columns = @columns.select { |column| column.type == :array }
+      child_types = array_columns.map do |array_column|
+        array_column.logical_type.child_type
+      end
+      assert(child_types.all? { |child_type| child_type.is_a?(DuckDB::LogicalType) })
+      assert_equal([:integer, :varchar], child_types.map(&:type))
     end
 
     private


### PR DESCRIPTION
refs: GH-690

In this PR, we support interfaces for Array logical type in DuckDB::Column#logical_type about the following.
- duckdb_logical_type [duckdb_array_type_child_type](https://duckdb.org/docs/api/c/api#duckdb_array_type_child_type) (duckdb_logical_type type);
- idx_t [duckdb_array_type_array_size](https://duckdb.org/docs/api/c/api#duckdb_array_type_array_size)(duckdb_logical_type type);
  - Except for Array column type, this API always returns 0.
  - ref: https://github.com/duckdb/duckdb/blob/main/src/main/capi/logical_types-c.cpp#L250-L259

This is one of the steps for supporting duckdb_logical_column_type C API.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced array type handling by providing API support for retrieving the size of array columns.
  - Improved logic for identifying the element type within array columns.
  - Introduced a new method to obtain the size of array columns in the logical type class.

- **Bug Fixes**
  - Improved error handling for various methods in the appender class, providing clearer error messages.

- **Tests**
  - Added tests that verify correct behavior for array columns, including their sizes and child element types.

- **Documentation**
  - Updated changelog to reflect new and deprecated methods in the logical type and result classes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->