### PR TITLE
bump duckdb v1.3.0

### DIFF
--- a/.github/workflows/test_on_macos.yml
+++ b/.github/workflows/test_on_macos.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         ruby: ['3.2.7', '3.3.8', '3.4.2', 'head', '3.5.0-preview1']
-        duckdb: ['1.2.2', '1.1.3', '1.1.1']
+        duckdb: ['1.2.2', '1.1.3', '1.1.1', '1.3.0']
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test_on_ubuntu.yml
+++ b/.github/workflows/test_on_ubuntu.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         ruby: ['3.2.7', '3.3.8', '3.4.2', 'head', '3.5.0-preview1']
-        duckdb: ['1.2.2', '1.1.3', '1.1.1']
+        duckdb: ['1.2.2', '1.1.3', '1.1.1', '1.3.0']
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test_on_windows.yml
+++ b/.github/workflows/test_on_windows.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         # ruby: ['3.2.6', '3.3.8', '3.4.1', 'ucrt', 'mingw', 'mswin', 'head']
         ruby: ['3.2.6', '3.3.8', '3.4.1', 'ucrt', 'mingw', 'mswin']
-        duckdb: ['1.2.2', '1.1.3', '1.1.1']
+        duckdb: ['1.2.2', '1.1.3', '1.1.1', '1.3.0']
 
     steps:
     - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+
 # Unreleased
+- bump duckdb to 1.3.0 on CI.
 
 # 1.2.2.0 - 2025-05-11
 - drop Ruby 3.1.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Expanded automated test coverage to include DuckDB version 1.3.0 across macOS, Ubuntu, and Windows environments.
  - Updated changelog to reflect the addition of DuckDB 1.3.0 in continuous integration testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->