### PR TITLE
Bind uint8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 # Unreleased
+- add `DuckDB::PreparedStatement#bind_uint8`.
 - support Enum type in `DuckDB::LogicalType` class.
   - `DuckDB::LogicalType#internal_type`, `DuckDB::LogicalType#dictionary_size`,
     `DuckDB::LogicalType#dictionary_value_at`, and `DuckDB::LogicalType#each_dictionary_value` are

--- a/ext/duckdb/prepared_statement.c
+++ b/ext/duckdb/prepared_statement.c
@@ -17,7 +17,6 @@ static VALUE duckdb_prepared_statement_parameter_name(VALUE self, VALUE vidx);
 static VALUE duckdb_prepared_statement_clear_bindings(VALUE self);
 static VALUE duckdb_prepared_statement_bind_bool(VALUE self, VALUE vidx, VALUE val);
 static VALUE duckdb_prepared_statement_bind_int8(VALUE self, VALUE vidx, VALUE val);
-static VALUE duckdb_prepared_statement_bind_uint8(VALUE self, VALUE vidx, VALUE val);
 static VALUE duckdb_prepared_statement_bind_int16(VALUE self, VALUE vidx, VALUE val);
 static VALUE duckdb_prepared_statement_bind_int32(VALUE self, VALUE vidx, VALUE val);
 static VALUE duckdb_prepared_statement_bind_int64(VALUE self, VALUE vidx, VALUE val);
@@ -28,6 +27,7 @@ static VALUE duckdb_prepared_statement_bind_blob(VALUE self, VALUE vidx, VALUE b
 static VALUE duckdb_prepared_statement_bind_null(VALUE self, VALUE vidx);
 static VALUE duckdb_prepared_statement__statement_type(VALUE self);
 static VALUE duckdb_prepared_statement__param_type(VALUE self, VALUE vidx);
+static VALUE duckdb_prepared_statement__bind_uint8(VALUE self, VALUE vidx, VALUE val);
 static VALUE duckdb_prepared_statement__bind_date(VALUE self, VALUE vidx, VALUE year, VALUE month, VALUE day);
 static VALUE duckdb_prepared_statement__bind_time(VALUE self, VALUE vidx, VALUE hour, VALUE min, VALUE sec, VALUE micros);
 static VALUE duckdb_prepared_statement__bind_timestamp(VALUE self, VALUE vidx, VALUE year, VALUE month, VALUE day, VALUE hour, VALUE min, VALUE sec, VALUE micros);
@@ -245,18 +245,6 @@ static VALUE duckdb_prepared_statement_bind_int8(VALUE self, VALUE vidx, VALUE v
     return self;
 }
 
-static VALUE duckdb_prepared_statement_bind_uint8(VALUE self, VALUE vidx, VALUE val) {
-    rubyDuckDBPreparedStatement *ctx;
-    idx_t idx = check_index(vidx);
-    uint8_t ui8val = (uint8_t)NUM2INT(val);
-
-    TypedData_Get_Struct(self, rubyDuckDBPreparedStatement, &prepared_statement_data_type, ctx);
-
-    if (duckdb_bind_uint8(ctx->prepared_statement, idx, ui8val) == DuckDBError) {
-        rb_raise(eDuckDBError, "fail to bind %llu parameter", (unsigned long long)idx);
-    }
-    return self;
-}
 
 static VALUE duckdb_prepared_statement_bind_int16(VALUE self, VALUE vidx, VALUE val) {
     rubyDuckDBPreparedStatement *ctx;
@@ -371,6 +359,20 @@ static VALUE duckdb_prepared_statement__param_type(VALUE self, VALUE vidx) {
     rubyDuckDBPreparedStatement *ctx;
     TypedData_Get_Struct(self, rubyDuckDBPreparedStatement, &prepared_statement_data_type, ctx);
     return INT2FIX(duckdb_param_type(ctx->prepared_statement, NUM2ULL(vidx)));
+}
+
+/* :nodoc: */
+static VALUE duckdb_prepared_statement__bind_uint8(VALUE self, VALUE vidx, VALUE val) {
+    rubyDuckDBPreparedStatement *ctx;
+    idx_t idx = check_index(vidx);
+    uint8_t ui8val = (uint8_t)NUM2UINT(val);
+
+    TypedData_Get_Struct(self, rubyDuckDBPreparedStatement, &prepared_statement_data_type, ctx);
+
+    if (duckdb_bind_uint8(ctx->prepared_statement, idx, ui8val) == DuckDBError) {
+        rb_raise(eDuckDBError, "fail to bind %llu parameter", (unsigned long long)idx);
+    }
+    return self;
 }
 
 /* :nodoc: */
@@ -517,7 +519,6 @@ void rbduckdb_init_duckdb_prepared_statement(void) {
     rb_define_method(cDuckDBPreparedStatement, "clear_bindings", duckdb_prepared_statement_clear_bindings, 0);
     rb_define_method(cDuckDBPreparedStatement, "bind_bool", duckdb_prepared_statement_bind_bool, 2);
     rb_define_method(cDuckDBPreparedStatement, "bind_int8", duckdb_prepared_statement_bind_int8, 2);
-    rb_define_method(cDuckDBPreparedStatement, "bind_uint8", duckdb_prepared_statement_bind_uint8, 2);
     rb_define_method(cDuckDBPreparedStatement, "bind_int16", duckdb_prepared_statement_bind_int16, 2);
     rb_define_method(cDuckDBPreparedStatement, "bind_int32", duckdb_prepared_statement_bind_int32, 2);
     rb_define_method(cDuckDBPreparedStatement, "bind_int64", duckdb_prepared_statement_bind_int64, 2);
@@ -526,6 +527,7 @@ void rbduckdb_init_duckdb_prepared_statement(void) {
     rb_define_method(cDuckDBPreparedStatement, "bind_varchar", duckdb_prepared_statement_bind_varchar, 2);
     rb_define_method(cDuckDBPreparedStatement, "bind_blob", duckdb_prepared_statement_bind_blob, 2);
     rb_define_method(cDuckDBPreparedStatement, "bind_null", duckdb_prepared_statement_bind_null, 1);
+    rb_define_method(cDuckDBPreparedStatement, "_bind_uint8", duckdb_prepared_statement__bind_uint8, 2);
     rb_define_private_method(cDuckDBPreparedStatement, "_statement_type", duckdb_prepared_statement__statement_type, 0);
     rb_define_private_method(cDuckDBPreparedStatement, "_param_type", duckdb_prepared_statement__param_type, 1);
     rb_define_private_method(cDuckDBPreparedStatement, "_bind_date", duckdb_prepared_statement__bind_date, 4);

--- a/ext/duckdb/prepared_statement.c
+++ b/ext/duckdb/prepared_statement.c
@@ -17,6 +17,7 @@ static VALUE duckdb_prepared_statement_parameter_name(VALUE self, VALUE vidx);
 static VALUE duckdb_prepared_statement_clear_bindings(VALUE self);
 static VALUE duckdb_prepared_statement_bind_bool(VALUE self, VALUE vidx, VALUE val);
 static VALUE duckdb_prepared_statement_bind_int8(VALUE self, VALUE vidx, VALUE val);
+static VALUE duckdb_prepared_statement_bind_uint8(VALUE self, VALUE vidx, VALUE val);
 static VALUE duckdb_prepared_statement_bind_int16(VALUE self, VALUE vidx, VALUE val);
 static VALUE duckdb_prepared_statement_bind_int32(VALUE self, VALUE vidx, VALUE val);
 static VALUE duckdb_prepared_statement_bind_int64(VALUE self, VALUE vidx, VALUE val);
@@ -239,6 +240,19 @@ static VALUE duckdb_prepared_statement_bind_int8(VALUE self, VALUE vidx, VALUE v
     TypedData_Get_Struct(self, rubyDuckDBPreparedStatement, &prepared_statement_data_type, ctx);
 
     if (duckdb_bind_int8(ctx->prepared_statement, idx, i8val) == DuckDBError) {
+        rb_raise(eDuckDBError, "fail to bind %llu parameter", (unsigned long long)idx);
+    }
+    return self;
+}
+
+static VALUE duckdb_prepared_statement_bind_uint8(VALUE self, VALUE vidx, VALUE val) {
+    rubyDuckDBPreparedStatement *ctx;
+    idx_t idx = check_index(vidx);
+    uint8_t ui8val = (uint8_t)NUM2INT(val);
+
+    TypedData_Get_Struct(self, rubyDuckDBPreparedStatement, &prepared_statement_data_type, ctx);
+
+    if (duckdb_bind_uint8(ctx->prepared_statement, idx, ui8val) == DuckDBError) {
         rb_raise(eDuckDBError, "fail to bind %llu parameter", (unsigned long long)idx);
     }
     return self;
@@ -503,6 +517,7 @@ void rbduckdb_init_duckdb_prepared_statement(void) {
     rb_define_method(cDuckDBPreparedStatement, "clear_bindings", duckdb_prepared_statement_clear_bindings, 0);
     rb_define_method(cDuckDBPreparedStatement, "bind_bool", duckdb_prepared_statement_bind_bool, 2);
     rb_define_method(cDuckDBPreparedStatement, "bind_int8", duckdb_prepared_statement_bind_int8, 2);
+    rb_define_method(cDuckDBPreparedStatement, "bind_uint8", duckdb_prepared_statement_bind_uint8, 2);
     rb_define_method(cDuckDBPreparedStatement, "bind_int16", duckdb_prepared_statement_bind_int16, 2);
     rb_define_method(cDuckDBPreparedStatement, "bind_int32", duckdb_prepared_statement_bind_int32, 2);
     rb_define_method(cDuckDBPreparedStatement, "bind_int64", duckdb_prepared_statement_bind_int64, 2);

--- a/ext/duckdb/prepared_statement.c
+++ b/ext/duckdb/prepared_statement.c
@@ -527,7 +527,7 @@ void rbduckdb_init_duckdb_prepared_statement(void) {
     rb_define_method(cDuckDBPreparedStatement, "bind_varchar", duckdb_prepared_statement_bind_varchar, 2);
     rb_define_method(cDuckDBPreparedStatement, "bind_blob", duckdb_prepared_statement_bind_blob, 2);
     rb_define_method(cDuckDBPreparedStatement, "bind_null", duckdb_prepared_statement_bind_null, 1);
-    rb_define_method(cDuckDBPreparedStatement, "_bind_uint8", duckdb_prepared_statement__bind_uint8, 2);
+    rb_define_private_method(cDuckDBPreparedStatement, "_bind_uint8", duckdb_prepared_statement__bind_uint8, 2);
     rb_define_private_method(cDuckDBPreparedStatement, "_statement_type", duckdb_prepared_statement__statement_type, 0);
     rb_define_private_method(cDuckDBPreparedStatement, "_param_type", duckdb_prepared_statement__param_type, 1);
     rb_define_private_method(cDuckDBPreparedStatement, "_bind_date", duckdb_prepared_statement__bind_date, 4);

--- a/lib/duckdb/prepared_statement.rb
+++ b/lib/duckdb/prepared_statement.rb
@@ -108,6 +108,16 @@ module DuckDB
     # binds i-th parameter with SQL prepared statement.
     # The first argument is index of parameter.
     # The index of first parameter is 1 not 0.
+    # The second argument value is to expected Integer value between 0 to 255.
+    def bind_uint8(index, val)
+      return _bind_uint8(index, val) if val.between?(0, 255)
+
+      raise DuckDB::Error, "can't bind uint8(bind_uint8) to `#{val}`. The `#{val}` is out of range 0..255."
+    end
+
+    # binds i-th parameter with SQL prepared statement.
+    # The first argument is index of parameter.
+    # The index of first parameter is 1 not 0.
     # The second argument value is to expected Integer value.
     # This method uses bind_varchar internally.
     #

--- a/test/duckdb_test/prepared_statement_test.rb
+++ b/test/duckdb_test/prepared_statement_test.rb
@@ -237,6 +237,26 @@ module DuckDBTest
       assert_equal(expected_row, stmt.execute.each.first)
     end
 
+    def test_bind_uint8
+      value = (2**8) - 1
+      @con.query('CREATE TABLE values (value UINT8)')
+
+      stmt = DuckDB::PreparedStatement.new(@con, 'INSERT INTO values(value) VALUES ($1)')
+      stmt.bind_uint8(1, value)
+      stmt.execute
+
+      stmt = DuckDB::PreparedStatement.new(@con, 'SELECT * FROM values WHERE value = $1')
+      stmt.bind_uint8(1, value)
+      assert_equal(value, stmt.execute.each.first[0])
+    end
+
+    def test_bind_uint8_with_negative
+      @con.query('CREATE TABLE values (value UINT8)')
+
+      stmt = DuckDB::PreparedStatement.new(@con, 'INSERT INTO values(value) VALUES ($1)')
+      assert_raises(DuckDB::Error) { stmt.bind_uint8(1, -1) }
+    end
+
     def test_bind_int16
       stmt = DuckDB::PreparedStatement.new(@con, 'SELECT * FROM a WHERE col_smallint = $1')
 


### PR DESCRIPTION
add DuckDB::PreparedStatement#bind_uint8. refs #697

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added support for binding unsigned 8-bit integers (0–255) to prepared statements for improved parameter handling.
- **Tests**
	- Introduced tests to verify successful binding of valid values and to ensure proper error handling for out-of-range inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->