### PR TITLE
add `DuckDB::LogicalType#each_member_name`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ All notable changes to this project will be documented in this file.
 - drop duckdb v1.0.0.
 - add `DuckDB::LogicalType` class.
   - `DuckDB::LogicalType` class is under construction. `DuckDB::LogicalType#member_count`,
-    `DuckDB::LogicalType#member_name_at`, and `DuckDB::LogicalType#member_type_at` are available.
+    `DuckDB::LogicalType#member_name_at`, `DuckDB::LogicalType#member_type_at`, and
+    `DuckDB::LogicalType#each_member_name` are available.
 - fix error message when `DuckDB::Appender#append_uint16`, `DuckDB::Appender#append_uint32`,
   `DuckDB::Appender#append_uint64`, `DuckDB::Appender#append_float`, `DuckDB::Appender#append_double`,
   `DuckDB::Appender#append_varchar`, `DuckDB::Appender#append_varchar_length`,

--- a/lib/duckdb/logical_type.rb
+++ b/lib/duckdb/logical_type.rb
@@ -18,5 +18,27 @@ module DuckDB
       type_id = _type
       DuckDB::Converter::IntToSym.type_to_sym(type_id)
     end
+
+    # Iterates over each union member name.
+    #
+    # When a block is provided, this method yields each union member name in
+    # order. It also returns the total number of members yielded.
+    #
+    #   union_logical_type.each_member_name do |name|
+    #     puts "Union member: #{name}"
+    #   end
+    #
+    # If no block is given, an Enumerator is returned, which can be used to
+    # retrieve all member names.
+    #
+    #   names = union_logical_type.each_member_name.to_a
+    #   # => ["member1", "member2"]
+    def each_member_name
+      return to_enum(__method__) {member_count} unless block_given?
+
+      member_count.times do |i|
+        yield member_name_at(i)
+      end
+    end
   end
 end

--- a/test/duckdb_test/logical_type_test.rb
+++ b/test/duckdb_test/logical_type_test.rb
@@ -180,12 +180,10 @@ module DuckDBTest
       assert_equal(2, union_column.logical_type.member_count)
     end
 
-    def test_union_member_name_at
+    def test_union_each_member_name
       union_column = @columns.find { |column| column.type == :union }
       union_logical_type = union_column.logical_type
-      member_names = union_logical_type.member_count.times.map do |i|
-        union_logical_type.member_name_at(i)
-      end
+      member_names = union_logical_type.each_member_name.to_a
       assert_equal(["num", "str"], member_names)
     end
 


### PR DESCRIPTION
refs: GH-690

This change adds `DuckDB::LogicalType#each_member_name` to simplify iterating over union member names.
Previously, users had to manually loop through `member_count` and call `member_name_at` repeatedly.

Now, they can call `each_member_name` with or without a block:
- With a block, the method yields each member name.
- Without a block, it returns an Enumerator for further processing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enabled streamlined iteration over union member names, allowing users to retrieve each member dynamically with flexible iteration support.
- **Tests**
	- Updated test cases to confirm the correct retrieval of union member names using the new iteration method.
- **Documentation**
	- Added detailed documentation for the new `each_member_name` method, including usage examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->