### PR TITLE
add ruby 3.5.0-preview1 in CI

### DIFF
--- a/.github/workflows/test_on_macos.yml
+++ b/.github/workflows/test_on_macos.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        ruby: ['3.2.7', '3.3.8', '3.4.2', 'head']
+        ruby: ['3.2.7', '3.3.8', '3.4.2', 'head', '3.5.0-preview1']
         duckdb: ['1.2.2', '1.1.3', '1.1.1']
 
     steps:

--- a/.github/workflows/test_on_ubuntu.yml
+++ b/.github/workflows/test_on_ubuntu.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ['3.2.7', '3.3.8', '3.4.2', 'head']
+        ruby: ['3.2.7', '3.3.8', '3.4.2', 'head', '3.5.0-preview1']
         duckdb: ['1.2.2', '1.1.3', '1.1.1']
 
     steps:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Expanded automated test coverage to include Ruby 3.5.0-preview1 on both macOS and Ubuntu environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->