### PR TITLE
fix error handling of DuckDB::Appender append hugeint methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to this project will be documented in this file.
   `DuckDB::Appender#append_varchar`, `DuckDB::Appender#append_varchar_length`,
   `DuckDB::Appender#append_blob`, `DuckDB::Appender#append_null`, `DuckDB::Appender#append_default`,
   `DuckDB::Appender#append_date`, `DuckDB::Appender#append_interval`, `DuckDB::Appender#append_time`,
-  `DuckDB::Appender#append_timestamp` failed.
+  `DuckDB::Appender#append_timestamp`, `DuckDB::Appender#append_hugeint` failed.
 
 # 1.2.0.0 - 2025-02-24
 - bump duckdb to 1.2.0.

--- a/ext/duckdb/appender.c
+++ b/ext/duckdb/appender.c
@@ -329,10 +329,8 @@ static VALUE appender__append_hugeint(VALUE self, VALUE lower, VALUE upper) {
     rubyDuckDBAppender *ctx;
 
     TypedData_Get_Struct(self, rubyDuckDBAppender, &appender_data_type, ctx);
-    if (duckdb_append_hugeint(ctx->appender, hugeint) == DuckDBError) {
-        rb_raise(eDuckDBError, "failed to append hugeint");
-    }
-    return self;
+
+    return duckdb_state_to_bool_value(duckdb_append_hugeint(ctx->appender, hugeint));
 }
 
 /* :nodoc: */
@@ -345,10 +343,8 @@ static VALUE appender__append_uhugeint(VALUE self, VALUE lower, VALUE upper) {
     rubyDuckDBAppender *ctx;
 
     TypedData_Get_Struct(self, rubyDuckDBAppender, &appender_data_type, ctx);
-    if (duckdb_append_uhugeint(ctx->appender, uhugeint) == DuckDBError) {
-        rb_raise(eDuckDBError, "failed to append uhugeint");
-    }
-    return self;
+
+    return duckdb_state_to_bool_value(duckdb_append_uhugeint(ctx->appender, uhugeint));
 }
 
 /* :nodoc: */

--- a/lib/duckdb/appender.rb
+++ b/lib/duckdb/appender.rb
@@ -428,7 +428,10 @@ module DuckDB
       raise_appender_error('failed to append_default')
     end
 
-    # appends huge int value.
+    # call-seq:
+    #   appender.append_hugeint(val) -> self
+    #
+    # Appends a huge int value to the current row in the appender.
     #
     #   require 'duckdb'
     #   db = DuckDB::Database.open
@@ -438,12 +441,19 @@ module DuckDB
     #   appender
     #     .append_hugeint(-170_141_183_460_469_231_731_687_303_715_884_105_727)
     #     .end_row
+    #     .flush
     def append_hugeint(value)
       lower, upper = integer_to_hugeint(value)
-      _append_hugeint(lower, upper)
+
+      return self if _append_hugeint(lower, upper)
+
+      raise_appender_error('failed to append_hugeint')
     end
 
-    # appends unsigned huge int value.
+    # call-seq:
+    #   appender.append_uhugeint(val) -> self
+    #
+    # Appends an unsigned huge int value to the current row in the appender.
     #
     #   require 'duckdb'
     #   db = DuckDB::Database.open
@@ -453,9 +463,13 @@ module DuckDB
     #   appender
     #     .append_hugeint(340_282_366_920_938_463_463_374_607_431_768_211_455)
     #     .end_row
+    #     .flush
     def append_uhugeint(value)
       lower, upper = integer_to_hugeint(value)
-      _append_uhugeint(lower, upper)
+
+      return self if _append_uhugeint(lower, upper)
+
+      raise_appender_error('failed to append_uhugeint')
     end
 
     # call-seq:


### PR DESCRIPTION
fix error handling of the following methods.
- DuckDB::Appender#append_hugeint
- DuckDB::Appender#append_uhugeint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated error messaging to accurately report failures during value appending.

- **Documentation**
  - Enhanced descriptions to clarify expected behavior and return values.

- **Refactor**
  - Streamlined error handling for more direct and consistent operation outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->