### PR TITLE
add DuckDB::PreparedStatement#bind_uint32(refs #704).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 All notable changes to this project will be documented in this file.
 # Unreleased
-- add `DuckDB::PreparedStatement#bind_uint8`, `DuckDB::PreparedStatement#bind_uint16`.
+- add `DuckDB::PreparedStatement#bind_uint8`, `DuckDB::PreparedStatement#bind_uint16`,
+  `DuckDB::PreparedStatement#bind_uint32`.
 - support Enum type in `DuckDB::LogicalType` class.
   - `DuckDB::LogicalType#internal_type`, `DuckDB::LogicalType#dictionary_size`,
     `DuckDB::LogicalType#dictionary_value_at`, and `DuckDB::LogicalType#each_dictionary_value` are

--- a/ext/duckdb/prepared_statement.c
+++ b/ext/duckdb/prepared_statement.c
@@ -28,6 +28,8 @@ static VALUE duckdb_prepared_statement_bind_null(VALUE self, VALUE vidx);
 static VALUE duckdb_prepared_statement__statement_type(VALUE self);
 static VALUE duckdb_prepared_statement__param_type(VALUE self, VALUE vidx);
 static VALUE duckdb_prepared_statement__bind_uint8(VALUE self, VALUE vidx, VALUE val);
+static VALUE duckdb_prepared_statement__bind_uint16(VALUE self, VALUE vidx, VALUE val);
+static VALUE duckdb_prepared_statement__bind_uint32(VALUE self, VALUE vidx, VALUE val);
 static VALUE duckdb_prepared_statement__bind_date(VALUE self, VALUE vidx, VALUE year, VALUE month, VALUE day);
 static VALUE duckdb_prepared_statement__bind_time(VALUE self, VALUE vidx, VALUE hour, VALUE min, VALUE sec, VALUE micros);
 static VALUE duckdb_prepared_statement__bind_timestamp(VALUE self, VALUE vidx, VALUE year, VALUE month, VALUE day, VALUE hour, VALUE min, VALUE sec, VALUE micros);
@@ -390,6 +392,20 @@ static VALUE duckdb_prepared_statement__bind_uint16(VALUE self, VALUE vidx, VALU
 }
 
 /* :nodoc: */
+static VALUE duckdb_prepared_statement__bind_uint32(VALUE self, VALUE vidx, VALUE val) {
+    rubyDuckDBPreparedStatement *ctx;
+    idx_t idx = check_index(vidx);
+    uint32_t ui32val = (uint32_t)NUM2UINT(val);
+
+    TypedData_Get_Struct(self, rubyDuckDBPreparedStatement, &prepared_statement_data_type, ctx);
+
+    if (duckdb_bind_uint32(ctx->prepared_statement, idx, ui32val) == DuckDBError) {
+        rb_raise(eDuckDBError, "fail to bind %llu parameter", (unsigned long long)idx);
+    }
+    return self;
+}
+
+/* :nodoc: */
 static VALUE duckdb_prepared_statement__bind_date(VALUE self, VALUE vidx, VALUE year, VALUE month, VALUE day) {
     rubyDuckDBPreparedStatement *ctx;
     duckdb_date dt;
@@ -543,6 +559,7 @@ void rbduckdb_init_duckdb_prepared_statement(void) {
     rb_define_method(cDuckDBPreparedStatement, "bind_null", duckdb_prepared_statement_bind_null, 1);
     rb_define_private_method(cDuckDBPreparedStatement, "_bind_uint8", duckdb_prepared_statement__bind_uint8, 2);
     rb_define_private_method(cDuckDBPreparedStatement, "_bind_uint16", duckdb_prepared_statement__bind_uint16, 2);
+    rb_define_private_method(cDuckDBPreparedStatement, "_bind_uint32", duckdb_prepared_statement__bind_uint32, 2);
     rb_define_private_method(cDuckDBPreparedStatement, "_statement_type", duckdb_prepared_statement__statement_type, 0);
     rb_define_private_method(cDuckDBPreparedStatement, "_param_type", duckdb_prepared_statement__param_type, 1);
     rb_define_private_method(cDuckDBPreparedStatement, "_bind_date", duckdb_prepared_statement__bind_date, 4);

--- a/lib/duckdb/prepared_statement.rb
+++ b/lib/duckdb/prepared_statement.rb
@@ -128,6 +128,15 @@ module DuckDB
     # binds i-th parameter with SQL prepared statement.
     # The first argument is index of parameter.
     # The index of first parameter is 1 not 0.
+    # The second argument value is to expected Integer value between 0 to 4294967295.
+    def bind_uint32(index, val)
+      return _bind_uint32(index, val) if val.between?(0, 4_294_967_295)
+
+      raise DuckDB::Error, "can't bind uint32(bind_uint32) to `#{val}`. The `#{val}` is out of range 0..4294967295."
+    end
+    # binds i-th parameter with SQL prepared statement.
+    # The first argument is index of parameter.
+    # The index of first parameter is 1 not 0.
     # The second argument value is to expected Integer value.
     # This method uses bind_varchar internally.
     #

--- a/test/duckdb_test/prepared_statement_test.rb
+++ b/test/duckdb_test/prepared_statement_test.rb
@@ -307,6 +307,26 @@ module DuckDBTest
       assert_nil(stmt.execute.each.first)
     end
 
+    def test_bind_uint32
+      value = (2**32) - 1
+      @con.query('CREATE TABLE values (value UINTEGER)')
+
+      stmt = DuckDB::PreparedStatement.new(@con, 'INSERT INTO values(value) VALUES ($1)')
+      stmt.bind_uint32(1, value)
+      stmt.execute
+
+      stmt = DuckDB::PreparedStatement.new(@con, 'SELECT * FROM values WHERE value = $1')
+      stmt.bind_uint32(1, value)
+      assert_equal(value, stmt.execute.each.first[0])
+    end
+
+    def test_bind_uint32_with_negative
+      @con.query('CREATE TABLE values (value UINT32)')
+
+      stmt = DuckDB::PreparedStatement.new(@con, 'INSERT INTO values(value) VALUES ($1)')
+      assert_raises(DuckDB::Error) { stmt.bind_uint32(1, -1) }
+    end
+
     def test_bind_int64
       stmt = DuckDB::PreparedStatement.new(@con, 'SELECT * FROM a WHERE col_smallint = $1')
 

--- a/test/duckdb_test/prepared_statement_test.rb
+++ b/test/duckdb_test/prepared_statement_test.rb
@@ -321,7 +321,7 @@ module DuckDBTest
     end
 
     def test_bind_uint32_with_negative
-      @con.query('CREATE TABLE values (value UINT32)')
+      @con.query('CREATE TABLE values (value UINTEGER)')
 
       stmt = DuckDB::PreparedStatement.new(@con, 'INSERT INTO values(value) VALUES ($1)')
       assert_raises(DuckDB::Error) { stmt.bind_uint32(1, -1) }


### PR DESCRIPTION
refs #704

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded prepared statement functionality to support binding 32-bit unsigned integer values with built-in range validation.
  
- **Tests**
  - Added tests to verify proper binding behavior and ensure that invalid values, such as negatives, trigger appropriate errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->