### PR TITLE
remove duckdb_pending_prepared_stream.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 # Unreleased
 - bump duckdb to 1.3.0 on CI.
 
+## Breaking changes
+- The second argument of `DuckDB::PendingResult.new` is now meaningless. The result is same when it is set to true.
+
 # 1.2.2.0 - 2025-05-11
 - drop Ruby 3.1.
 - implement `DuckDB::InstanceCache` class.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 - bump duckdb to 1.3.0 on CI.
 
 ## Breaking changes
-- The second argument of `DuckDB::PendingResult.new` is now meaningless. The result is same when it is set to true.
+- The second argument of `DuckDB::PendingResult.new` is now meaningless. The result is the same when it is set to true.
 
 # 1.2.2.0 - 2025-05-11
 - drop Ruby 3.1.

--- a/ext/duckdb/pending_result.c
+++ b/ext/duckdb/pending_result.c
@@ -40,13 +40,9 @@ static VALUE duckdb_pending_result_initialize(int argc, VALUE *argv, VALUE self)
     VALUE streaming_p = Qfalse;
     duckdb_state state;
 
-    /*
-     * FIXME: The 2nd argument is deprecated and will be removed in the future.
-     * The behavior will be same as streaming.
     if (argc == 2) {
-        rb_warn("The 2nd argument is deprecated and will be removed in the future.");
+        rb_warn("The second argument of `DuckDB::PendingResult#new` is now meaningless. The result is the same when it is set to true.");
     }
-    */
     rb_scan_args(argc, argv, "11", &oDuckDBPreparedStatement, &streaming_p);
 
     if (rb_obj_is_kind_of(oDuckDBPreparedStatement, cDuckDBPreparedStatement) != Qtrue) {
@@ -56,20 +52,7 @@ static VALUE duckdb_pending_result_initialize(int argc, VALUE *argv, VALUE self)
     rubyDuckDBPendingResult *ctx = get_struct_pending_result(self);
     rubyDuckDBPreparedStatement *stmt = get_struct_prepared_statement(oDuckDBPreparedStatement);
 
-#ifdef DUCKDB_API_NO_DEPRECATED
     state = duckdb_pending_prepared(stmt->prepared_statement, &(ctx->pending_result));
-#else
-    /*
-     * FIXME: streaming_p check will be removed in the future.
-     *
-     * state = duckdb_pending_prepared(stmt->prepared_statement, &(ctx->pending_result));
-     */
-    if (!NIL_P(streaming_p) && streaming_p == Qtrue) {
-        state = duckdb_pending_prepared_streaming(stmt->prepared_statement, &(ctx->pending_result));
-    } else {
-        state = duckdb_pending_prepared(stmt->prepared_statement, &(ctx->pending_result));
-    }
-#endif
 
     if (state == DuckDBError) {
         rb_raise(eDuckDBError, "%s", duckdb_pending_error(ctx->pending_result));

--- a/test/duckdb_test/connection_test.rb
+++ b/test/duckdb_test/connection_test.rb
@@ -103,7 +103,6 @@ module DuckDBTest
       pending_result.execute_task
       sleep 0.1
       result = pending_result.execute_pending
-      assert(result.streaming?)
       assert_equal([1, 'a'], result.each.first)
     end
 


### PR DESCRIPTION
duckdb_pending_prepared_stream is deprecated. and we should use duckdb_pending_prepared only.

refs #913
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the changelog with a new "Breaking changes" section, clarifying that the second argument of the constructor for pending results is now ignored.

- **Bug Fixes**
  - Simplified behavior of pending result initialization so that the second argument no longer affects the outcome.

- **Tests**
  - Updated tests to remove checks related to the streaming status of query results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->