### PR TITLE
bump Ruby 3.3.8 on CI

### DIFF
--- a/.github/workflows/test_on_macos.yml
+++ b/.github/workflows/test_on_macos.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        ruby: ['3.1.6', '3.2.7', '3.3.7', '3.4.2', 'head']
+        ruby: ['3.1.6', '3.2.7', '3.3.8', '3.4.2', 'head']
         duckdb: ['1.2.1', '1.1.3', '1.1.1']
 
     steps:

--- a/.github/workflows/test_on_ubuntu.yml
+++ b/.github/workflows/test_on_ubuntu.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ['3.1.6', '3.2.7', '3.3.7', '3.4.2', 'head']
+        ruby: ['3.1.6', '3.2.7', '3.3.8', '3.4.2', 'head']
         duckdb: ['1.2.1', '1.1.3', '1.1.1']
 
     steps:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the automated testing setup by replacing Ruby 3.3.7 with Ruby 3.3.8 on both macOS and Ubuntu platforms, ensuring our test environments remain current and aligned with the latest Ruby improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->