### PR TITLE
DuckDB::Result#streaming? will be deprecated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ All notable changes to this project will be documented in this file.
      p record # <= this works fine.
    end
    ```
+- `DuckDB::Result#streaming?` will be deprecated.
 
 # 1.1.3.1 - 2024-11-27
 - fix to `DuckDB::Connection#query` with multiple SQL statements. Calling PreparedStatement#destroy after each statement executed.

--- a/ext/duckdb/result.c
+++ b/ext/duckdb/result.c
@@ -169,11 +169,7 @@ static VALUE duckdb_result_columns(VALUE oDuckDBResult) {
 }
 
 /*
- *  call-seq:
- *    result.streaming? -> Boolean
- *
- *  Returns true if the result is streaming, otherwise false.
- *
+ * :nodoc:
  */
 static VALUE duckdb_result_streaming_p(VALUE oDuckDBResult) {
     rubyDuckDBResult *ctx;
@@ -181,6 +177,7 @@ static VALUE duckdb_result_streaming_p(VALUE oDuckDBResult) {
 #ifdef DUCKDB_API_NO_DEPRECATED
     return Qtrue;
 #else
+    rb_warn("`DuckDB::Result#streaming?` will be deprecated in the future.");
     /* FIXME streaming is allways true. so this method is not useful and deprecated. */
     TypedData_Get_Struct(oDuckDBResult, rubyDuckDBResult, &result_data_type, ctx);
     return duckdb_result_is_streaming(ctx->result) ? Qtrue : Qfalse;


### PR DESCRIPTION
DuckDB::Result#streaming? is check the result is streaming or not. This method is used for determining either duckdb_fetch_chunk C-API or duckdb_get_chunk C-API should be called to fetch data.

Currently duckdb_get_chunk is deprecated and duckdb_fetch_chunk always should be called.

And duckdb_result_is_streaming C-API is deprecated too.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Introduced a deprecation notice for the functionality that checks result streaming, warning users of its future removal.
- **Chores**
  - Adjusted internal notifications to align with ongoing API streamlining efforts while maintaining current functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->