### PR TITLE
support interfaces for Union logical type in DuckDB::LogicalType 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this project will be documented in this file.
 # Unreleased
 - drop duckdb v1.0.0.
+- add `DuckDB::LogicalType` class.
+  - `DuckDB::LogicalType` class is under construction. `DuckDB::LogicalType#member_count`,
+    `DuckDB::LogicalType#member_name_at`, and `DuckDB::LogicalType#member_type_at` are available.
 
 # 1.2.0.0 - 2025-02-24
 - bump duckdb to 1.2.0.

--- a/ext/duckdb/logical_type.c
+++ b/ext/duckdb/logical_type.c
@@ -13,6 +13,7 @@ static VALUE duckdb_logical_type_size(VALUE self);
 static VALUE duckdb_logical_type_key_type(VALUE self);
 static VALUE duckdb_logical_type_value_type(VALUE self);
 static VALUE duckdb_logical_type_member_count(VALUE self);
+static VALUE duckdb_logical_type_member_name_at(VALUE self, VALUE midx);
 
 static const rb_data_type_t logical_type_data_type = {
     "DuckDB/LogicalType",
@@ -172,6 +173,30 @@ static VALUE duckdb_logical_type_value_type(VALUE self) {
     return INT2FIX(duckdb_union_type_member_count(ctx->logical_type));
 }
 
+/*
+ *  call-seq:
+ *    union_col.logical_type.member_name_at(index) -> String
+ *
+ *  Returns the name of the union member at the specified index.
+ *
+ */
+ static VALUE duckdb_logical_type_member_name_at(VALUE self, VALUE midx) {
+    rubyDuckDBLogicalType *ctx;
+    VALUE mname;
+    const char *member_name;
+    idx_t idx = NUM2ULL(midx);
+
+    TypedData_Get_Struct(self, rubyDuckDBLogicalType, &logical_type_data_type, ctx);
+
+    member_name = duckdb_union_type_member_name(ctx->logical_type, idx);
+    if (member_name == NULL) {
+        rb_raise(eDuckDBError, "fail to get name of %llu member", (unsigned long long)idx);
+    }
+    mname = rb_str_new_cstr(member_name);
+    duckdb_free((void *)member_name);
+    return mname;
+}
+
 VALUE rbduckdb_create_logical_type(duckdb_logical_type logical_type) {
     VALUE obj;
     rubyDuckDBLogicalType *ctx;
@@ -199,4 +224,5 @@ void rbduckdb_init_duckdb_logical_type(void) {
     rb_define_method(cDuckDBLogicalType, "key_type", duckdb_logical_type_key_type, 0);
     rb_define_method(cDuckDBLogicalType, "value_type", duckdb_logical_type_value_type, 0);
     rb_define_method(cDuckDBLogicalType, "member_count", duckdb_logical_type_member_count, 0);
+    rb_define_method(cDuckDBLogicalType, "member_name_at", duckdb_logical_type_member_name_at, 1);
 }

--- a/ext/duckdb/logical_type.c
+++ b/ext/duckdb/logical_type.c
@@ -12,6 +12,7 @@ static VALUE duckdb_logical_type_child_type(VALUE self);
 static VALUE duckdb_logical_type_size(VALUE self);
 static VALUE duckdb_logical_type_key_type(VALUE self);
 static VALUE duckdb_logical_type_value_type(VALUE self);
+static VALUE duckdb_logical_type_member_count(VALUE self);
 
 static const rb_data_type_t logical_type_data_type = {
     "DuckDB/LogicalType",
@@ -158,6 +159,19 @@ static VALUE duckdb_logical_type_value_type(VALUE self) {
     return logical_type;
 }
 
+/*
+ *  call-seq:
+ *    member_col.logical_type.member_count -> Integer
+ *
+ *  Returns the member count of union type, otherwise 0.
+ *
+ */
+ static VALUE duckdb_logical_type_member_count(VALUE self) {
+    rubyDuckDBLogicalType *ctx;
+    TypedData_Get_Struct(self, rubyDuckDBLogicalType, &logical_type_data_type, ctx);
+    return INT2FIX(duckdb_union_type_member_count(ctx->logical_type));
+}
+
 VALUE rbduckdb_create_logical_type(duckdb_logical_type logical_type) {
     VALUE obj;
     rubyDuckDBLogicalType *ctx;
@@ -184,4 +198,5 @@ void rbduckdb_init_duckdb_logical_type(void) {
     rb_define_method(cDuckDBLogicalType, "size", duckdb_logical_type_size, 0);
     rb_define_method(cDuckDBLogicalType, "key_type", duckdb_logical_type_key_type, 0);
     rb_define_method(cDuckDBLogicalType, "value_type", duckdb_logical_type_value_type, 0);
+    rb_define_method(cDuckDBLogicalType, "member_count", duckdb_logical_type_member_count, 0);
 }

--- a/ext/duckdb/logical_type.c
+++ b/ext/duckdb/logical_type.c
@@ -14,6 +14,7 @@ static VALUE duckdb_logical_type_key_type(VALUE self);
 static VALUE duckdb_logical_type_value_type(VALUE self);
 static VALUE duckdb_logical_type_member_count(VALUE self);
 static VALUE duckdb_logical_type_member_name_at(VALUE self, VALUE midx);
+static VALUE duckdb_logical_type_member_type_at(VALUE self, VALUE midx);
 
 static const rb_data_type_t logical_type_data_type = {
     "DuckDB/LogicalType",
@@ -197,6 +198,31 @@ static VALUE duckdb_logical_type_value_type(VALUE self) {
     return mname;
 }
 
+/*
+ *  call-seq:
+ *    union_col.logical_type.member_type_at(index) -> DuckDB::LogicalType
+ *
+ *  Returns the logical type of the union member at the specified index as a
+ *  DuckDB::LogicalType object.
+ *
+ */
+ static VALUE duckdb_logical_type_member_type_at(VALUE self, VALUE midx) {
+    rubyDuckDBLogicalType *ctx;
+    duckdb_logical_type union_member_type;
+    idx_t idx = NUM2ULL(midx);
+
+    TypedData_Get_Struct(self, rubyDuckDBLogicalType, &logical_type_data_type, ctx);
+
+    union_member_type = duckdb_union_type_member_type(ctx->logical_type, idx);
+    if (union_member_type == NULL) {
+        rb_raise(eDuckDBError,
+                 "Failed to get the union member type at index %llu",
+                 (unsigned long long)idx);
+    }
+
+    return rbduckdb_create_logical_type(union_member_type);
+}
+
 VALUE rbduckdb_create_logical_type(duckdb_logical_type logical_type) {
     VALUE obj;
     rubyDuckDBLogicalType *ctx;
@@ -225,4 +251,5 @@ void rbduckdb_init_duckdb_logical_type(void) {
     rb_define_method(cDuckDBLogicalType, "value_type", duckdb_logical_type_value_type, 0);
     rb_define_method(cDuckDBLogicalType, "member_count", duckdb_logical_type_member_count, 0);
     rb_define_method(cDuckDBLogicalType, "member_name_at", duckdb_logical_type_member_name_at, 1);
+    rb_define_method(cDuckDBLogicalType, "member_type_at", duckdb_logical_type_member_type_at, 1);
 }

--- a/test/duckdb_test/logical_type_test.rb
+++ b/test/duckdb_test/logical_type_test.rb
@@ -189,6 +189,16 @@ module DuckDBTest
       assert_equal(["num", "str"], member_names)
     end
 
+    def test_union_member_type_at
+      union_column = @columns.find { |column| column.type == :union }
+      union_logical_type = union_column.logical_type
+      member_types = union_logical_type.member_count.times.map do |i|
+        union_logical_type.member_type_at(i)
+      end
+      assert(member_types.all? { |member_type| member_type.is_a?(DuckDB::LogicalType) })
+      assert_equal([:integer, :varchar], member_types.map(&:type))
+    end
+
     private
 
     def create_data(con)

--- a/test/duckdb_test/logical_type_test.rb
+++ b/test/duckdb_test/logical_type_test.rb
@@ -180,6 +180,15 @@ module DuckDBTest
       assert_equal(2, union_column.logical_type.member_count)
     end
 
+    def test_union_member_name_at
+      union_column = @columns.find { |column| column.type == :union }
+      union_logical_type = union_column.logical_type
+      member_names = union_logical_type.member_count.times.map do |i|
+        union_logical_type.member_name_at(i)
+      end
+      assert_equal(["num", "str"], member_names)
+    end
+
     private
 
     def create_data(con)

--- a/test/duckdb_test/logical_type_test.rb
+++ b/test/duckdb_test/logical_type_test.rb
@@ -35,7 +35,8 @@ module DuckDBTest
         varchar_list_array_col VARCHAR[2],
         struct_col STRUCT(word VARCHAR, length INTEGER),
         uuid_col UUID,
-        map_col MAP(INTEGER, VARCHAR)
+        map_col MAP(INTEGER, VARCHAR),
+        union_col UNION(num INTEGER, str VARCHAR)
       );
     SQL
 
@@ -67,7 +68,8 @@ module DuckDBTest
         [['a', 'b'], ['c', 'd']],
         ROW('Ruby', 4),
         '#{SecureRandom.uuid}',
-        MAP{1: 'foo'}
+        MAP{1: 'foo'},
+        1::INTEGER,
       )
     SQL
 
@@ -100,6 +102,7 @@ module DuckDBTest
       struct
       uuid
       map
+      union
     ].freeze
 
     def setup
@@ -170,6 +173,11 @@ module DuckDBTest
       value_type = map_column.logical_type.value_type
       assert(value_type.is_a?(DuckDB::LogicalType))
       assert_equal(:varchar, value_type.type)
+    end
+
+    def test_union_member_count
+      union_column = @columns.find { |column| column.type == :union }
+      assert_equal(2, union_column.logical_type.member_count)
     end
 
     private


### PR DESCRIPTION
refs: GH-690

In this PR, we support interfaces for Union logical type in DuckDB::Column#logical_type about the following.

- idx_t [duckdb_union_type_member_count](https://duckdb.org/docs/clients/c/api.html#duckdb_union_type_member_count)(duckdb_logical_type type);
  - Except for Union column type, this API always returns 0. 
  - https://github.com/duckdb/duckdb/blob/main/src/main/capi/logical_types-c.cpp#L291-L300
- char *[duckdb_union_type_member_name](https://duckdb.org/docs/clients/c/api.html#duckdb_union_type_member_name)(duckdb_logical_type type, idx_t index);
- duckdb_logical_type [duckdb_union_type_member_type](https://duckdb.org/docs/clients/c/api.html#duckdb_union_type_member_type)(duckdb_logical_type type, idx_t index);

This is one of the steps for supporting duckdb_logical_column_type C API.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced enhanced union-type support, allowing users to retrieve union member counts, names, and types via new interface methods.
	- Expanded SQL schema capabilities with the addition of a union column, enabling more flexible, robust data modeling.
- **Tests**
	- Added unit tests for verifying union member count, names, and types to ensure expected behavior of the new union type functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->