### PR TITLE
create DuckDB::InstanceCache class.

### DIFF
--- a/ext/duckdb/duckdb.c
+++ b/ext/duckdb/duckdb.c
@@ -39,4 +39,7 @@ Init_duckdb_native(void) {
     rbduckdb_init_duckdb_config();
     rbduckdb_init_duckdb_converter();
     rbduckdb_init_duckdb_extracted_statements();
+#ifdef HAVE_DUCKDB_H_GE_V1_2_0
+    rbduckdb_init_duckdb_instance_cache();
+#endif
 }

--- a/ext/duckdb/instance_cache.c
+++ b/ext/duckdb/instance_cache.c
@@ -35,17 +35,15 @@ static VALUE allocate(VALUE klass) {
 
 static VALUE duckdb_instance_cache_initialize(VALUE self) {
     rubyDuckDBInstanceCache *ctx;
-    VALUE obj;
 
-    obj = allocate(cDuckDBInstanceCache);
-    TypedData_Get_Struct(obj, rubyDuckDBInstanceCache, &instance_cache_data_type, ctx);
+    TypedData_Get_Struct(self, rubyDuckDBInstanceCache, &instance_cache_data_type, ctx);
 
     ctx->instance_cache = duckdb_create_instance_cache();
     if (ctx->instance_cache == NULL) {
         rb_raise(eDuckDBError, "Failed to create instance cache");
     }
 
-    return obj;
+    return self;
 }
 
 static VALUE duckdb_instance_cache_destroy(VALUE self) {

--- a/ext/duckdb/instance_cache.c
+++ b/ext/duckdb/instance_cache.c
@@ -1,0 +1,72 @@
+#include "ruby-duckdb.h"
+
+#ifdef HAVE_DUCKDB_H_GE_V1_2_0
+VALUE cDuckDBInstanceCache;
+
+static void deallocate(void * ctx);
+static VALUE allocate(VALUE klass);
+static size_t memsize(const void *p);
+static VALUE duckdb_instance_cache_initialize(VALUE self);
+static VALUE duckdb_instance_cache_destroy(VALUE self);
+
+static const rb_data_type_t instance_cache_data_type = {
+    "DuckDB/InstanceCache",
+    {NULL, deallocate, memsize,},
+    0, 0, RUBY_TYPED_FREE_IMMEDIATELY
+};
+
+static void deallocate(void * ctx) {
+    rubyDuckDBInstanceCache *p = (rubyDuckDBInstanceCache *)ctx;
+
+    if (p->instance_cache) {
+        duckdb_destroy_instance_cache(&(p->instance_cache));
+    }
+    xfree(p);
+}
+
+static size_t memsize(const void *p) {
+    return sizeof(rubyDuckDBInstanceCache);
+}
+
+static VALUE allocate(VALUE klass) {
+    rubyDuckDBInstanceCache *ctx = xcalloc((size_t)1, sizeof(rubyDuckDBInstanceCache));
+    return TypedData_Wrap_Struct(klass, &instance_cache_data_type, ctx);
+}
+
+static VALUE duckdb_instance_cache_initialize(VALUE self) {
+    rubyDuckDBInstanceCache *ctx;
+    VALUE obj;
+
+    obj = allocate(cDuckDBInstanceCache);
+    TypedData_Get_Struct(obj, rubyDuckDBInstanceCache, &instance_cache_data_type, ctx);
+
+    ctx->instance_cache = duckdb_create_instance_cache();
+    if (ctx->instance_cache == NULL) {
+        rb_raise(eDuckDBError, "Failed to create instance cache");
+    }
+
+    return obj;
+}
+
+static VALUE duckdb_instance_cache_destroy(VALUE self) {
+    rubyDuckDBInstanceCache *ctx;
+    TypedData_Get_Struct(self, rubyDuckDBInstanceCache, &instance_cache_data_type, ctx);
+
+    if (ctx->instance_cache) {
+        duckdb_destroy_instance_cache(&(ctx->instance_cache));
+        ctx->instance_cache = NULL;
+    }
+
+    return Qnil;
+}
+
+void rbduckdb_init_duckdb_instance_cache(void) {
+#if 0
+    VALUE mDuckDB = rb_define_module("DuckDB");
+#endif
+    cDuckDBInstanceCache = rb_define_class_under(mDuckDB, "InstanceCache", rb_cObject);
+    rb_define_method(cDuckDBInstanceCache, "initialize", duckdb_instance_cache_initialize, 0);
+    rb_define_method(cDuckDBInstanceCache, "destroy", duckdb_instance_cache_destroy, 0);
+    rb_define_alloc_func(cDuckDBInstanceCache, allocate);
+}
+#endif

--- a/ext/duckdb/instance_cache.h
+++ b/ext/duckdb/instance_cache.h
@@ -1,0 +1,17 @@
+#ifndef RUBY_DUCKDB_INSTANCE_CACHE_H
+#define RUBY_DUCKDB_INSTANCE_CACHE_H
+
+#ifdef HAVE_DUCKDB_H_GE_V1_2_0
+
+struct _rubyDuckDBInstanceCache {
+    duckdb_instance_cache instance_cache;
+};
+
+typedef struct _rubyDuckDBInstanceCache rubyDuckDBInstanceCache;
+
+void rbduckdb_init_duckdb_instance_cache(void);
+
+#endif
+
+#endif
+

--- a/ext/duckdb/ruby-duckdb.h
+++ b/ext/duckdb/ruby-duckdb.h
@@ -32,6 +32,10 @@
 #include "./appender.h"
 #include "./config.h"
 
+#ifdef HAVE_DUCKDB_H_GE_V1_2_0
+#include "./instance_cache.h"
+#endif
+
 extern VALUE mDuckDB;
 extern VALUE cDuckDBDatabase;
 extern VALUE cDuckDBConnection;
@@ -42,5 +46,9 @@ extern VALUE mDuckDBConverter;
 extern VALUE cDuckDBPreparedStatement;
 extern VALUE PositiveInfinity;
 extern VALUE NegativeInfinity;
+
+#ifdef HAVE_DUCKDB_H_GE_V1_2_0
+extern VALUE cDuckDBInstanceCache;
+#endif
 
 #endif

--- a/test/duckdb_test/instance_cache_test.rb
+++ b/test/duckdb_test/instance_cache_test.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+if defined?(DuckDB::InstanceCache)
+
+module DuckDBTest
+  class InstanceCacheTest < Minitest::Test
+    def test_s_new
+      assert_instance_of DuckDB::InstanceCache, DuckDB::InstanceCache.new
+    end
+  end
+end
+
+end

--- a/test/duckdb_test/instance_cache_test.rb
+++ b/test/duckdb_test/instance_cache_test.rb
@@ -9,6 +9,11 @@ module DuckDBTest
     def test_s_new
       assert_instance_of DuckDB::InstanceCache, DuckDB::InstanceCache.new
     end
+
+    def test_destroy
+      cache = DuckDB::InstanceCache.new
+      assert_nil cache.destroy
+    end
   end
 end
 


### PR DESCRIPTION
define DuckDB::InstanceCache class.

- Currently this class do nothing.
  - The available method is `DuckDB::InstanceCache.new` only.
- This class is wrapper of duckdb_create_instance_cache.
- This class is only available with duckdb >= 1.2.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced enhanced instance caching for the DuckDB integration in Ruby, optimizing resource management and ensuring compatibility with newer DuckDB versions.
- **Tests**
	- Added test coverage to verify the proper instantiation and functioning of the new caching feature.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->