### PR TITLE
add DuckDB::PreparedStatement#bind_uint16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 # Unreleased
-- add `DuckDB::PreparedStatement#bind_uint8`.
+- add `DuckDB::PreparedStatement#bind_uint8`, `DuckDB::PreparedStatement#bind_uint16`.
 - support Enum type in `DuckDB::LogicalType` class.
   - `DuckDB::LogicalType#internal_type`, `DuckDB::LogicalType#dictionary_size`,
     `DuckDB::LogicalType#dictionary_value_at`, and `DuckDB::LogicalType#each_dictionary_value` are

--- a/ext/duckdb/prepared_statement.c
+++ b/ext/duckdb/prepared_statement.c
@@ -376,6 +376,20 @@ static VALUE duckdb_prepared_statement__bind_uint8(VALUE self, VALUE vidx, VALUE
 }
 
 /* :nodoc: */
+static VALUE duckdb_prepared_statement__bind_uint16(VALUE self, VALUE vidx, VALUE val) {
+    rubyDuckDBPreparedStatement *ctx;
+    idx_t idx = check_index(vidx);
+    uint16_t ui16val = (uint16_t)NUM2UINT(val);
+
+    TypedData_Get_Struct(self, rubyDuckDBPreparedStatement, &prepared_statement_data_type, ctx);
+
+    if (duckdb_bind_uint16(ctx->prepared_statement, idx, ui16val) == DuckDBError) {
+        rb_raise(eDuckDBError, "fail to bind %llu parameter", (unsigned long long)idx);
+    }
+    return self;
+}
+
+/* :nodoc: */
 static VALUE duckdb_prepared_statement__bind_date(VALUE self, VALUE vidx, VALUE year, VALUE month, VALUE day) {
     rubyDuckDBPreparedStatement *ctx;
     duckdb_date dt;
@@ -528,6 +542,7 @@ void rbduckdb_init_duckdb_prepared_statement(void) {
     rb_define_method(cDuckDBPreparedStatement, "bind_blob", duckdb_prepared_statement_bind_blob, 2);
     rb_define_method(cDuckDBPreparedStatement, "bind_null", duckdb_prepared_statement_bind_null, 1);
     rb_define_private_method(cDuckDBPreparedStatement, "_bind_uint8", duckdb_prepared_statement__bind_uint8, 2);
+    rb_define_private_method(cDuckDBPreparedStatement, "_bind_uint16", duckdb_prepared_statement__bind_uint16, 2);
     rb_define_private_method(cDuckDBPreparedStatement, "_statement_type", duckdb_prepared_statement__statement_type, 0);
     rb_define_private_method(cDuckDBPreparedStatement, "_param_type", duckdb_prepared_statement__param_type, 1);
     rb_define_private_method(cDuckDBPreparedStatement, "_bind_date", duckdb_prepared_statement__bind_date, 4);

--- a/lib/duckdb/prepared_statement.rb
+++ b/lib/duckdb/prepared_statement.rb
@@ -118,6 +118,16 @@ module DuckDB
     # binds i-th parameter with SQL prepared statement.
     # The first argument is index of parameter.
     # The index of first parameter is 1 not 0.
+    # The second argument value is to expected Integer value between 0 to 65535.
+    def bind_uint16(index, val)
+      return _bind_uint16(index, val) if val.between?(0, 65_535)
+
+      raise DuckDB::Error, "can't bind uint16(bind_uint16) to `#{val}`. The `#{val}` is out of range 0..65535."
+    end
+
+    # binds i-th parameter with SQL prepared statement.
+    # The first argument is index of parameter.
+    # The index of first parameter is 1 not 0.
     # The second argument value is to expected Integer value.
     # This method uses bind_varchar internally.
     #

--- a/test/duckdb_test/prepared_statement_test.rb
+++ b/test/duckdb_test/prepared_statement_test.rb
@@ -272,6 +272,26 @@ module DuckDBTest
       assert_nil(stmt.execute.each.first)
     end
 
+    def test_bind_uint16
+      value = (2**16) - 1
+      @con.query('CREATE TABLE values (value USMALLINT)')
+
+      stmt = DuckDB::PreparedStatement.new(@con, 'INSERT INTO values(value) VALUES ($1)')
+      stmt.bind_uint16(1, value)
+      stmt.execute
+
+      stmt = DuckDB::PreparedStatement.new(@con, 'SELECT * FROM values WHERE value = $1')
+      stmt.bind_uint16(1, value)
+      assert_equal(value, stmt.execute.each.first[0])
+    end
+
+    def test_bind_uint16_with_negative
+      @con.query('CREATE TABLE values (value UINT16)')
+
+      stmt = DuckDB::PreparedStatement.new(@con, 'INSERT INTO values(value) VALUES ($1)')
+      assert_raises(DuckDB::Error) { stmt.bind_uint16(1, -1) }
+    end
+
     def test_bind_int32
       stmt = DuckDB::PreparedStatement.new(@con, 'SELECT * FROM a WHERE col_smallint = $1')
 


### PR DESCRIPTION
refs #703

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for binding unsigned 16-bit integer values in prepared statements, expanding the range to 0–65,535 and enhancing numeric parameter flexibility.
  
- **Tests**
  - Implemented tests to verify correct binding behavior for valid 16-bit values and to ensure that invalid (negative) inputs trigger appropriate error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->