### PR TITLE
DuckDB::Result#chunk_each is deprecated.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ All notable changes to this project will be documented in this file.
 - `DuckDB::Result#row_count`, `DuckDB::Result#row_size` are deprecated.
 - `DuckDB::Result#use_chunk_each?`, `DuckDB::Result#use_chunk_each=` are deprecated.
 - `DuckDB::Result#chunk_each` is deprecated.
--  `DuckDB::Result#each` only works only at first time because duckdb_chunk_each C-API is deprecated.
+-  `DuckDB::Result#each` only works at first time because duckdb_chunk_each C-API is deprecated.
    Calling `DuckDB::Result#each` twice or more does not work.
    ```ruby
    result = con.query('SELECT * FROM table')

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,32 @@ All notable changes to this project will be documented in this file.
 ## Breaking changes
 - `DuckDB::Result#row_count`, `DuckDB::Result#row_size` are deprecated.
 - `DuckDB::Result#use_chunk_each?`, `DuckDB::Result#use_chunk_each=` are deprecated.
+- `DuckDB::Result#chunk_each` is deprecated.
+-  `DuckDB::Result#each` only works only at first time because duckdb_chunk_each C-API is deprecated.
+   Calling `DuckDB::Result#each` twice or more does not work.
+   ```ruby
+   result = con.query('SELECT * FROM table')
+   result.each do |record|
+     p record # <= this works fine.
+   end
+   # calling each again does not work.
+   result.each do |record|
+     p record # <= this will not work
+   end
+   ```
+   If you prefer to use `DuckDB::Result#each` multiple times, set `DuckDB::Result.use_chunk_each = true`.
+   But this behavior will be removed in the future release.
+   ```ruby
+   DuckDB::Result.use_chunk_each = true
+   result = con.query('SELECT * FROM table')
+   result.each do |record|
+     p record # <= this works fine.
+   end
+   # calling each again works.
+   result.each do |record|
+     p record # <= this works fine.
+   end
+   ```
 
 # 1.1.3.1 - 2024-11-27
 - fix to `DuckDB::Connection#query` with multiple SQL statements. Calling PreparedStatement#destroy after each statement executed.

--- a/ext/duckdb/result.c
+++ b/ext/duckdb/result.c
@@ -28,7 +28,7 @@ static VALUE duckdb_result_rows_changed(VALUE oDuckDBResult);
 static VALUE duckdb_result_columns(VALUE oDuckDBResult);
 static VALUE duckdb_result_streaming_p(VALUE oDuckDBResult);
 static VALUE destroy_data_chunk(VALUE arg);
-static VALUE duckdb_result_chunk_each(VALUE oDuckDBResult);
+static VALUE duckdb_result__chunk_each(VALUE oDuckDBResult);
 
 static VALUE duckdb_result__chunk_stream(VALUE oDuckDBResult);
 static VALUE yield_rows(VALUE arg);
@@ -194,7 +194,7 @@ static VALUE destroy_data_chunk(VALUE arg) {
 }
 
 /* :nodoc: */
-static VALUE duckdb_result_chunk_each(VALUE oDuckDBResult) {
+static VALUE duckdb_result__chunk_each(VALUE oDuckDBResult) {
 /*
 #ifdef HAVE_DUCKDB_H_GE_V1_0_0
     return duckdb_result__chunk_stream(oDuckDBResult);
@@ -881,7 +881,7 @@ void rbduckdb_init_duckdb_result(void) {
     rb_define_method(cDuckDBResult, "rows_changed", duckdb_result_rows_changed, 0);
     rb_define_method(cDuckDBResult, "columns", duckdb_result_columns, 0);
     rb_define_method(cDuckDBResult, "streaming?", duckdb_result_streaming_p, 0);
-    rb_define_method(cDuckDBResult, "chunk_each", duckdb_result_chunk_each, 0);
+    rb_define_private_method(cDuckDBResult, "_chunk_each", duckdb_result__chunk_each, 0);
     rb_define_private_method(cDuckDBResult, "_chunk_stream", duckdb_result__chunk_stream, 0);
     rb_define_private_method(cDuckDBResult, "_column_type", duckdb_result__column_type, 1);
     rb_define_private_method(cDuckDBResult, "_return_type", duckdb_result__return_type, 0);

--- a/lib/duckdb/result.rb
+++ b/lib/duckdb/result.rb
@@ -37,10 +37,6 @@ module DuckDB
 
       attr_writer :use_chunk_each
 
-      # def use_chunk_each=(value)
-      #   @use_chunk_each = value
-      # end
-
       def use_chunk_each?
         @use_chunk_each
       end

--- a/lib/duckdb/result.rb
+++ b/lib/duckdb/result.rb
@@ -28,22 +28,40 @@ module DuckDB
 
     alias column_size column_count
 
+    @use_chunk_each = false
+
     class << self
       def new
         raise DuckDB::Error, 'DuckDB::Result cannot be instantiated directly.'
       end
+
+      attr_writer :use_chunk_each
+
+      # def use_chunk_each=(value)
+      #   @use_chunk_each = value
+      # end
+
+      def use_chunk_each?
+        @use_chunk_each
+      end
     end
 
     def each(&)
-      if streaming?
-        return _chunk_stream unless block_given?
-
-        _chunk_stream(&)
-      else
+      if self.class.use_chunk_each?
         return chunk_each unless block_given?
 
         chunk_each(&)
+      else
+        return _chunk_stream unless block_given?
+
+        _chunk_stream(&)
       end
+    end
+
+    # :nodoc:
+    def chunk_each(&)
+      warn 'DuckDB::Result#chunk_each will be deprecated.'
+      _chunk_each(&)
     end
 
     # returns return type. The return value is one of the following symbols:

--- a/test/duckdb_test/result_test.rb
+++ b/test/duckdb_test/result_test.rb
@@ -33,8 +33,11 @@ module DuckDBTest
     # If using duckdb_fetch_chunk in Result#chunk_each
     # then this test will fail.
     def test_each_using_duckdb_fetch_chunk
-      ary = @result.to_a
+      DuckDB::Result.use_chunk_each = true
+      ary = @result.to_a # fetch again
       assert(ary.first, 'FAILED because of using duckdb_fetch_chunk in Result#chunk_each')
+    ensure
+      DuckDB::Result.use_chunk_each = false
     end
 
     def test_each_without_block


### PR DESCRIPTION
duckdb_chunk_each is deprecated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a configuration option that enables consistent, repeated iteration over result sets.
- **Refactor**
  - Updated the primary iteration method behavior; the previous iteration mode is now deprecated.
- **Tests**
  - Enhanced test coverage to verify the new configurable iteration functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->