### PR TITLE
fix error handling of DuckDB::Appender#append_default.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to this project will be documented in this file.
 - fix error message when `DuckDB::Appender#append_uint16`, `DuckDB::Appender#append_uint32`,
   `DuckDB::Appender#append_uint64`, `DuckDB::Appender#append_float`, `DuckDB::Appender#append_double`,
   `DuckDB::Appender#append_varchar`, `DuckDB::Appender#append_varchar_length`,
-  `DuckDB::Appender#append_blob`, `DuckDB::Appender#append_null` failed.
+  `DuckDB::Appender#append_blob`, `DuckDB::Appender#append_null`, `DuckDB::Appender#append_default` failed.
 
 # 1.2.0.0 - 2025-02-24
 - bump duckdb to 1.2.0.

--- a/ext/duckdb/appender.c
+++ b/ext/duckdb/appender.c
@@ -22,9 +22,7 @@ static VALUE appender__append_varchar(VALUE self, VALUE val);
 static VALUE appender__append_varchar_length(VALUE self, VALUE val, VALUE len);
 static VALUE appender__append_blob(VALUE self, VALUE val);
 static VALUE appender__append_null(VALUE self);
-
-static VALUE appender_append_default(VALUE self);
-
+static VALUE appender__append_default(VALUE self);
 static VALUE appender__end_row(VALUE self);
 static VALUE appender__append_date(VALUE self, VALUE yearval, VALUE monthval, VALUE dayval);
 static VALUE appender__append_interval(VALUE self, VALUE months, VALUE days, VALUE micros);
@@ -268,14 +266,11 @@ static VALUE appender__append_null(VALUE self) {
 }
 
 /* :nodoc: */
-static VALUE appender_append_default(VALUE self) {
+static VALUE appender__append_default(VALUE self) {
     rubyDuckDBAppender *ctx;
     TypedData_Get_Struct(self, rubyDuckDBAppender, &appender_data_type, ctx);
 
-    if (duckdb_append_default(ctx->appender) == DuckDBError) {
-        rb_raise(eDuckDBError, "failed to append default");
-    }
-    return self;
+    return duckdb_state_to_bool_value(duckdb_append_default(ctx->appender));
 }
 
 /* :nodoc: */
@@ -399,7 +394,6 @@ void rbduckdb_init_duckdb_appender(void) {
     rb_define_alloc_func(cDuckDBAppender, allocate);
     rb_define_method(cDuckDBAppender, "initialize", appender_initialize, 3);
     rb_define_method(cDuckDBAppender, "error_message", appender_error_message, 0);
-    rb_define_method(cDuckDBAppender, "append_default", appender_append_default, 0);
     rb_define_private_method(cDuckDBAppender, "_end_row", appender__end_row, 0);
     rb_define_private_method(cDuckDBAppender, "_flush", appender__flush, 0);
     rb_define_private_method(cDuckDBAppender, "_close", appender__close, 0);
@@ -418,6 +412,7 @@ void rbduckdb_init_duckdb_appender(void) {
     rb_define_private_method(cDuckDBAppender, "_append_varchar_length", appender__append_varchar_length, 2);
     rb_define_private_method(cDuckDBAppender, "_append_blob", appender__append_blob, 1);
     rb_define_private_method(cDuckDBAppender, "_append_null", appender__append_null, 0);
+    rb_define_private_method(cDuckDBAppender, "_append_default", appender__append_default, 0);
     rb_define_private_method(cDuckDBAppender, "_append_date", appender__append_date, 3);
     rb_define_private_method(cDuckDBAppender, "_append_interval", appender__append_interval, 3);
     rb_define_private_method(cDuckDBAppender, "_append_time", appender__append_time, 4);

--- a/lib/duckdb/appender.rb
+++ b/lib/duckdb/appender.rb
@@ -406,6 +406,28 @@ module DuckDB
       raise_appender_error('failed to append_null')
     end
 
+    # call-seq:
+    #   appender.append_default -> self
+    #
+    # Appends a default value to the current row in the appender.
+    # If the column does not have a default value, this method
+    # appends a NULL value.
+    #
+    #   require 'duckdb'
+    #   db = DuckDB::Database.open
+    #   con = db.connect
+    #   con.query('CREATE TABLE values (value INTEGER DEFAULT 1)')
+    #   appender = con.appender('values')
+    #   appender
+    #     .append_default
+    #     .end_row
+    #     .flush
+    def append_default
+      return self if _append_default
+
+      raise_appender_error('failed to append_default')
+    end
+
     # appends huge int value.
     #
     #   require 'duckdb'

--- a/test/duckdb_test/appender_test.rb
+++ b/test/duckdb_test/appender_test.rb
@@ -259,27 +259,11 @@ module DuckDBTest
     end
 
     def test_append_default_without_default
-      if DuckDB::Appender.instance_methods.include?(:append_default)
-        assert_duckdb_appender(nil, 'VARCHAR', &:append_default)
-      else
-        if Gem::Version.new(DuckDB::VERSION) >= Gem::Version.new('1.3.0')
-          raise "#{__method__} must be enabled. Please check the ##{__FILE__}:##{__method__} method."
-        end
-
-        skip('DuckDB::Appender#append_default is not available')
-      end
+      assert_duckdb_appender(nil, 'VARCHAR', &:append_default)
     end
 
     def test_append_default_with_default
-      if DuckDB::Appender.instance_methods.include?(:append_default)
-        assert_duckdb_appender('foobar', "VARCHAR DEFAULT 'foobar'", &:append_default)
-      else
-        if Gem::Version.new(DuckDB::VERSION) >= Gem::Version.new('1.3.0')
-          raise "#{__method__} must be enabled. Please check the ##{__FILE__}:##{__method__} method."
-        end
-
-        skip('DuckDB::Appender#append_default is not available')
-      end
+      assert_duckdb_appender('foobar', "VARCHAR DEFAULT 'foobar'", &:append_default)
     end
 
     def test_append_interval


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a method to append default values when inserting data; if no default exists, a NULL value is used.
  
- **Bug Fixes**
  - Enhanced error messaging for default value appending, providing clearer feedback when issues occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->