### PR TITLE
Add bind uhugeint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
   `DuckDB::Appender#append_blob`, `DuckDB::Appender#append_null`, `DuckDB::Appender#append_default`,
   `DuckDB::Appender#append_date`, `DuckDB::Appender#append_interval`, `DuckDB::Appender#append_time`,
   `DuckDB::Appender#append_timestamp`, `DuckDB::Appender#append_hugeint` failed.
+- add `DuckDB::PreparedStatement#bind_uhugeint`.
 
 # 1.2.0.0 - 2025-02-24
 - bump duckdb to 1.2.0.

--- a/lib/duckdb/prepared_statement.rb
+++ b/lib/duckdb/prepared_statement.rb
@@ -135,12 +135,29 @@ module DuckDB
     #   require 'duckdb'
     #   db = DuckDB::Database.open('duckdb_database')
     #   con = db.connect
-    #   sql ='SELECT name FROM users WHERE bigint_col = ?'
+    #   sql ='SELECT name FROM users WHERE hugeint_col = ?'
     #   stmt = PreparedStatement.new(con, sql)
     #   stmt.bind_hugeint_internal(1, 1_234_567_890_123_456_789_012_345)
     def bind_hugeint_internal(index, value)
       lower, upper = integer_to_hugeint(value)
       _bind_hugeint(index, lower, upper)
+    end
+
+    # binds i-th parameter with SQL prepared statement.
+    # The first argument is index of parameter.
+    # The index of first parameter is 1 not 0.
+    # The second argument value must be Integer value.
+    # This method uses duckdb_bind_uhugeint internally.
+    #
+    #   require 'duckdb'
+    #   db = DuckDB::Database.open('duckdb_database')
+    #   con = db.connect
+    #   sql ='SELECT name FROM users WHERE uhugeint_col = ?'
+    #   stmt = PreparedStatement.new(con, sql)
+    #   stmt.bind_uhugeint(1, (2**128) - 1)
+    def bind_uhugeint(index, value)
+      lower, upper = integer_to_hugeint(value)
+      _bind_uhugeint(index, lower, upper)
     end
 
     # binds i-th parameter with SQL prepared statement.

--- a/test/duckdb_test/prepared_statement_test.rb
+++ b/test/duckdb_test/prepared_statement_test.rb
@@ -317,16 +317,16 @@ module DuckDBTest
       assert_equal('2nd argument `1.5` must be Integer.', e.message)
     end
 
-    def test_bind_uhugeint_internal
+    def test_bind_uhugeint
       value = (2**128) - 1
       @con.query('CREATE TABLE values (value UHUGEINT)')
 
       stmt = DuckDB::PreparedStatement.new(@con, 'INSERT INTO values(value) VALUES ($1)')
-      stmt.bind_uhugeint_internal(1, value)
+      stmt.bind_uhugeint(1, value)
       stmt.execute
 
       stmt = DuckDB::PreparedStatement.new(@con, 'SELECT * FROM values WHERE value = $1')
-      stmt.bind_uhugeint_internal(1, value)
+      stmt.bind_uhugeint(1, value)
       assert_equal(value, stmt.execute.each.first[0])
     end
 


### PR DESCRIPTION
refs #696.

- Add DuckDB::PreparedStatement#bind_uhugeint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced functionality to support binding an additional large integer type in SQL prepared statements.
- **Tests**
  - Added tests to validate the new binding functionality and ensured proper cleanup after test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->