### PR TITLE
Add alias to logical type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,11 @@ All notable changes to this project will be documented in this file.
 # Unreleased
 - add `DuckDB::PreparedStatement#bind_uint8`, `DuckDB::PreparedStatement#bind_uint16`,
   `DuckDB::PreparedStatement#bind_uint32`, `DuckDB::PreparedStatement#bind_uint64`.
-- support Enum type in `DuckDB::LogicalType` class.
-  - `DuckDB::LogicalType#internal_type`, `DuckDB::LogicalType#dictionary_size`,
-    `DuckDB::LogicalType#dictionary_value_at`, and `DuckDB::LogicalType#each_dictionary_value` are
-    available.
+- add `DuckDB::LogicalType` class.
+  - `DuckDB::LogicalType` class is under construction. `DuckDB::LogicalType#internal_type`,
+    `DuckDB::LogicalType#dictionary_size`, `DuckDB::LogicalType#dictionary_value_at`,
+    `DuckDB::LogicalType#each_dictionary_value`, `DuckDB::LogicalType#alias`, and
+    `DuckDB::LogicalType#alias=`are available.
 
 # 1.2.1.0 - 2025-03-30
 - bump duckdb v1.2.1 on CI.

--- a/ext/duckdb/logical_type.c
+++ b/ext/duckdb/logical_type.c
@@ -21,6 +21,7 @@ static VALUE duckdb_logical_type_member_type_at(VALUE self, VALUE midx);
 static VALUE duckdb_logical_type__internal_type(VALUE self);
 static VALUE duckdb_logical_type_dictionary_size(VALUE self);
 static VALUE duckdb_logical_type_dictionary_value_at(VALUE self, VALUE didx);
+static VALUE duckdb_logical_type__get_alias(VALUE self);
 
 static const rb_data_type_t logical_type_data_type = {
     "DuckDB/LogicalType",
@@ -357,6 +358,28 @@ static VALUE duckdb_logical_type_dictionary_value_at(VALUE self, VALUE didx) {
     return dvalue;
 }
 
+/*
+ *  call-seq:
+ *    col.logical_type.alias -> String
+ *
+ *  Returns the alias of the logical type.
+ *
+ */
+static VALUE duckdb_logical_type__get_alias(VALUE self) {
+    rubyDuckDBLogicalType *ctx;
+    VALUE alias = Qnil;
+    const char *_alias;
+
+    TypedData_Get_Struct(self, rubyDuckDBLogicalType, &logical_type_data_type, ctx);
+
+    _alias = duckdb_logical_type_get_alias(ctx->logical_type);
+    if (_alias != NULL) {
+        alias = rb_utf8_str_new_cstr(_alias);
+    }
+    duckdb_free((void *)_alias);
+    return alias;
+}
+
 VALUE rbduckdb_create_logical_type(duckdb_logical_type logical_type) {
     VALUE obj;
     rubyDuckDBLogicalType *ctx;
@@ -392,4 +415,6 @@ void rbduckdb_init_duckdb_logical_type(void) {
     rb_define_method(cDuckDBLogicalType, "_internal_type", duckdb_logical_type__internal_type, 0);
     rb_define_method(cDuckDBLogicalType, "dictionary_size", duckdb_logical_type_dictionary_size, 0);
     rb_define_method(cDuckDBLogicalType, "dictionary_value_at", duckdb_logical_type_dictionary_value_at, 1);
+    rb_define_method(cDuckDBLogicalType, "alias", duckdb_logical_type_alias, 0);
+    rb_define_method(cDuckDBLogicalType, "get_alias", duckdb_logical_type__get_alias, 0);
 }

--- a/ext/duckdb/logical_type.c
+++ b/ext/duckdb/logical_type.c
@@ -22,6 +22,7 @@ static VALUE duckdb_logical_type__internal_type(VALUE self);
 static VALUE duckdb_logical_type_dictionary_size(VALUE self);
 static VALUE duckdb_logical_type_dictionary_value_at(VALUE self, VALUE didx);
 static VALUE duckdb_logical_type__get_alias(VALUE self);
+static VALUE duckdb_logical_type__set_alias(VALUE self, VALUE aname);
 
 static const rb_data_type_t logical_type_data_type = {
     "DuckDB/LogicalType",
@@ -380,6 +381,27 @@ static VALUE duckdb_logical_type__get_alias(VALUE self) {
     return alias;
 }
 
+/*
+ *  call-seq:
+ *    col.logical_type.alias(alias) -> String
+ *
+ *  Return the set alias of the logical type.
+ *
+ */
+static VALUE duckdb_logical_type__set_alias(VALUE self, VALUE aname) {
+    rubyDuckDBLogicalType *ctx;
+    VALUE alias = Qnil;
+    const char *_alias = StringValuePtr(aname);
+
+    TypedData_Get_Struct(self, rubyDuckDBLogicalType, &logical_type_data_type, ctx);
+    duckdb_logical_type_set_alias(ctx->logical_type, _alias);
+    if (_alias != NULL) {
+        alias = rb_utf8_str_new_cstr(_alias);
+    }
+
+    return alias;
+}
+
 VALUE rbduckdb_create_logical_type(duckdb_logical_type logical_type) {
     VALUE obj;
     rubyDuckDBLogicalType *ctx;
@@ -415,6 +437,6 @@ void rbduckdb_init_duckdb_logical_type(void) {
     rb_define_method(cDuckDBLogicalType, "_internal_type", duckdb_logical_type__internal_type, 0);
     rb_define_method(cDuckDBLogicalType, "dictionary_size", duckdb_logical_type_dictionary_size, 0);
     rb_define_method(cDuckDBLogicalType, "dictionary_value_at", duckdb_logical_type_dictionary_value_at, 1);
-    rb_define_method(cDuckDBLogicalType, "alias", duckdb_logical_type_alias, 0);
     rb_define_method(cDuckDBLogicalType, "get_alias", duckdb_logical_type__get_alias, 0);
+    rb_define_method(cDuckDBLogicalType, "set_alias", duckdb_logical_type__set_alias, 1);
 }

--- a/lib/duckdb/logical_type.rb
+++ b/lib/duckdb/logical_type.rb
@@ -3,6 +3,7 @@
 module DuckDB
   class LogicalType
     alias :alias get_alias
+    alias :alias= set_alias
 
     # returns logical type's type symbol
     # `:unknown` means that the logical type's type is unknown/unsupported by ruby-duckdb.

--- a/lib/duckdb/logical_type.rb
+++ b/lib/duckdb/logical_type.rb
@@ -2,6 +2,8 @@
 
 module DuckDB
   class LogicalType
+    alias :alias get_alias
+
     # returns logical type's type symbol
     # `:unknown` means that the logical type's type is unknown/unsupported by ruby-duckdb.
     # `:invalid` means that the logical type's type is invalid in duckdb.

--- a/test/duckdb_test/logical_type_test.rb
+++ b/test/duckdb_test/logical_type_test.rb
@@ -118,6 +118,13 @@ module DuckDBTest
       assert_equal(EXPECTED_TYPES, logical_types.map(&:type))
     end
 
+    def test_alias
+      enum_column = @columns.find { |column| column.type == :enum }
+      enum_logical_type = enum_column.logical_type
+      assert_equal("mood", enum_logical_type.alias=("mood"))
+      assert_equal("mood", enum_logical_type.alias)
+    end
+
     def test_decimal_internal_type
       decimal_column = @columns.find { |column| column.type == :decimal }
       assert_equal(:integer, decimal_column.logical_type.internal_type)


### PR DESCRIPTION
refs: GH-690

In this PR, we support interfaces for alias in DuckDB::Column#logical_type about the following.

- char *[duckdb_logical_type_get_alias](https://duckdb.org/docs/stable/clients/c/api.html#duckdb_logical_type_get_alias)(duckdb_logical_type type);
- void [duckdb_logical_type_set_alias](https://duckdb.org/docs/stable/clients/c/api.html#duckdb_logical_type_set_alias)(duckdb_logical_type type, const char *alias);

This is one of the steps for supporting the duckdb_logical_column_type C API.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced enhanced logical type handling that enables users to set and retrieve custom aliases through an improved, intuitive interface.
  
- **Tests**
  - Added tests to ensure the new alias functionality works as expected, verifying that aliases can be set and retrieved correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->