### PR TITLE
bump duckdb to 1.2.2 on CI

### DIFF
--- a/.github/workflows/test_on_macos.yml
+++ b/.github/workflows/test_on_macos.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         ruby: ['3.1.6', '3.2.7', '3.3.7', '3.4.2', 'head']
-        duckdb: ['1.2.1', '1.1.3', '1.1.1']
+        duckdb: ['1.2.2', '1.1.3', '1.1.1']
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test_on_ubuntu.yml
+++ b/.github/workflows/test_on_ubuntu.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         ruby: ['3.1.6', '3.2.7', '3.3.7', '3.4.2', 'head']
-        duckdb: ['1.2.1', '1.1.3', '1.1.1']
+        duckdb: ['1.2.2', '1.1.3', '1.1.1']
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test_on_windows.yml
+++ b/.github/workflows/test_on_windows.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         ruby: ['3.1.6', '3.2.6', '3.3.6', '3.4.1', 'ucrt', 'mingw', 'mswin', 'head']
-        duckdb: ['1.2.1', '1.1.3', '1.1.1']
+        duckdb: ['1.2.2', '1.1.3', '1.1.1']
 
     steps:
     - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 # Unreleased
+- bump duckdb to 1.2.2 on CI.
 - add `DuckDB::PreparedStatement#bind_uint8`, `DuckDB::PreparedStatement#bind_uint16`,
   `DuckDB::PreparedStatement#bind_uint32`, `DuckDB::PreparedStatement#bind_uint64`.
 - add `DuckDB::LogicalType` class.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated testing workflows across platforms to use the latest dependency version.

- **Documentation**
  - Added a changelog entry reflecting the dependency update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->