### PR TITLE
bump ruby on CI.

### DIFF
--- a/.github/workflows/test_on_macos.yml
+++ b/.github/workflows/test_on_macos.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        ruby: ['3.1.6', '3.2.6', '3.3.6', '3.4.2', 'head']
+        ruby: ['3.1.6', '3.2.7', '3.3.7', '3.4.2', 'head']
         duckdb: ['1.2.1', '1.1.3', '1.1.1']
 
     steps:

--- a/.github/workflows/test_on_ubuntu.yml
+++ b/.github/workflows/test_on_ubuntu.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ['3.1.6', '3.2.6', '3.3.6', '3.4.2', 'head']
+        ruby: ['3.1.6', '3.2.7', '3.3.7', '3.4.2', 'head']
         duckdb: ['1.2.1', '1.1.3', '1.1.1']
 
     steps:


### PR DESCRIPTION
- Use ruby 3.2.7, 3.3.7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated our automated testing environment with the latest Ruby patch updates to ensure optimal reliability and performance across supported platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->