### PR TITLE
fix handling error of DuckDB::Appender time methods.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ All notable changes to this project will be documented in this file.
   `DuckDB::Appender#append_uint64`, `DuckDB::Appender#append_float`, `DuckDB::Appender#append_double`,
   `DuckDB::Appender#append_varchar`, `DuckDB::Appender#append_varchar_length`,
   `DuckDB::Appender#append_blob`, `DuckDB::Appender#append_null`, `DuckDB::Appender#append_default`,
-  `DuckDB::Appender#append_date`, `DuckDB::Appender#append_interval` failed.
+  `DuckDB::Appender#append_date`, `DuckDB::Appender#append_interval`, `DuckDB::Appender#append_time`,
+  `DuckDB::Appender#append_timestamp` failed.
 
 # 1.2.0.0 - 2025-02-24
 - bump duckdb to 1.2.0.

--- a/ext/duckdb/appender.c
+++ b/ext/duckdb/appender.c
@@ -303,10 +303,7 @@ static VALUE appender__append_time(VALUE self, VALUE hour, VALUE min, VALUE sec,
     TypedData_Get_Struct(self, rubyDuckDBAppender, &appender_data_type, ctx);
     time = rbduckdb_to_duckdb_time_from_value(hour, min, sec, micros);
 
-    if (duckdb_append_time(ctx->appender, time) == DuckDBError) {
-        rb_raise(eDuckDBError, "failed to append time");
-    }
-    return self;
+    return duckdb_state_to_bool_value(duckdb_append_time(ctx->appender, time));
 }
 
 /* :nodoc: */
@@ -319,10 +316,7 @@ static VALUE appender__append_timestamp(VALUE self, VALUE year, VALUE month, VAL
 
     timestamp = rbduckdb_to_duckdb_timestamp_from_value(year, month, day, hour, min, sec, micros);
 
-    if (duckdb_append_timestamp(ctx->appender, timestamp) == DuckDBError) {
-        rb_raise(eDuckDBError, "failed to append timestamp");
-    }
-    return self;
+    return duckdb_state_to_bool_value(duckdb_append_timestamp(ctx->appender, timestamp));
 }
 
 /* :nodoc: */

--- a/lib/duckdb/appender.rb
+++ b/lib/duckdb/appender.rb
@@ -482,7 +482,10 @@ module DuckDB
       raise_appender_error('failed to append_date')
     end
 
-    # appends time value.
+    # call-seq:
+    #   appender.append_time(val) -> self
+    #
+    # Appends a time value to the current row in the appender.
     #
     #   require 'duckdb'
     #   db = DuckDB::Database.open
@@ -497,10 +500,15 @@ module DuckDB
     def append_time(value)
       time = _parse_time(value)
 
-      _append_time(time.hour, time.min, time.sec, time.usec)
+      return self if _append_time(time.hour, time.min, time.sec, time.usec)
+
+      raise_appender_error('failed to append_time')
     end
 
-    # appends timestamp value.
+    # call-seq:
+    #   appender.append_timestamp(val) -> self
+    #
+    # Appends a timestamp value to the current row in the appender.
     #
     #   require 'duckdb'
     #   db = DuckDB::Database.open
@@ -516,7 +524,9 @@ module DuckDB
     def append_timestamp(value)
       time = to_time(value)
 
-      _append_timestamp(time.year, time.month, time.day, time.hour, time.min, time.sec, time.nsec / 1000)
+      return self if _append_timestamp(time.year, time.month, time.day, time.hour, time.min, time.sec, time.nsec / 1000)
+
+      raise_appender_error('failed to append_timestamp')
     end
 
     # call-seq:


### PR DESCRIPTION
fix handling error of the following instance mathods of DuckDB::Appender.
- append_time
- append_timestamp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Enhanced error messages now provide clearer feedback for failures involving time and timestamp data.
  - Updated method descriptions clarify expected outcomes, ensuring users understand the behavior on both success and failure.

- **Refactor**
  - Streamlined error handling for time and timestamp operations, resulting in consistent success or failure indications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->