### PR TITLE
implement DuckDB::InstanceCache#get_or_create

### DIFF
--- a/.github/workflows/test_on_windows.yml
+++ b/.github/workflows/test_on_windows.yml
@@ -15,7 +15,8 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        ruby: ['3.1.6', '3.2.6', '3.3.6', '3.4.1', 'ucrt', 'mingw', 'mswin', 'head']
+        # ruby: ['3.1.6', '3.2.6', '3.3.6', '3.4.1', 'ucrt', 'mingw', 'mswin', 'head']
+        ruby: ['3.1.6', '3.2.6', '3.3.6', '3.4.1', 'ucrt', 'mingw', 'mswin']
         duckdb: ['1.2.2', '1.1.3', '1.1.1']
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 # Unreleased
+- implement `DuckDB::InstanceCache` class.
 - bump duckdb to 1.2.2 on CI.
 - add `DuckDB::PreparedStatement#bind_uint8`, `DuckDB::PreparedStatement#bind_uint16`,
   `DuckDB::PreparedStatement#bind_uint32`, `DuckDB::PreparedStatement#bind_uint64`.

--- a/ext/duckdb/database.c
+++ b/ext/duckdb/database.c
@@ -118,6 +118,14 @@ static VALUE duckdb_database_close(VALUE self) {
     return self;
 }
 
+VALUE rbduckdb_create_database_obj(duckdb_database db) {
+    VALUE obj = allocate(cDuckDBDatabase);
+    rubyDuckDB *ctx;
+    TypedData_Get_Struct(obj, rubyDuckDB, &database_data_type, ctx);
+    ctx->db = db;
+    return obj;
+}
+
 void rbduckdb_init_duckdb_database(void) {
 #if 0
     VALUE mDuckDB = rb_define_module("DuckDB");

--- a/ext/duckdb/database.h
+++ b/ext/duckdb/database.h
@@ -8,6 +8,7 @@ struct _rubyDuckDB {
 typedef struct _rubyDuckDB rubyDuckDB;
 
 rubyDuckDB *rbduckdb_get_struct_database(VALUE obj);
+VALUE rbduckdb_create_database_obj(duckdb_database db);
 void rbduckdb_init_duckdb_database(void);
 
 #endif

--- a/ext/duckdb/instance_cache.c
+++ b/ext/duckdb/instance_cache.c
@@ -74,7 +74,7 @@ static VALUE duckdb_instance_cache_get_or_create(int argc, VALUE *argv, VALUE se
         if (error) {
             VALUE message = rb_str_new_cstr(error);
             duckdb_free(error);
-            rb_raise(eDuckDBError, "%s", StringValuePtr(message))
+            rb_raise(eDuckDBError, "%s", StringValuePtr(message));
         } else {
             rb_raise(eDuckDBError, "Failed to get or create database from instance cache");
         }

--- a/ext/duckdb/instance_cache.c
+++ b/ext/duckdb/instance_cache.c
@@ -72,7 +72,9 @@ static VALUE duckdb_instance_cache_get_or_create(int argc, VALUE *argv, VALUE se
 
     if (duckdb_get_or_create_from_cache(ctx->instance_cache, path, &db, config, &error) == DuckDBError) {
         if (error) {
-            rb_raise(eDuckDBError, "%s", error);
+            VALUE message = rb_str_new_cstr(error);
+            duckdb_free(error);
+            rb_raise(eDuckDBError, "%s", StringValuePtr(message))
         } else {
             rb_raise(eDuckDBError, "Failed to get or create database from instance cache");
         }

--- a/ext/duckdb/instance_cache.c
+++ b/ext/duckdb/instance_cache.c
@@ -7,6 +7,7 @@ static void deallocate(void * ctx);
 static VALUE allocate(VALUE klass);
 static size_t memsize(const void *p);
 static VALUE duckdb_instance_cache_initialize(VALUE self);
+static VALUE duckdb_instance_cache_get_or_create(int argc, VALUE *argv, VALUE self);
 static VALUE duckdb_instance_cache_destroy(VALUE self);
 
 static const rb_data_type_t instance_cache_data_type = {
@@ -46,6 +47,39 @@ static VALUE duckdb_instance_cache_initialize(VALUE self) {
     return self;
 }
 
+static VALUE duckdb_instance_cache_get_or_create(int argc, VALUE *argv, VALUE self) {
+    VALUE vpath = Qnil;
+    VALUE vconfig = Qnil;
+    const char *path = NULL;
+    char *error = NULL;
+    duckdb_config config = NULL;
+    duckdb_database db;
+    rubyDuckDBInstanceCache *ctx;
+
+    rb_scan_args(argc, argv, "02", &vpath, &vconfig);
+    if (!NIL_P(vpath)) {
+        path = StringValuePtr(vpath);
+    }
+    if (!NIL_P(vconfig)) {
+        if (!rb_obj_is_kind_of(vconfig, cDuckDBConfig)) {
+            rb_raise(rb_eTypeError, "The second argument must be DuckDB::Config object.");
+        }
+        rubyDuckDBConfig *ctx_config = get_struct_config(vconfig);
+        config = ctx_config->config;
+    }
+
+    TypedData_Get_Struct(self, rubyDuckDBInstanceCache, &instance_cache_data_type, ctx);
+
+    if (duckdb_get_or_create_from_cache(ctx->instance_cache, path, &db, config, &error) == DuckDBError) {
+        if (error) {
+            rb_raise(eDuckDBError, "%s", error);
+        } else {
+            rb_raise(eDuckDBError, "Failed to get or create database from instance cache");
+        }
+    }
+    return rbduckdb_create_database_obj(db);
+}
+
 static VALUE duckdb_instance_cache_destroy(VALUE self) {
     rubyDuckDBInstanceCache *ctx;
     TypedData_Get_Struct(self, rubyDuckDBInstanceCache, &instance_cache_data_type, ctx);
@@ -64,6 +98,7 @@ void rbduckdb_init_duckdb_instance_cache(void) {
 #endif
     cDuckDBInstanceCache = rb_define_class_under(mDuckDB, "InstanceCache", rb_cObject);
     rb_define_method(cDuckDBInstanceCache, "initialize", duckdb_instance_cache_initialize, 0);
+    rb_define_method(cDuckDBInstanceCache, "get_or_create", duckdb_instance_cache_get_or_create, -1);
     rb_define_method(cDuckDBInstanceCache, "destroy", duckdb_instance_cache_destroy, 0);
     rb_define_alloc_func(cDuckDBInstanceCache, allocate);
 }

--- a/ext/duckdb/instance_cache.c
+++ b/ext/duckdb/instance_cache.c
@@ -47,6 +47,7 @@ static VALUE duckdb_instance_cache_initialize(VALUE self) {
     return self;
 }
 
+/* :nodoc: */
 static VALUE duckdb_instance_cache_get_or_create(int argc, VALUE *argv, VALUE self) {
     VALUE vpath = Qnil;
     VALUE vconfig = Qnil;

--- a/lib/duckdb.rb
+++ b/lib/duckdb.rb
@@ -15,6 +15,7 @@ require 'duckdb/config'
 require 'duckdb/column'
 require 'duckdb/logical_type'
 require 'duckdb/infinity'
+require 'duckdb/instance_cache'
 
 # DuckDB provides Ruby interface of DuckDB.
 module DuckDB

--- a/lib/duckdb/instance_cache.rb
+++ b/lib/duckdb/instance_cache.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+if defined?(DuckDB::InstanceCache)
+
+module DuckDB
+  # The DuckDB::InstanceCache is necessary if a client/program (re)opens
+  # multiple databases to the same file within the same statement.
+  #
+  #   require 'duckdb'
+  #   cache = DuckDB::InstanceCache.new
+  #   db1 = cache.get(path: 'db.duckdb')
+  #   db2 = cache.get(path: 'db.duckdb')
+  class InstanceCache
+    def get(path: nil, config: nil)
+      get_or_create(path, config)
+    end
+  end
+end
+
+end

--- a/lib/duckdb/instance_cache.rb
+++ b/lib/duckdb/instance_cache.rb
@@ -11,6 +11,12 @@ module DuckDB
   #   db1 = cache.get(path: 'db.duckdb')
   #   db2 = cache.get(path: 'db.duckdb')
   class InstanceCache
+    # :call-seq:
+    #   instance_cache.get(path:, config:) -> self
+    #
+    # Returns a DuckDB::Database object for the given path and config.
+    #   db1 = cache.get(path: 'db.duckdb')
+    #   db2 = cache.get(path: 'db.duckdb')
     def get(path: nil, config: nil)
       get_or_create(path, config)
     end

--- a/test/duckdb_test/instance_cache_test.rb
+++ b/test/duckdb_test/instance_cache_test.rb
@@ -50,6 +50,22 @@ module DuckDBTest
       db.close
     end
 
+    def test_get_or_create_with_config
+      cache = DuckDB::InstanceCache.new
+      config = DuckDB::Config.new
+      config['default_order'] = 'DESC'
+      db = cache.get_or_create(nil, config)
+      con = db.connect
+      con.query('CREATE TABLE numbers (number INTEGER)')
+      con.query('INSERT INTO numbers VALUES (2), (1), (4), (3)')
+
+      result = con.query('SELECT number FROM numbers ORDER BY number')
+      assert_equal(4, result.first.first)
+      con.close
+      db.close
+      cache.destroy
+    end
+
     def test_destroy
       cache = DuckDB::InstanceCache.new
       assert_nil cache.destroy

--- a/test/duckdb_test/instance_cache_test.rb
+++ b/test/duckdb_test/instance_cache_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'test_helper'
+require 'fileutils'
 
 if defined?(DuckDB::InstanceCache)
 
@@ -8,6 +9,45 @@ module DuckDBTest
   class InstanceCacheTest < Minitest::Test
     def test_s_new
       assert_instance_of DuckDB::InstanceCache, DuckDB::InstanceCache.new
+    end
+
+    def test_get_or_create
+      cache = DuckDB::InstanceCache.new
+      path = 'test_shared_db.db'
+      30.times do
+        thread = Thread.new do
+          db = cache.get_or_create(path)
+          assert_instance_of DuckDB::Database, db
+          db.close
+        end
+        db = cache.get_or_create(path)
+        assert_instance_of DuckDB::Database, db
+        db.close
+        thread.join
+
+        FileUtils.rm_f(path)
+      end
+    end
+
+    def test_get_or_create_without_path
+      cache = DuckDB::InstanceCache.new
+      db = cache.get_or_create
+      assert_instance_of DuckDB::Database, db
+      db.close
+    end
+
+    def test_get_or_create_with_empty_path
+      cache = DuckDB::InstanceCache.new
+      db = cache.get_or_create('')
+      assert_instance_of DuckDB::Database, db
+      db.close
+    end
+
+    def test_get_or_create_with_memory
+      cache = DuckDB::InstanceCache.new
+      db = cache.get_or_create(':memory:')
+      assert_instance_of DuckDB::Database, db
+      db.close
     end
 
     def test_destroy


### PR DESCRIPTION
- `DuckDB::InstanceCache#get_or_create` is wrapping C-API `duckdb_get_or_create_from_cache`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced functionality to create database objects from existing handles.
	- Implemented a caching mechanism for efficient retrieval or creation of database instances with customizable options.
	- Added a new class to manage database instances with keyword arguments for path and configuration.
- **Bug Fixes**
	- Enhanced error handling for database instance creation failures.
- **Tests**
	- Added comprehensive tests for the `get_or_create` method under various scenarios to ensure reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->