### PR TITLE
fix error handling of DuckDB::Append#append_uint32.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 - add `DuckDB::LogicalType` class.
   - `DuckDB::LogicalType` class is under construction. `DuckDB::LogicalType#member_count`,
     `DuckDB::LogicalType#member_name_at`, and `DuckDB::LogicalType#member_type_at` are available.
-- fix error message when `DuckDB::Appender#append_uint16`.
+- fix error message when `DuckDB::Appender#append_uint16`, `DuckDB::Appender#append_uint32`.
 
 # 1.2.0.0 - 2025-02-24
 - bump duckdb to 1.2.0.

--- a/ext/duckdb/appender.c
+++ b/ext/duckdb/appender.c
@@ -14,7 +14,7 @@ static VALUE appender__append_int32(VALUE self, VALUE val);
 static VALUE appender__append_int64(VALUE self, VALUE val);
 static VALUE appender__append_uint8(VALUE self, VALUE val);
 static VALUE appender__append_uint16(VALUE self, VALUE val);
-static VALUE appender_append_uint32(VALUE self, VALUE val);
+static VALUE appender__append_uint32(VALUE self, VALUE val);
 static VALUE appender_append_uint64(VALUE self, VALUE val);
 static VALUE appender_append_float(VALUE self, VALUE val);
 static VALUE appender_append_double(VALUE self, VALUE val);
@@ -187,16 +187,14 @@ static VALUE appender__append_uint16(VALUE self, VALUE val) {
     return  duckdb_state_to_bool_value(duckdb_append_uint16(ctx->appender, ui16val));
 }
 
-static VALUE appender_append_uint32(VALUE self, VALUE val) {
+/* :nodoc: */
+static VALUE appender__append_uint32(VALUE self, VALUE val) {
     rubyDuckDBAppender *ctx;
     uint32_t ui32val = (uint32_t)NUM2UINT(val);
 
     TypedData_Get_Struct(self, rubyDuckDBAppender, &appender_data_type, ctx);
 
-    if (duckdb_append_uint32(ctx->appender, ui32val) == DuckDBError) {
-        rb_raise(eDuckDBError, "failed to append uint32");
-    }
-    return self;
+    return  duckdb_state_to_bool_value(duckdb_append_uint32(ctx->appender, ui32val));
 }
 
 static VALUE appender_append_uint64(VALUE self, VALUE val) {
@@ -418,7 +416,6 @@ void rbduckdb_init_duckdb_appender(void) {
     rb_define_alloc_func(cDuckDBAppender, allocate);
     rb_define_method(cDuckDBAppender, "initialize", appender_initialize, 3);
     rb_define_method(cDuckDBAppender, "error_message", appender_error_message, 0);
-    rb_define_method(cDuckDBAppender, "append_uint32", appender_append_uint32, 1);
     rb_define_method(cDuckDBAppender, "append_uint64", appender_append_uint64, 1);
     rb_define_method(cDuckDBAppender, "append_float", appender_append_float, 1);
     rb_define_method(cDuckDBAppender, "append_double", appender_append_double, 1);
@@ -441,6 +438,7 @@ void rbduckdb_init_duckdb_appender(void) {
     rb_define_private_method(cDuckDBAppender, "_append_int64", appender__append_int64, 1);
     rb_define_private_method(cDuckDBAppender, "_append_uint8", appender__append_uint8, 1);
     rb_define_private_method(cDuckDBAppender, "_append_uint16", appender__append_uint16, 1);
+    rb_define_private_method(cDuckDBAppender, "_append_uint32", appender__append_uint32, 1);
     rb_define_private_method(cDuckDBAppender, "_append_date", appender__append_date, 3);
     rb_define_private_method(cDuckDBAppender, "_append_interval", appender__append_interval, 3);
     rb_define_private_method(cDuckDBAppender, "_append_time", appender__append_time, 4);

--- a/lib/duckdb/appender.rb
+++ b/lib/duckdb/appender.rb
@@ -244,6 +244,27 @@ module DuckDB
       raise_appender_error('failed to append_uint16')
     end
 
+    # call-seq:
+    #  appender.append_uint32(val) -> self
+    #
+    # Appends an uint32 value to the current row in the appender.
+    #
+    #  require 'duckdb'
+    #  db = DuckDB::Database.open
+    #  con = db.connect
+    #  con.query('CREATE TABLE users (id INTEGER, age UINTEGER)')
+    #  appender = con.appender('users')
+    #  appender
+    #  .append_int32(1)
+    #  .append_uint32(20)
+    #  .end_row
+    #  .flush
+    def append_uint32(value)
+      return self if _append_uint32(value)
+
+      raise_appender_error('failed to append_uint32')
+    end
+
     # appends huge int value.
     #
     #   require 'duckdb'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced support for appending 32-bit unsigned integer values with a streamlined public interface.
- **Bug Fixes**
  - Enhanced error messaging for unsigned integer operations to provide clearer feedback when issues occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->