### PR TITLE
support interfaces for Struct type in DuckDB::LogicalType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ All notable changes to this project will be documented in this file.
 - add `DuckDB::LogicalType` class.
   - `DuckDB::LogicalType` class is under construction. `DuckDB::LogicalType#member_count`,
     `DuckDB::LogicalType#member_name_at`, `DuckDB::LogicalType#member_type_at`,
-    `DuckDB::LogicalType#each_member_name`, and `DuckDB::LogicalType#each_member_type` are available.
+    `DuckDB::LogicalType#each_member_name`, `DuckDB::LogicalType#each_member_type`,
+    `DuckDB::LogicalType#child_count`, `DuckDB::LogicalType#child_name_at`,
+    `DuckDB::LogicalType#child_type_at`, `DuckDB::LogicalType#each_child_name`, and
+    `DuckDB::LogicalType#each_child_type` are available.
 - fix error message when `DuckDB::Appender#append_uint16`, `DuckDB::Appender#append_uint32`,
   `DuckDB::Appender#append_uint64`, `DuckDB::Appender#append_float`, `DuckDB::Appender#append_double`,
   `DuckDB::Appender#append_varchar`, `DuckDB::Appender#append_varchar_length`,

--- a/ext/duckdb/logical_type.c
+++ b/ext/duckdb/logical_type.c
@@ -11,6 +11,7 @@ static VALUE duckdb_logical_type_scale(VALUE self);
 static VALUE duckdb_logical_type_child_count(VALUE self);
 static VALUE duckdb_logical_type_child_name_at(VALUE self, VALUE cidx);
 static VALUE duckdb_logical_type_child_type(VALUE self);
+static VALUE duckdb_logical_type_child_type_at(VALUE self, VALUE cidx);
 static VALUE duckdb_logical_type_size(VALUE self);
 static VALUE duckdb_logical_type_key_type(VALUE self);
 static VALUE duckdb_logical_type_value_type(VALUE self);
@@ -153,6 +154,31 @@ static VALUE duckdb_logical_type_child_type(VALUE self) {
 
 /*
  *  call-seq:
+ *    struct_col.logical_type.child_type_at(index) -> DuckDB::LogicalType
+ *
+ *  Returns the child logical type for struct types at the specified index as a
+ *  DuckDB::LogicalType object.
+ *
+ */
+static VALUE duckdb_logical_type_child_type_at(VALUE self, VALUE cidx) {
+    rubyDuckDBLogicalType *ctx;
+    duckdb_logical_type struct_child_type;
+    idx_t idx = NUM2ULL(cidx);
+
+    TypedData_Get_Struct(self, rubyDuckDBLogicalType, &logical_type_data_type, ctx);
+
+    struct_child_type = duckdb_struct_type_child_type(ctx->logical_type, idx);
+    if (struct_child_type == NULL) {
+        rb_raise(eDuckDBError,
+                 "Failed to get the struct child type at index %llu",
+                 (unsigned long long)idx);
+    }
+
+    return rbduckdb_create_logical_type(struct_child_type);
+}
+
+/*
+ *  call-seq:
  *    list_col.logical_type.size -> Integer
  *
  *  Returns the size of the array column, otherwise 0.
@@ -287,6 +313,7 @@ void rbduckdb_init_duckdb_logical_type(void) {
     rb_define_method(cDuckDBLogicalType, "child_count", duckdb_logical_type_child_count, 0);
     rb_define_method(cDuckDBLogicalType, "child_name_at", duckdb_logical_type_child_name_at, 1);
     rb_define_method(cDuckDBLogicalType, "child_type", duckdb_logical_type_child_type, 0);
+    rb_define_method(cDuckDBLogicalType, "child_type_at", duckdb_logical_type_child_type_at, 1);
     rb_define_method(cDuckDBLogicalType, "size", duckdb_logical_type_size, 0);
     rb_define_method(cDuckDBLogicalType, "key_type", duckdb_logical_type_key_type, 0);
     rb_define_method(cDuckDBLogicalType, "value_type", duckdb_logical_type_value_type, 0);

--- a/ext/duckdb/logical_type.c
+++ b/ext/duckdb/logical_type.c
@@ -9,6 +9,7 @@ static VALUE duckdb_logical_type__type(VALUE self);
 static VALUE duckdb_logical_type_width(VALUE self);
 static VALUE duckdb_logical_type_scale(VALUE self);
 static VALUE duckdb_logical_type_child_count(VALUE self);
+static VALUE duckdb_logical_type_child_name_at(VALUE self, VALUE cidx);
 static VALUE duckdb_logical_type_child_type(VALUE self);
 static VALUE duckdb_logical_type_size(VALUE self);
 static VALUE duckdb_logical_type_key_type(VALUE self);
@@ -92,6 +93,30 @@ static VALUE duckdb_logical_type_child_count(VALUE self) {
     rubyDuckDBLogicalType *ctx;
     TypedData_Get_Struct(self, rubyDuckDBLogicalType, &logical_type_data_type, ctx);
     return INT2FIX(duckdb_struct_type_child_count(ctx->logical_type));
+}
+
+/*
+ *  call-seq:
+ *    struct_col.logical_type.child_name(index) -> String
+ *
+ *  Returns the name of the struct child at the specified index.
+ *
+ */
+static VALUE duckdb_logical_type_child_name_at(VALUE self, VALUE cidx) {
+    rubyDuckDBLogicalType *ctx;
+    VALUE cname;
+    const char *child_name;
+    idx_t idx = NUM2ULL(cidx);
+
+    TypedData_Get_Struct(self, rubyDuckDBLogicalType, &logical_type_data_type, ctx);
+
+    child_name = duckdb_struct_type_child_name(ctx->logical_type, idx);
+    if (child_name == NULL) {
+        rb_raise(eDuckDBError, "fail to get name of %llu child", (unsigned long long)idx);
+    }
+    cname = rb_str_new_cstr(child_name);
+    duckdb_free((void *)child_name);
+    return cname;
 }
 
 /*
@@ -260,6 +285,7 @@ void rbduckdb_init_duckdb_logical_type(void) {
     rb_define_method(cDuckDBLogicalType, "width", duckdb_logical_type_width, 0);
     rb_define_method(cDuckDBLogicalType, "scale", duckdb_logical_type_scale, 0);
     rb_define_method(cDuckDBLogicalType, "child_count", duckdb_logical_type_child_count, 0);
+    rb_define_method(cDuckDBLogicalType, "child_name_at", duckdb_logical_type_child_name_at, 1);
     rb_define_method(cDuckDBLogicalType, "child_type", duckdb_logical_type_child_type, 0);
     rb_define_method(cDuckDBLogicalType, "size", duckdb_logical_type_size, 0);
     rb_define_method(cDuckDBLogicalType, "key_type", duckdb_logical_type_key_type, 0);

--- a/ext/duckdb/logical_type.c
+++ b/ext/duckdb/logical_type.c
@@ -8,6 +8,7 @@ static size_t memsize(const void *p);
 static VALUE duckdb_logical_type__type(VALUE self);
 static VALUE duckdb_logical_type_width(VALUE self);
 static VALUE duckdb_logical_type_scale(VALUE self);
+static VALUE duckdb_logical_type_child_count(VALUE self);
 static VALUE duckdb_logical_type_child_type(VALUE self);
 static VALUE duckdb_logical_type_size(VALUE self);
 static VALUE duckdb_logical_type_key_type(VALUE self);
@@ -78,6 +79,19 @@ static VALUE duckdb_logical_type_scale(VALUE self) {
     rubyDuckDBLogicalType *ctx;
     TypedData_Get_Struct(self, rubyDuckDBLogicalType, &logical_type_data_type, ctx);
     return INT2FIX(duckdb_decimal_scale(ctx->logical_type));
+}
+
+/*
+ *  call-seq:
+ *    struct_col.logical_type.child_count -> Integer
+ *
+ *  Returns the number of children of a struct type, otherwise 0.
+ *
+ */
+static VALUE duckdb_logical_type_child_count(VALUE self) {
+    rubyDuckDBLogicalType *ctx;
+    TypedData_Get_Struct(self, rubyDuckDBLogicalType, &logical_type_data_type, ctx);
+    return INT2FIX(duckdb_struct_type_child_count(ctx->logical_type));
 }
 
 /*
@@ -245,6 +259,7 @@ void rbduckdb_init_duckdb_logical_type(void) {
     rb_define_private_method(cDuckDBLogicalType, "_type", duckdb_logical_type__type, 0);
     rb_define_method(cDuckDBLogicalType, "width", duckdb_logical_type_width, 0);
     rb_define_method(cDuckDBLogicalType, "scale", duckdb_logical_type_scale, 0);
+    rb_define_method(cDuckDBLogicalType, "child_count", duckdb_logical_type_child_count, 0);
     rb_define_method(cDuckDBLogicalType, "child_type", duckdb_logical_type_child_type, 0);
     rb_define_method(cDuckDBLogicalType, "size", duckdb_logical_type_size, 0);
     rb_define_method(cDuckDBLogicalType, "key_type", duckdb_logical_type_key_type, 0);

--- a/lib/duckdb/logical_type.rb
+++ b/lib/duckdb/logical_type.rb
@@ -62,5 +62,27 @@ module DuckDB
         yield member_type_at(i)
       end
     end
+
+    # Iterates over each struct child name.
+    #
+    # When a block is provided, this method yields each struct child name in
+    # order. It also returns the total number of children yielded.
+    #
+    #   struct_logical_type.each_child_name do |name|
+    #     puts "Struct child: #{name}"
+    #   end
+    #
+    # If no block is given, an Enumerator is returned, which can be used to
+    # retrieve all child names.
+    #
+    #   names = struct_logical_type.each_child_name.to_a
+    #   # => ["child1", "child2"]
+    def each_child_name
+      return to_enum(__method__) {child_count} unless block_given?
+
+      child_count.times do |i|
+        yield child_name_at(i)
+      end
+    end
   end
 end

--- a/lib/duckdb/logical_type.rb
+++ b/lib/duckdb/logical_type.rb
@@ -84,5 +84,27 @@ module DuckDB
         yield child_name_at(i)
       end
     end
+
+    # Iterates over each struct child type.
+    #
+    # When a block is provided, this method yields each struct child type in
+    # order. It also returns the total number of children yielded.
+    #
+    #   struct_logical_type.each_child_type do |logical_type|
+    #     puts "Struct child type: #{logical_type.type}"
+    #   end
+    #
+    # If no block is given, an Enumerator is returned, which can be used to
+    # retrieve all child logical types.
+    #
+    #   types = struct_logical_type.each_child_type.map(&:type)
+    #   # => [:integer, :varchar]
+    def each_child_type
+      return to_enum(__method__) {child_count} unless block_given?
+
+      child_count.times do |i|
+        yield child_type_at(i)
+      end
+    end
   end
 end

--- a/test/duckdb_test/logical_type_test.rb
+++ b/test/duckdb_test/logical_type_test.rb
@@ -207,6 +207,14 @@ module DuckDBTest
       assert_equal(["word", "length"], child_names)
     end
 
+    def test_struct_each_child_type
+      struct_column = @columns.find { |column| column.type == :struct }
+      struct_logical_type = struct_column.logical_type
+      child_types = struct_logical_type.each_child_type.to_a
+      assert(child_types.all? { |child_type| child_type.is_a?(DuckDB::LogicalType) })
+      assert_equal([:varchar, :integer], child_types.map(&:type))
+    end
+
     private
 
     def create_data(con)

--- a/test/duckdb_test/logical_type_test.rb
+++ b/test/duckdb_test/logical_type_test.rb
@@ -195,6 +195,11 @@ module DuckDBTest
       assert_equal([:integer, :varchar], member_types.map(&:type))
     end
 
+    def test_struct_child_count
+      struct_column = @columns.find { |column| column.type == :struct }
+      assert_equal(2, struct_column.logical_type.child_count)
+    end
+
     private
 
     def create_data(con)

--- a/test/duckdb_test/logical_type_test.rb
+++ b/test/duckdb_test/logical_type_test.rb
@@ -200,6 +200,13 @@ module DuckDBTest
       assert_equal(2, struct_column.logical_type.child_count)
     end
 
+    def test_struct_each_child_name
+      struct_column = @columns.find { |column| column.type == :struct }
+      struct_logical_type = struct_column.logical_type
+      child_names = struct_logical_type.each_child_name.to_a
+      assert_equal(["word", "length"], child_names)
+    end
+
     private
 
     def create_data(con)


### PR DESCRIPTION
refs: GH-690

In this PR, we support interfaces for Struct type in DuckDB::Column#logical_type about the following.

- idx_t [duckdb_struct_type_child_count](https://duckdb.org/docs/stable/clients/c/api.html#duckdb_struct_type_child_count)(duckdb_logical_type type);
- char *[duckdb_struct_type_child_name](https://duckdb.org/docs/stable/clients/c/api.html#duckdb_struct_type_child_name)(duckdb_logical_type type, idx_t index);
- duckdb_logical_type [duckdb_struct_type_child_type](https://duckdb.org/docs/stable/clients/c/api.html#duckdb_struct_type_child_type)(duckdb_logical_type type, idx_t index);

This is one of the steps for supporting the duckdb_logical_column_type C API.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced structured type support by adding functionality to retrieve child counts, names, and types.
  - Introduced iteration capabilities for accessing child elements more conveniently.

- **Tests**
  - Expanded test coverage for structured types to ensure correct handling of child counts, names, and types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->