### PR TITLE
drop ruby 3.1

### DIFF
--- a/.github/workflows/test_on_macos.yml
+++ b/.github/workflows/test_on_macos.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        ruby: ['3.1.6', '3.2.7', '3.3.7', '3.4.2', 'head']
+        ruby: ['3.2.7', '3.3.7', '3.4.2', 'head']
         duckdb: ['1.2.2', '1.1.3', '1.1.1']
 
     steps:

--- a/.github/workflows/test_on_ubuntu.yml
+++ b/.github/workflows/test_on_ubuntu.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ['3.1.6', '3.2.7', '3.3.7', '3.4.2', 'head']
+        ruby: ['3.2.7', '3.3.7', '3.4.2', 'head']
         duckdb: ['1.2.2', '1.1.3', '1.1.1']
 
     steps:

--- a/.github/workflows/test_on_windows.yml
+++ b/.github/workflows/test_on_windows.yml
@@ -15,8 +15,8 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        # ruby: ['3.1.6', '3.2.6', '3.3.6', '3.4.1', 'ucrt', 'mingw', 'mswin', 'head']
-        ruby: ['3.1.6', '3.2.6', '3.3.6', '3.4.1', 'ucrt', 'mingw', 'mswin']
+        # ruby: ['3.2.6', '3.3.6', '3.4.1', 'ucrt', 'mingw', 'mswin', 'head']
+        ruby: ['3.2.6', '3.3.6', '3.4.1', 'ucrt', 'mingw', 'mswin']
         duckdb: ['1.2.2', '1.1.3', '1.1.1']
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 # Unreleased
+- drop Ruby 3.1.
 - implement `DuckDB::InstanceCache` class.
 - bump duckdb to 1.2.2 on CI.
 - add `DuckDB::PreparedStatement#bind_uint8`, `DuckDB::PreparedStatement#bind_uint16`,


### PR DESCRIPTION
Ruby 3.1 is EOL now. 
https://www.ruby-lang.org/en/downloads/branches/
So drop ruby 3.1 on CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated test workflows to remove Ruby 3.1.6 from the supported versions on macOS, Ubuntu, and Windows.
  - Updated documentation to note the removal of Ruby 3.1 support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->