### PR TITLE
bump ruby 3.3.8 on windows

### DIFF
--- a/.github/workflows/test_on_windows.yml
+++ b/.github/workflows/test_on_windows.yml
@@ -15,8 +15,8 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        # ruby: ['3.2.6', '3.3.6', '3.4.1', 'ucrt', 'mingw', 'mswin', 'head']
-        ruby: ['3.2.6', '3.3.6', '3.4.1', 'ucrt', 'mingw', 'mswin']
+        # ruby: ['3.2.6', '3.3.8', '3.4.1', 'ucrt', 'mingw', 'mswin', 'head']
+        ruby: ['3.2.6', '3.3.8', '3.4.1', 'ucrt', 'mingw', 'mswin']
         duckdb: ['1.2.2', '1.1.3', '1.1.1']
 
     steps:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the Ruby version tested in the Windows workflow to 3.3.8.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->