### PR TITLE
remove HAVE_DUCKDB_H_GE_V1_1_0

### DIFF
--- a/ext/duckdb/appender.c
+++ b/ext/duckdb/appender.c
@@ -23,9 +23,7 @@ static VALUE appender__append_varchar_length(VALUE self, VALUE val, VALUE len);
 static VALUE appender__append_blob(VALUE self, VALUE val);
 static VALUE appender__append_null(VALUE self);
 
-#ifdef HAVE_DUCKDB_H_GE_V1_1_0
 static VALUE appender_append_default(VALUE self);
-#endif
 
 static VALUE appender__end_row(VALUE self);
 static VALUE appender__append_date(VALUE self, VALUE yearval, VALUE monthval, VALUE dayval);
@@ -269,7 +267,7 @@ static VALUE appender__append_null(VALUE self) {
     return duckdb_state_to_bool_value(duckdb_append_null(ctx->appender));
 }
 
-#ifdef HAVE_DUCKDB_H_GE_V1_1_0
+/* :nodoc: */
 static VALUE appender_append_default(VALUE self) {
     rubyDuckDBAppender *ctx;
     TypedData_Get_Struct(self, rubyDuckDBAppender, &appender_data_type, ctx);
@@ -279,7 +277,6 @@ static VALUE appender_append_default(VALUE self) {
     }
     return self;
 }
-#endif
 
 /* :nodoc: */
 static VALUE appender__append_date(VALUE self, VALUE year, VALUE month, VALUE day) {
@@ -402,11 +399,7 @@ void rbduckdb_init_duckdb_appender(void) {
     rb_define_alloc_func(cDuckDBAppender, allocate);
     rb_define_method(cDuckDBAppender, "initialize", appender_initialize, 3);
     rb_define_method(cDuckDBAppender, "error_message", appender_error_message, 0);
-
-#ifdef HAVE_DUCKDB_H_GE_V1_1_0
     rb_define_method(cDuckDBAppender, "append_default", appender_append_default, 0);
-#endif
-
     rb_define_private_method(cDuckDBAppender, "_end_row", appender__end_row, 0);
     rb_define_private_method(cDuckDBAppender, "_flush", appender__flush, 0);
     rb_define_private_method(cDuckDBAppender, "_close", appender__close, 0);

--- a/ext/duckdb/result.c
+++ b/ext/duckdb/result.c
@@ -279,7 +279,7 @@ static VALUE duckdb_result__return_type(VALUE oDuckDBResult) {
 /*
  * remove this #if ... #else statement when dropping duckdb 1.1.0.
  */
-#if !defined(HAVE_DUCKDB_H_GE_V1_1_1) && defined(HAVE_DUCKDB_H_GE_V1_1_0) && defined(DUCKDB_API_NO_DEPRECATED)
+#if !defined(HAVE_DUCKDB_H_GE_V1_1_1) && defined(DUCKDB_API_NO_DEPRECATED)
     rb_raise(eDuckDBError, "duckdb_result_return_type C-API is not available with duckdb v1.1.0 with enabled DUCKDB_API_NO_DEPRECATED.");
 #else
     return INT2FIX(duckdb_result_return_type(ctx->result));

--- a/ext/duckdb/ruby-duckdb.h
+++ b/ext/duckdb/ruby-duckdb.h
@@ -8,10 +8,6 @@
 #include "ruby/thread.h"
 #include <duckdb.h>
 
-#ifdef HAVE_DUCKDB_RESULT_ERROR_TYPE
-#define HAVE_DUCKDB_H_GE_V1_1_0 1
-#endif
-
 #ifdef HAVE_CONST_DUCKDB_TYPE_SQLNULL
 #define HAVE_DUCKDB_H_GE_V1_1_1 1
 #endif


### PR DESCRIPTION
current ruby-duckdb requires duckdb >= 1.1.0.
So, we can remove HAVE_DUCKDB_H_GE_V1_1_0 definition.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Streamlined internal database operations by removing outdated version checks and refining error handling. These improvements ensure a more consistent and reliable experience when interacting with database-driven features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->