### PR TITLE
support interfaces for Map logical type in DuckDB::LogicalType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ All notable changes to this project will be documented in this file.
 - bump duckdb to 1.2.0.
 - add `DuckDB::LogicalType` class(Thanks to @otegami).
   - `DuckDB::LogicalType` class is under construction. `DuckDB::LogicalType#type`, `DuckDB::LogicalType#width`,
-    `DuckDB::LogicalType#scale`, `DuckDB::LogicalType#child_type`, `DuckDB::LogicalType#size` are available.
+    `DuckDB::LogicalType#scale`, `DuckDB::LogicalType#child_type`, `DuckDB::LogicalType#size`,
+    `DuckDB::LogicalType#key_type` are available.
 - add `DuckDB::Appender#error_message`.
 - fix error message when `DuckDB::Appender#flush`, `DuckDB::Appender#close`, `DuckDB::Appender#end_row`,
   `DuckDB::Appender#append_bool`, `DuckDB::Appender#append_int8`, `DuckDB::Appender#append_int16`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 - add `DuckDB::LogicalType` class(Thanks to @otegami).
   - `DuckDB::LogicalType` class is under construction. `DuckDB::LogicalType#type`, `DuckDB::LogicalType#width`,
     `DuckDB::LogicalType#scale`, `DuckDB::LogicalType#child_type`, `DuckDB::LogicalType#size`,
-    `DuckDB::LogicalType#key_type` are available.
+    `DuckDB::LogicalType#key_type`, and `DuckDB::LogicalType#value_type` are available.
 - add `DuckDB::Appender#error_message`.
 - fix error message when `DuckDB::Appender#flush`, `DuckDB::Appender#close`, `DuckDB::Appender#end_row`,
   `DuckDB::Appender#append_bool`, `DuckDB::Appender#append_int8`, `DuckDB::Appender#append_int16`,

--- a/ext/duckdb/logical_type.c
+++ b/ext/duckdb/logical_type.c
@@ -10,6 +10,7 @@ static VALUE duckdb_logical_type_width(VALUE self);
 static VALUE duckdb_logical_type_scale(VALUE self);
 static VALUE duckdb_logical_type_child_type(VALUE self);
 static VALUE duckdb_logical_type_size(VALUE self);
+static VALUE duckdb_logical_type_key_type(VALUE self);
 
 static const rb_data_type_t logical_type_data_type = {
     "DuckDB/LogicalType",
@@ -120,6 +121,24 @@ static VALUE duckdb_logical_type_size(VALUE self) {
     return INT2FIX(duckdb_array_type_array_size(ctx->logical_type));
 }
 
+/*
+ *  call-seq:
+ *    map_col.logical_type.key_type -> DuckDB::LogicalType
+ *
+ *  Returns the key logical type for map type, otherwise nil.
+ *
+ */
+static VALUE duckdb_logical_type_key_type(VALUE self) {
+    rubyDuckDBLogicalType *ctx;
+    duckdb_logical_type key_logical_type;
+    VALUE logical_type = Qnil;
+
+    TypedData_Get_Struct(self, rubyDuckDBLogicalType, &logical_type_data_type, ctx);
+    key_logical_type = duckdb_map_type_key_type(ctx->logical_type);
+    logical_type = rbduckdb_create_logical_type(key_logical_type);
+    return logical_type;
+}
+
 VALUE rbduckdb_create_logical_type(duckdb_logical_type logical_type) {
     VALUE obj;
     rubyDuckDBLogicalType *ctx;
@@ -144,4 +163,5 @@ void rbduckdb_init_duckdb_logical_type(void) {
     rb_define_method(cDuckDBLogicalType, "scale", duckdb_logical_type_scale, 0);
     rb_define_method(cDuckDBLogicalType, "child_type", duckdb_logical_type_child_type, 0);
     rb_define_method(cDuckDBLogicalType, "size", duckdb_logical_type_size, 0);
+    rb_define_method(cDuckDBLogicalType, "key_type", duckdb_logical_type_key_type, 0);
 }

--- a/ext/duckdb/logical_type.c
+++ b/ext/duckdb/logical_type.c
@@ -11,6 +11,7 @@ static VALUE duckdb_logical_type_scale(VALUE self);
 static VALUE duckdb_logical_type_child_type(VALUE self);
 static VALUE duckdb_logical_type_size(VALUE self);
 static VALUE duckdb_logical_type_key_type(VALUE self);
+static VALUE duckdb_logical_type_value_type(VALUE self);
 
 static const rb_data_type_t logical_type_data_type = {
     "DuckDB/LogicalType",
@@ -139,6 +140,24 @@ static VALUE duckdb_logical_type_key_type(VALUE self) {
     return logical_type;
 }
 
+/*
+ *  call-seq:
+ *    map_col.logical_type.value_type -> DuckDB::LogicalType
+ *
+ *  Returns the value logical type for map type, otherwise nil.
+ *
+ */
+static VALUE duckdb_logical_type_value_type(VALUE self) {
+    rubyDuckDBLogicalType *ctx;
+    duckdb_logical_type value_logical_type;
+    VALUE logical_type = Qnil;
+
+    TypedData_Get_Struct(self, rubyDuckDBLogicalType, &logical_type_data_type, ctx);
+    value_logical_type = duckdb_map_type_value_type(ctx->logical_type);
+    logical_type = rbduckdb_create_logical_type(value_logical_type);
+    return logical_type;
+}
+
 VALUE rbduckdb_create_logical_type(duckdb_logical_type logical_type) {
     VALUE obj;
     rubyDuckDBLogicalType *ctx;
@@ -164,4 +183,5 @@ void rbduckdb_init_duckdb_logical_type(void) {
     rb_define_method(cDuckDBLogicalType, "child_type", duckdb_logical_type_child_type, 0);
     rb_define_method(cDuckDBLogicalType, "size", duckdb_logical_type_size, 0);
     rb_define_method(cDuckDBLogicalType, "key_type", duckdb_logical_type_key_type, 0);
+    rb_define_method(cDuckDBLogicalType, "value_type", duckdb_logical_type_value_type, 0);
 }

--- a/test/duckdb_test/logical_type_test.rb
+++ b/test/duckdb_test/logical_type_test.rb
@@ -158,6 +158,13 @@ module DuckDBTest
       assert_equal([3, 2], array_sizes)
     end
 
+    def test_map_key_type
+      map_column = @columns.find { |column| column.type == :map }
+      key_type = map_column.logical_type.key_type
+      assert(key_type.is_a?(DuckDB::LogicalType))
+      assert_equal(:integer, key_type.type)
+    end
+
     private
 
     def create_data(con)

--- a/test/duckdb_test/logical_type_test.rb
+++ b/test/duckdb_test/logical_type_test.rb
@@ -165,6 +165,13 @@ module DuckDBTest
       assert_equal(:integer, key_type.type)
     end
 
+    def test_map_value_type
+      map_column = @columns.find { |column| column.type == :map }
+      value_type = map_column.logical_type.value_type
+      assert(value_type.is_a?(DuckDB::LogicalType))
+      assert_equal(:varchar, value_type.type)
+    end
+
     private
 
     def create_data(con)


### PR DESCRIPTION
refs: GH-690

In this PR, we support interfaces for Map logical type in DuckDB::Column#logical_type about the following.
This is one of the steps for supporting duckdb_logical_column_type C API.

- duckdb_logical_type [duckdb_map_type_key_type](https://duckdb.org/docs/api/c/api.html#duckdb_map_type_key_type)(duckdb_logical_type type);
- duckdb_logical_type [duckdb_map_type_value_type](https://duckdb.org/docs/api/c/api.html#duckdb_map_type_value_type)(duckdb_logical_type type);

The above APIs, they return nil except for the Map column type.
- ref: https://github.com/duckdb/duckdb/blob/main/src/main/capi/logical_types-c.cpp#L261-L281

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced handling for map column types with clear key and value type retrieval.
	- Introduced a streamlined default operation for appending data.

- **Bug Fixes**
	- Improved error messaging during data operations for a better user experience.

- **Deprecations**
	- Phasing out legacy methods for result details to promote a more streamlined future experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->