### PR TITLE
fix DuckDB::Appender#append_interval document.

### DIFF
--- a/lib/duckdb/appender.rb
+++ b/lib/duckdb/appender.rb
@@ -519,9 +519,11 @@ module DuckDB
       _append_timestamp(time.year, time.month, time.day, time.hour, time.min, time.sec, time.nsec / 1000)
     end
 
-    # appends interval.
+    # call-seq:
+    #   appender.append_interval(val) -> self
+    #
+    # Appends an interval value to the current row in the appender.
     # The argument must be ISO8601 duration format.
-    # WARNING: This method is expremental.
     #
     #   require 'duckdb'
     #   db = DuckDB::Database.open


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Enhanced the clarity of the interval appending feature’s documentation, detailing its usage and the required ISO8601 duration format.
  - Removed the previous experimental status note to provide a more streamlined and user-friendly guide for this functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->