### PR TITLE
remove DUCKDB_1_0_0 definition.

### DIFF
--- a/ext/duckdb/ruby-duckdb.h
+++ b/ext/duckdb/ruby-duckdb.h
@@ -8,10 +8,6 @@
 #include "ruby/thread.h"
 #include <duckdb.h>
 
-#ifdef HAVE_DUCKDB_FETCH_CHUNK
-#define HAVE_DUCKDB_H_GE_V1_0_0 1
-#endif
-
 #ifdef HAVE_DUCKDB_RESULT_ERROR_TYPE
 #define HAVE_DUCKDB_H_GE_V1_1_0 1
 #endif


### PR DESCRIPTION
We dropped duckdb v1.0.0. so we can remove definition of ruby-duckdb.h

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Streamlined internal version handling logic for enhanced compatibility, ensuring stable behavior without affecting public functionalities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->