### PR TITLE
prepare to release 1.2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file.
 # Unreleased
+
+# 1.2.0.0 - 2025-02-24
 - bump duckdb to 1.2.0.
 - add `DuckDB::LogicalType` class(Thanks to @otegami).
   - `DuckDB::LogicalType` class is under construction. `DuckDB::LogicalType#type`, `DuckDB::LogicalType#width`,

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,36 +1,36 @@
 PATH
   remote: .
   specs:
-    duckdb (1.1.3.1)
+    duckdb (1.2.0.0)
       bigdecimal (>= 3.1.4)
 
 GEM
   remote: https://rubygems.org/
   specs:
     benchmark-ips (2.14.0)
-    bigdecimal (3.1.8)
+    bigdecimal (3.1.9)
     mini_portile2 (2.8.8)
-    minitest (5.25.2)
-    nokogiri (1.18.0)
+    minitest (5.25.4)
+    nokogiri (1.18.3)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
-    nokogiri (1.18.0-aarch64-linux-gnu)
+    nokogiri (1.18.3-aarch64-linux-gnu)
       racc (~> 1.4)
-    nokogiri (1.18.0-arm-linux-gnu)
+    nokogiri (1.18.3-arm-linux-gnu)
       racc (~> 1.4)
-    nokogiri (1.18.0-arm64-darwin)
+    nokogiri (1.18.3-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.18.0-x86_64-darwin)
+    nokogiri (1.18.3-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.18.0-x86_64-linux-gnu)
+    nokogiri (1.18.3-x86_64-linux-gnu)
       racc (~> 1.4)
     racc (1.8.1)
     rake (13.2.1)
-    rake-compiler (1.2.8)
+    rake-compiler (1.2.9)
       rake
-    ruby_memcheck (3.0.0)
+    ruby_memcheck (3.0.1)
       nokogiri
-    stackprof (0.2.26)
+    stackprof (0.2.27)
 
 PLATFORMS
   aarch64-linux

--- a/duckdb.gemspec
+++ b/duckdb.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/suketa/ruby-duckdb'
   spec.license       = 'MIT'
 
+  spec.metadata['rubygems_mfa_required'] = 'true'
   spec.metadata['homepage_uri'] = spec.homepage
   spec.metadata['source_code_uri'] = 'https://github.com/suketa/ruby-duckdb'
   spec.metadata['changelog_uri'] = 'https://github.com/suketa/ruby-duckdb/blob/master/CHANGELOG.md'

--- a/lib/duckdb/version.rb
+++ b/lib/duckdb/version.rb
@@ -3,5 +3,5 @@
 module DuckDB
   # The version string of ruby-duckdb.
   # Currently, ruby-duckdb is NOT semantic versioning.
-  VERSION = '1.1.3.1'
+  VERSION = '1.2.0.0'
 end


### PR DESCRIPTION
- prepare to release 1.2.0.0
- set rubygems_mfa_required to `true` in duckdb.gemspec.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced enhanced type handling capabilities that expand data management options.
- **Bug Fixes**
	- Improved error reporting and consistency in data appending operations.
- **Chores**
	- Upgraded the underlying database library and updated the release version to 1.2.0.0.
	- Implemented additional security measures for gem publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->