### PR TITLE
Release the GVL when executing a prepared statement.

### DIFF
--- a/ext/duckdb/ruby-duckdb.h
+++ b/ext/duckdb/ruby-duckdb.h
@@ -5,6 +5,7 @@
 #define DUCKDB_NO_EXTENSION_FUNCTIONS // disable extension C-functions
 
 #include "ruby.h"
+#include "ruby/thread.h"
 #include <duckdb.h>
 
 #ifdef HAVE_DUCKDB_FETCH_CHUNK


### PR DESCRIPTION
This change allows the Ruby VM to continue executing other Ruby threads while the DuckDB prepared statement is being executed.

There are many other methods that are candidates for this same treatment. This PR addresses only execution of a prepared statement, which is also what `DuckDB::Connection#query` uses. If accepted, we could adopt a similar approach for other high-value functions.

Ideally, we'd also be able to give Ruby the `duckdb_interrupt` function to handle signals, etc, but it seems there is nothing in the DuckDB C API that lets us interrupt a prepared statement, only a connection. (And it doesn't seem safe to interrupt a connection without _reliably_ being able to know our given prepared statement is the active query on the connection.)

Locally, this doesn't seem to have an effect on the performance of benchmarks, but presumably someone doing a whole lot of tiny transactions may be better able to detect it.

This fixes https://github.com/suketa/ruby-duckdb/issues/873 specifically, but we'll want to follow up with more if we determine this is a path we want to take.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enabled non-blocking execution for prepared statements, improving responsiveness and performance.
  - Enhanced error reporting to provide clearer feedback on execution issues.

- **Chores**
  - Updated threading support to better manage concurrent operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->