### PR TITLE
add `DuckDB::LogicalType#each_member_type`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ All notable changes to this project will be documented in this file.
 - drop duckdb v1.0.0.
 - add `DuckDB::LogicalType` class.
   - `DuckDB::LogicalType` class is under construction. `DuckDB::LogicalType#member_count`,
-    `DuckDB::LogicalType#member_name_at`, `DuckDB::LogicalType#member_type_at`, and
-    `DuckDB::LogicalType#each_member_name` are available.
+    `DuckDB::LogicalType#member_name_at`, `DuckDB::LogicalType#member_type_at`,
+    `DuckDB::LogicalType#each_member_name`, and `DuckDB::LogicalType#each_member_type` are available.
 - fix error message when `DuckDB::Appender#append_uint16`, `DuckDB::Appender#append_uint32`,
   `DuckDB::Appender#append_uint64`, `DuckDB::Appender#append_float`, `DuckDB::Appender#append_double`,
   `DuckDB::Appender#append_varchar`, `DuckDB::Appender#append_varchar_length`,

--- a/lib/duckdb/logical_type.rb
+++ b/lib/duckdb/logical_type.rb
@@ -40,5 +40,27 @@ module DuckDB
         yield member_name_at(i)
       end
     end
+
+    # Iterates over each union member type.
+    #
+    # When a block is provided, this method yields each union member logical
+    # type in order. It also returns the total number of members yielded.
+    #
+    #   union_logical_type.each_member_type do |logical_type|
+    #     puts "Union member: #{logical_type.type}"
+    #   end
+    #
+    # If no block is given, an Enumerator is returned, which can be used to
+    # retrieve all member logical types.
+    #
+    #   names = union_logical_type.each_member_type.map(&:type)
+    #   # => [:varchar, :integer]
+    def each_member_type
+      return to_enum(__method__) {member_count} unless block_given?
+
+      member_count.times do |i|
+        yield member_type_at(i)
+      end
+    end
   end
 end

--- a/test/duckdb_test/logical_type_test.rb
+++ b/test/duckdb_test/logical_type_test.rb
@@ -187,12 +187,10 @@ module DuckDBTest
       assert_equal(["num", "str"], member_names)
     end
 
-    def test_union_member_type_at
+    def test_union_each_member_type
       union_column = @columns.find { |column| column.type == :union }
       union_logical_type = union_column.logical_type
-      member_types = union_logical_type.member_count.times.map do |i|
-        union_logical_type.member_type_at(i)
-      end
+      member_types = union_logical_type.each_member_type.to_a
       assert(member_types.all? { |member_type| member_type.is_a?(DuckDB::LogicalType) })
       assert_equal([:integer, :varchar], member_types.map(&:type))
     end


### PR DESCRIPTION
refs: GH-690

This change adds `DuckDB::LogicalType#each_member_type` to simplify iterating over union member types.
Previously, users had to manually loop through `member_count` and call `member_type_at` repeatedly.

Now, they can call `each_member_type` with or without a block:
- With a block, the method yields each member type.
- Without a block, it returns an Enumerator for further processing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an enhanced way to iterate over union member types, streamlining the processing of union structures.

- **Tests**
  - Updated tests to validate and ensure the reliability of the improved union member type iteration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->