### PR TITLE
use ruby 3.4.2 in CI with Mac and Ubuntu, 3.4.1 in CI with Windows.

### DIFF
--- a/.github/workflows/test_on_macos.yml
+++ b/.github/workflows/test_on_macos.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        ruby: ['3.1.6', '3.2.6', '3.3.6', '3.4.1', 'head']
+        ruby: ['3.1.6', '3.2.6', '3.3.6', '3.4.2', 'head']
         duckdb: ['1.2.0', '1.1.3', '1.1.1', '1.0.0']
 
     steps:

--- a/.github/workflows/test_on_ubuntu.yml
+++ b/.github/workflows/test_on_ubuntu.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ['3.1.6', '3.2.6', '3.3.6', '3.4.1', 'head']
+        ruby: ['3.1.6', '3.2.6', '3.3.6', '3.4.2', 'head']
         duckdb: ['1.2.0', '1.1.3', '1.1.1', '1.0.0']
 
     steps:

--- a/.github/workflows/test_on_windows.yml
+++ b/.github/workflows/test_on_windows.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        ruby: ['3.1.6', '3.2.6', '3.3.6', 'ucrt', 'mingw', 'mswin', 'head']
+        ruby: ['3.1.6', '3.2.6', '3.3.6', '3.4.1', 'ucrt', 'mingw', 'mswin', 'head']
         duckdb: ['1.2.0', '1.1.3', '1.1.1', '1.0.0']
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
   `DuckDB::Appender#append_bool`, `DuckDB::Appender#append_int8`, `DuckDB::Appender#append_int16`,
   `DuckDB::Appender#append_int32`, `DuckDB::Appender#append_int64`, `DuckDB::Appender#append_uint8` failed.
 - `DuckDB::Appender#begin_row` does nothing. Only returns self. `DuckDB::Appender#end_row` is only required.
+- bump ruby in CI. use 3.4.2 on MacOS, 3.4.3 on Ubuntu, 3.4.1 on Windows.
 
 ## Breaking changes
 - `DuckDB::Result#row_count`, `DuckDB::Result#row_size` are deprecated.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ All notable changes to this project will be documented in this file.
   `DuckDB::Appender#append_bool`, `DuckDB::Appender#append_int8`, `DuckDB::Appender#append_int16`,
   `DuckDB::Appender#append_int32`, `DuckDB::Appender#append_int64`, `DuckDB::Appender#append_uint8` failed.
 - `DuckDB::Appender#begin_row` does nothing. Only returns self. `DuckDB::Appender#end_row` is only required.
-- bump ruby in CI. use 3.4.2 on MacOS, 3.4.3 on Ubuntu, 3.4.1 on Windows.
+- bump ruby in CI. use 3.4.2 on MacOS and Ubuntu, 3.4.1 on Windows.
 
 ## Breaking changes
 - `DuckDB::Result#row_count`, `DuckDB::Result#row_size` are deprecated.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the automated testing setup to use Ruby version 3.4.2 on MacOS and Ubuntu, and 3.4.1 on Windows, ensuring more stable and reliable tests.
- **Documentation**
  - Added specifications for the Ruby versions used in the Continuous Integration environment to the CHANGELOG.md.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->