### PR TITLE
bump duckdb to 1.2.1 on CI

### DIFF
--- a/.github/workflows/test_on_macos.yml
+++ b/.github/workflows/test_on_macos.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         ruby: ['3.1.6', '3.2.6', '3.3.6', '3.4.2', 'head']
-        duckdb: ['1.2.0', '1.1.3', '1.1.1']
+        duckdb: ['1.2.1', '1.1.3', '1.1.1']
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test_on_ubuntu.yml
+++ b/.github/workflows/test_on_ubuntu.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         ruby: ['3.1.6', '3.2.6', '3.3.6', '3.4.2', 'head']
-        duckdb: ['1.2.0', '1.1.3', '1.1.1']
+        duckdb: ['1.2.1', '1.1.3', '1.1.1']
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test_on_windows.yml
+++ b/.github/workflows/test_on_windows.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         ruby: ['3.1.6', '3.2.6', '3.3.6', '3.4.1', 'ucrt', 'mingw', 'mswin', 'head']
-        duckdb: ['1.2.0', '1.1.3', '1.1.1']
+        duckdb: ['1.2.1', '1.1.3', '1.1.1']
 
     steps:
     - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 # Unreleased
+- bump duckdb v1.2.1 on CI.
 - drop duckdb v1.0.0.
 - add `DuckDB::LogicalType` class.
   - `DuckDB::LogicalType` class is under construction. `DuckDB::LogicalType#member_count`,


### PR DESCRIPTION
use duckdb v1.2.1 on CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Upgraded the database dependency version in the testing configurations across multiple platforms.
- **Documentation**
  - Updated the changelog to reflect the dependency version bump.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->