### PR TITLE
fix error handling of varchar appender

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ All notable changes to this project will be documented in this file.
   - `DuckDB::LogicalType` class is under construction. `DuckDB::LogicalType#member_count`,
     `DuckDB::LogicalType#member_name_at`, and `DuckDB::LogicalType#member_type_at` are available.
 - fix error message when `DuckDB::Appender#append_uint16`, `DuckDB::Appender#append_uint32`,
-  `DuckDB::Appender#append_uint64`, `DuckDB::Appender#append_float`, `DuckDB::Appender#append_double` failed.
+  `DuckDB::Appender#append_uint64`, `DuckDB::Appender#append_float`, `DuckDB::Appender#append_double`,
+  `DuckDB::Appender#append_varchar`, `DuckDB::Appender#append_varchar_length` failed.
 
 # 1.2.0.0 - 2025-02-24
 - bump duckdb to 1.2.0.

--- a/ext/duckdb/appender.c
+++ b/ext/duckdb/appender.c
@@ -18,8 +18,8 @@ static VALUE appender__append_uint32(VALUE self, VALUE val);
 static VALUE appender__append_uint64(VALUE self, VALUE val);
 static VALUE appender__append_float(VALUE self, VALUE val);
 static VALUE appender__append_double(VALUE self, VALUE val);
-static VALUE appender_append_varchar(VALUE self, VALUE val);
-static VALUE appender_append_varchar_length(VALUE self, VALUE val, VALUE len);
+static VALUE appender__append_varchar(VALUE self, VALUE val);
+static VALUE appender__append_varchar_length(VALUE self, VALUE val, VALUE len);
 static VALUE appender_append_blob(VALUE self, VALUE val);
 static VALUE appender_append_null(VALUE self);
 
@@ -217,6 +217,7 @@ static VALUE appender__append_float(VALUE self, VALUE val) {
     return duckdb_state_to_bool_value(duckdb_append_float(ctx->appender, fval));
 }
 
+/* :nodoc: */
 static VALUE appender__append_double(VALUE self, VALUE val) {
     rubyDuckDBAppender *ctx;
     double dval = NUM2DBL(val);
@@ -226,19 +227,18 @@ static VALUE appender__append_double(VALUE self, VALUE val) {
     return duckdb_state_to_bool_value(duckdb_append_double(ctx->appender, dval));
 }
 
-static VALUE appender_append_varchar(VALUE self, VALUE val) {
+/* :nodoc: */
+static VALUE appender__append_varchar(VALUE self, VALUE val) {
     rubyDuckDBAppender *ctx;
     char *pval = StringValuePtr(val);
 
     TypedData_Get_Struct(self, rubyDuckDBAppender, &appender_data_type, ctx);
 
-    if (duckdb_append_varchar(ctx->appender, pval) == DuckDBError) {
-        rb_raise(eDuckDBError, "failed to append varchar");
-    }
-    return self;
+    return duckdb_state_to_bool_value(duckdb_append_varchar(ctx->appender, pval));
 }
 
-static VALUE appender_append_varchar_length(VALUE self, VALUE val, VALUE len) {
+/* :nodoc: */
+static VALUE appender__append_varchar_length(VALUE self, VALUE val, VALUE len) {
     rubyDuckDBAppender *ctx;
 
     char *pval = StringValuePtr(val);
@@ -246,10 +246,7 @@ static VALUE appender_append_varchar_length(VALUE self, VALUE val, VALUE len) {
 
     TypedData_Get_Struct(self, rubyDuckDBAppender, &appender_data_type, ctx);
 
-    if (duckdb_append_varchar_length(ctx->appender, pval, length) == DuckDBError) {
-        rb_raise(eDuckDBError, "failed to append varchar with length");
-    }
-    return self;
+    return duckdb_state_to_bool_value(duckdb_append_varchar_length(ctx->appender, pval, length));
 }
 
 static VALUE appender_append_blob(VALUE self, VALUE val) {
@@ -409,8 +406,6 @@ void rbduckdb_init_duckdb_appender(void) {
     rb_define_alloc_func(cDuckDBAppender, allocate);
     rb_define_method(cDuckDBAppender, "initialize", appender_initialize, 3);
     rb_define_method(cDuckDBAppender, "error_message", appender_error_message, 0);
-    rb_define_method(cDuckDBAppender, "append_varchar", appender_append_varchar, 1);
-    rb_define_method(cDuckDBAppender, "append_varchar_length", appender_append_varchar_length, 2);
     rb_define_method(cDuckDBAppender, "append_blob", appender_append_blob, 1);
     rb_define_method(cDuckDBAppender, "append_null", appender_append_null, 0);
 
@@ -432,6 +427,8 @@ void rbduckdb_init_duckdb_appender(void) {
     rb_define_private_method(cDuckDBAppender, "_append_uint64", appender__append_uint64, 1);
     rb_define_private_method(cDuckDBAppender, "_append_float", appender__append_float, 1);
     rb_define_private_method(cDuckDBAppender, "_append_double", appender__append_double, 1);
+    rb_define_private_method(cDuckDBAppender, "_append_varchar", appender__append_varchar, 1);
+    rb_define_private_method(cDuckDBAppender, "_append_varchar_length", appender__append_varchar_length, 2);
     rb_define_private_method(cDuckDBAppender, "_append_date", appender__append_date, 3);
     rb_define_private_method(cDuckDBAppender, "_append_interval", appender__append_interval, 3);
     rb_define_private_method(cDuckDBAppender, "_append_time", appender__append_time, 4);

--- a/lib/duckdb/appender.rb
+++ b/lib/duckdb/appender.rb
@@ -326,6 +326,46 @@ module DuckDB
       raise_appender_error('failed to append_double')
     end
 
+    # call-seq:
+    #   appender.append_varchar(val) -> self
+    #
+    # Appends a varchar value to the current row in the appender.
+    #
+    #   require 'duckdb'
+    #   db = DuckDB::Database.open
+    #   con = db.connect
+    #   con.query('CREATE TABLE names (name VARCHAR)')
+    #   appender = con.appender('names')
+    #   appender
+    #     .append_varchar('Alice')
+    #     .end_row
+    #     .flush
+    def append_varchar(value)
+      return self if _append_varchar(value)
+
+      raise_appender_error('failed to append_varchar')
+    end
+
+    # call-seq:
+    #   appender.append_varchar_length(val, len) -> self
+    #
+    # Appends a varchar value to the current row in the appender.
+    #
+    #   require 'duckdb'
+    #   db = DuckDB::Database.open
+    #   con = db.connect
+    #   con.query('CREATE TABLE names (name VARCHAR)')
+    #   appender = con.appender('names')
+    #   appender
+    #     .append_varchar_length('Alice', 5)
+    #     .end_row
+    #     .flush
+    def append_varchar_length(value, length)
+      return self if _append_varchar_length(value, length)
+
+      raise_appender_error('failed to append_varchar_length')
+    end
+
     # appends huge int value.
     #
     #   require 'duckdb'


### PR DESCRIPTION
- DuckDB::Appeder#append_varchar,
- DuckDB::Append#append_varchar_length.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced enhanced support for appending text-based data with two new methods that improve error feedback for variable-length text operations.

- **Documentation**
  - Updated public documentation with detailed usage examples and revised error messaging guidelines to assist with the new text appending functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->