### PR TITLE
drop duckdb v1.0.0.

### DIFF
--- a/.github/workflows/test_on_macos.yml
+++ b/.github/workflows/test_on_macos.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         ruby: ['3.1.6', '3.2.6', '3.3.6', '3.4.2', 'head']
-        duckdb: ['1.2.0', '1.1.3', '1.1.1', '1.0.0']
+        duckdb: ['1.2.0', '1.1.3', '1.1.1']
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test_on_ubuntu.yml
+++ b/.github/workflows/test_on_ubuntu.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         ruby: ['3.1.6', '3.2.6', '3.3.6', '3.4.2', 'head']
-        duckdb: ['1.2.0', '1.1.3', '1.1.1', '1.0.0']
+        duckdb: ['1.2.0', '1.1.3', '1.1.1']
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test_on_windows.yml
+++ b/.github/workflows/test_on_windows.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         ruby: ['3.1.6', '3.2.6', '3.3.6', '3.4.1', 'ucrt', 'mingw', 'mswin', 'head']
-        duckdb: ['1.2.0', '1.1.3', '1.1.1', '1.0.0']
+        duckdb: ['1.2.0', '1.1.3', '1.1.1']
 
     steps:
     - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 # Unreleased
+- drop duckdb v1.0.0.
 
 # 1.2.0.0 - 2025-02-24
 - bump duckdb to 1.2.0.

--- a/ext/duckdb/extconf.rb
+++ b/ext/duckdb/extconf.rb
@@ -2,7 +2,7 @@
 
 require 'mkmf'
 
-DUCKDB_REQUIRED_VERSION = '1.0.0'
+DUCKDB_REQUIRED_VERSION = '1.1.0'
 
 def check_duckdb_header(header, version)
   found = find_header(
@@ -56,10 +56,7 @@ end
 dir_config('duckdb')
 
 check_duckdb_header('duckdb.h', DUCKDB_REQUIRED_VERSION)
-check_duckdb_library('duckdb', 'duckdb_appender_column_count', DUCKDB_REQUIRED_VERSION)
-
-# check duckdb >= 1.0.0
-have_func('duckdb_fetch_chunk', 'duckdb.h')
+check_duckdb_library('duckdb', 'duckdb_result_error_type', DUCKDB_REQUIRED_VERSION)
 
 # check duckdb >= 1.1.0
 have_func('duckdb_result_error_type', 'duckdb.h')


### PR DESCRIPTION
drop duckdb v1.0.0 support

ruby-duckdb supports duckdb v1.1.x and v1.2.x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Refined our testing workflows to phase out support for an older DuckDB version, streamlining compatibility checks across platforms.
  - Adjusted the minimum required DuckDB version to ensure enhanced performance and reliability.

- **Documentation**
  - Updated release notes to reflect the revised DuckDB version support and compatibility improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->