### PR TITLE
support interfaces for Enum type in DuckDB::LogicalType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 # Unreleased
+- support Enum type in `DuckDB::LogicalType` class.
+  - `DuckDB::LogicalType#internal_type`, `DuckDB::LogicalType#dictionary_size`,
+    `DuckDB::LogicalType#dictionary_value_at`, and `DuckDB::LogicalType#each_dictionary_value` are
+    available.
 
 # 1.2.1.0 - 2025-03-30
 - bump duckdb v1.2.1 on CI.

--- a/ext/duckdb/logical_type.c
+++ b/ext/duckdb/logical_type.c
@@ -20,6 +20,7 @@ static VALUE duckdb_logical_type_member_name_at(VALUE self, VALUE midx);
 static VALUE duckdb_logical_type_member_type_at(VALUE self, VALUE midx);
 static VALUE duckdb_logical_type__internal_type(VALUE self);
 static VALUE duckdb_logical_type_dictionary_size(VALUE self);
+static VALUE duckdb_logical_type_dictionary_value_at(VALUE self, VALUE didx);
 
 static const rb_data_type_t logical_type_data_type = {
     "DuckDB/LogicalType",
@@ -332,6 +333,30 @@ static VALUE duckdb_logical_type_dictionary_size(VALUE self) {
     return INT2FIX(duckdb_enum_dictionary_size(ctx->logical_type));
 }
 
+/*
+ *  call-seq:
+ *    enum_col.logical_type.dictionary_value_at(index) -> String
+ *
+ *  Returns the dictionary value at the specified index.
+ *
+ */
+static VALUE duckdb_logical_type_dictionary_value_at(VALUE self, VALUE didx) {
+    rubyDuckDBLogicalType *ctx;
+    VALUE dvalue;
+    const char *dict_value;
+    idx_t idx = NUM2ULL(didx);
+
+    TypedData_Get_Struct(self, rubyDuckDBLogicalType, &logical_type_data_type, ctx);
+
+    dict_value = duckdb_enum_dictionary_value(ctx->logical_type, idx);
+    if (dict_value == NULL) {
+        rb_raise(eDuckDBError, "fail to get dictionary value of %llu", (unsigned long long)idx);
+    }
+    dvalue = rb_utf8_str_new_cstr(dict_value);
+    duckdb_free((void *)dict_value);
+    return dvalue;
+}
+
 VALUE rbduckdb_create_logical_type(duckdb_logical_type logical_type) {
     VALUE obj;
     rubyDuckDBLogicalType *ctx;
@@ -366,4 +391,5 @@ void rbduckdb_init_duckdb_logical_type(void) {
     rb_define_method(cDuckDBLogicalType, "member_type_at", duckdb_logical_type_member_type_at, 1);
     rb_define_method(cDuckDBLogicalType, "_internal_type", duckdb_logical_type__internal_type, 0);
     rb_define_method(cDuckDBLogicalType, "dictionary_size", duckdb_logical_type_dictionary_size, 0);
+    rb_define_method(cDuckDBLogicalType, "dictionary_value_at", duckdb_logical_type_dictionary_value_at, 1);
 }

--- a/ext/duckdb/logical_type.c
+++ b/ext/duckdb/logical_type.c
@@ -19,6 +19,7 @@ static VALUE duckdb_logical_type_member_count(VALUE self);
 static VALUE duckdb_logical_type_member_name_at(VALUE self, VALUE midx);
 static VALUE duckdb_logical_type_member_type_at(VALUE self, VALUE midx);
 static VALUE duckdb_logical_type__internal_type(VALUE self);
+static VALUE duckdb_logical_type_dictionary_size(VALUE self);
 
 static const rb_data_type_t logical_type_data_type = {
     "DuckDB/LogicalType",
@@ -318,6 +319,19 @@ static VALUE duckdb_logical_type__internal_type(VALUE self) {
     return INT2FIX(internal_type_id);
 }
 
+/*
+ *  call-seq:
+ *    enum_col.logical_type.dictionary_size -> Integer
+ *
+ *  Returns the dictionary size of the enum type.
+ *
+ */
+static VALUE duckdb_logical_type_dictionary_size(VALUE self) {
+    rubyDuckDBLogicalType *ctx;
+    TypedData_Get_Struct(self, rubyDuckDBLogicalType, &logical_type_data_type, ctx);
+    return INT2FIX(duckdb_enum_dictionary_size(ctx->logical_type));
+}
+
 VALUE rbduckdb_create_logical_type(duckdb_logical_type logical_type) {
     VALUE obj;
     rubyDuckDBLogicalType *ctx;
@@ -351,4 +365,5 @@ void rbduckdb_init_duckdb_logical_type(void) {
     rb_define_method(cDuckDBLogicalType, "member_name_at", duckdb_logical_type_member_name_at, 1);
     rb_define_method(cDuckDBLogicalType, "member_type_at", duckdb_logical_type_member_type_at, 1);
     rb_define_method(cDuckDBLogicalType, "_internal_type", duckdb_logical_type__internal_type, 0);
+    rb_define_method(cDuckDBLogicalType, "dictionary_size", duckdb_logical_type_dictionary_size, 0);
 }

--- a/ext/duckdb/logical_type.c
+++ b/ext/duckdb/logical_type.c
@@ -18,6 +18,7 @@ static VALUE duckdb_logical_type_value_type(VALUE self);
 static VALUE duckdb_logical_type_member_count(VALUE self);
 static VALUE duckdb_logical_type_member_name_at(VALUE self, VALUE midx);
 static VALUE duckdb_logical_type_member_type_at(VALUE self, VALUE midx);
+static VALUE duckdb_logical_type__internal_type(VALUE self);
 
 static const rb_data_type_t logical_type_data_type = {
     "DuckDB/LogicalType",
@@ -288,6 +289,35 @@ static VALUE duckdb_logical_type_member_type_at(VALUE self, VALUE midx) {
     return rbduckdb_create_logical_type(union_member_type);
 }
 
+/*
+ *  call-seq:
+ *    enum_col.logical_type.internal_type -> Symbol
+ *
+ *  Returns the logical type's internal type.
+ *
+ */
+static VALUE duckdb_logical_type__internal_type(VALUE self) {
+    rubyDuckDBLogicalType *ctx;
+    duckdb_type type_id;
+    duckdb_type internal_type_id;
+
+    TypedData_Get_Struct(self, rubyDuckDBLogicalType, &logical_type_data_type, ctx);
+
+    type_id = duckdb_get_type_id(ctx->logical_type);
+    switch (type_id) {
+        case DUCKDB_TYPE_DECIMAL:
+            internal_type_id = duckdb_decimal_internal_type(ctx->logical_type);
+            break;
+        case DUCKDB_TYPE_ENUM:
+            internal_type_id = duckdb_enum_internal_type(ctx->logical_type);
+            break;
+        default:
+            internal_type_id = DUCKDB_TYPE_INVALID;
+    }
+
+    return INT2FIX(internal_type_id);
+}
+
 VALUE rbduckdb_create_logical_type(duckdb_logical_type logical_type) {
     VALUE obj;
     rubyDuckDBLogicalType *ctx;
@@ -320,4 +350,5 @@ void rbduckdb_init_duckdb_logical_type(void) {
     rb_define_method(cDuckDBLogicalType, "member_count", duckdb_logical_type_member_count, 0);
     rb_define_method(cDuckDBLogicalType, "member_name_at", duckdb_logical_type_member_name_at, 1);
     rb_define_method(cDuckDBLogicalType, "member_type_at", duckdb_logical_type_member_type_at, 1);
+    rb_define_method(cDuckDBLogicalType, "_internal_type", duckdb_logical_type__internal_type, 0);
 }

--- a/lib/duckdb/logical_type.rb
+++ b/lib/duckdb/logical_type.rb
@@ -124,5 +124,27 @@ module DuckDB
         yield child_type_at(i)
       end
     end
+
+    # Iterates over each enum dictionary value.
+    #
+    # When a block is provided, this method yields each enum dictionary value
+    # in order. It also returns the total number of dictionary values yielded.
+    #
+    #   enum_logical_type.each_value do |value|
+    #     puts "Enum value: #{value}"
+    #   end
+    #
+    # If no block is given, an Enumerator is returned, which can be used to
+    # retrieve all enum dictionary values.
+    #
+    #   values = enum_logical_type.each_value.to_a
+    #   # => ["happy", "sad"]
+    def each_dictionary_value
+      return to_enum(__method__) {dictionary_size} unless block_given?
+
+      dictionary_size.times do |i|
+        yield dictionary_value_at(i)
+      end
+    end
   end
 end

--- a/lib/duckdb/logical_type.rb
+++ b/lib/duckdb/logical_type.rb
@@ -19,6 +19,24 @@ module DuckDB
       DuckDB::Converter::IntToSym.type_to_sym(type_id)
     end
 
+    # returns logical type's internal type symbol for Decimal or Enum types
+    # `:unknown` means that the logical type's type is unknown/unsupported by ruby-duckdb.
+    # `:invalid` means that the logical type's type is invalid in duckdb.
+    #
+    #   require 'duckdb'
+    #   db = DuckDB::Database.open
+    #   con = db.connect
+    #   con.query("CREATE TYPE mood AS ENUM ('happy', 'sad')")
+    #   con.query("CREATE TABLE emotions (id INTEGER, enum_col mood)")
+    #
+    #   users = con.query('SELECT * FROM emotions')
+    #   ernum_col = users.columns.find { |col| col.name == 'enum_col' }
+    #   enum_col.logical_type.internal_type #=> :utinyint
+    def internal_type
+      type_id = _internal_type
+      DuckDB::Converter::IntToSym.type_to_sym(type_id)
+    end
+
     # Iterates over each union member name.
     #
     # When a block is provided, this method yields each union member name in

--- a/test/duckdb_test/logical_type_test.rb
+++ b/test/duckdb_test/logical_type_test.rb
@@ -118,6 +118,11 @@ module DuckDBTest
       assert_equal(EXPECTED_TYPES, logical_types.map(&:type))
     end
 
+    def test_decimal_internal_type
+      decimal_column = @columns.find { |column| column.type == :decimal }
+      assert_equal(:integer, decimal_column.logical_type.internal_type)
+    end
+
     def test_decimal_width
       decimal_column = @columns.find { |column| column.type == :decimal }
       assert_equal(9, decimal_column.logical_type.width)
@@ -213,6 +218,11 @@ module DuckDBTest
       child_types = struct_logical_type.each_child_type.to_a
       assert(child_types.all? { |child_type| child_type.is_a?(DuckDB::LogicalType) })
       assert_equal([:varchar, :integer], child_types.map(&:type))
+    end
+
+    def test_enum_internal_type
+      enum_column = @columns.find { |column| column.type == :enum }
+      assert_equal(:utinyint, enum_column.logical_type.internal_type)
     end
 
     private

--- a/test/duckdb_test/logical_type_test.rb
+++ b/test/duckdb_test/logical_type_test.rb
@@ -230,6 +230,13 @@ module DuckDBTest
       assert_equal(4, enum_column.logical_type.dictionary_size)
     end
 
+    def test_enum_each_dictionary_value
+      enum_column = @columns.find { |column| column.type == :enum }
+      enum_logical_type = enum_column.logical_type
+      dictionary_values = enum_logical_type.each_dictionary_value.to_a
+      assert_equal(["sad", "ok", "happy", "𝘾𝝾օɭ 😎"], dictionary_values)
+    end
+
     private
 
     def create_data(con)

--- a/test/duckdb_test/logical_type_test.rb
+++ b/test/duckdb_test/logical_type_test.rb
@@ -225,6 +225,11 @@ module DuckDBTest
       assert_equal(:utinyint, enum_column.logical_type.internal_type)
     end
 
+    def test_enum_dictionary_size
+      enum_column = @columns.find { |column| column.type == :enum }
+      assert_equal(4, enum_column.logical_type.dictionary_size)
+    end
+
     private
 
     def create_data(con)


### PR DESCRIPTION
refs: GH-690

In this PR, we support interfaces for Enum type in DuckDB::Column#logical_type about the following.

- duckdb_type [duckdb_enum_internal_type](https://duckdb.org/docs/stable/clients/c/api.html#duckdb_enum_internal_type)(duckdb_logical_type type);
- uint32_t [duckdb_enum_dictionary_size](https://duckdb.org/docs/stable/clients/c/api.html#duckdb_enum_dictionary_size)(duckdb_logical_type type);
- char *[duckdb_enum_dictionary_value](https://duckdb.org/docs/stable/clients/c/api.html#duckdb_enum_dictionary_value)(duckdb_logical_type type, idx_t index);

This is one of the steps for supporting the duckdb_logical_column_type C API.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced enhanced support for enumeration types, enabling querying of type information, dictionary sizes, and iteration over dictionary values.
- **Tests**
	- Expanded test coverage to validate the new enumeration and numeric type functionalities, ensuring robust and reliable behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->