### PR TITLE
remove `DuckDB::Result#streaming?`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 - bump duckdb to 1.3.0 on CI.
 
 ## Breaking changes
+- `DuckDB::Result#streaming?` is deplicated.
 - The second argument of `DuckDB::PendingResult.new` is now meaningless. The result is the same when it is set to true.
 - `DuckDB::PreparedStatement#pending_prepared` behaves the same as `DuckDB::PreparedStatement#pending_prepared_stream`.
    - `DuckDB::PreparedStatement#pending_prepared_stream` will be depreacted. Use `pending_prepared` instead.

--- a/ext/duckdb/result.c
+++ b/ext/duckdb/result.c
@@ -26,7 +26,6 @@ static size_t memsize(const void *p);
 static VALUE duckdb_result_column_count(VALUE oDuckDBResult);
 static VALUE duckdb_result_rows_changed(VALUE oDuckDBResult);
 static VALUE duckdb_result_columns(VALUE oDuckDBResult);
-static VALUE duckdb_result_streaming_p(VALUE oDuckDBResult);
 static VALUE destroy_data_chunk(VALUE arg);
 static VALUE duckdb_result__chunk_each(VALUE oDuckDBResult);
 
@@ -166,22 +165,6 @@ static VALUE duckdb_result_columns(VALUE oDuckDBResult) {
         rb_ary_store(ary, col_idx, column);
     }
     return ary;
-}
-
-/*
- * :nodoc:
- */
-static VALUE duckdb_result_streaming_p(VALUE oDuckDBResult) {
-    rubyDuckDBResult *ctx;
-
-#ifdef DUCKDB_API_NO_DEPRECATED
-    return Qtrue;
-#else
-    rb_warn("`DuckDB::Result#streaming?` will be deprecated in the future.");
-    /* FIXME streaming is allways true. so this method is not useful and deprecated. */
-    TypedData_Get_Struct(oDuckDBResult, rubyDuckDBResult, &result_data_type, ctx);
-    return duckdb_result_is_streaming(ctx->result) ? Qtrue : Qfalse;
-#endif
 }
 
 static VALUE destroy_data_chunk(VALUE arg) {
@@ -877,7 +860,6 @@ void rbduckdb_init_duckdb_result(void) {
     rb_define_method(cDuckDBResult, "column_count", duckdb_result_column_count, 0);
     rb_define_method(cDuckDBResult, "rows_changed", duckdb_result_rows_changed, 0);
     rb_define_method(cDuckDBResult, "columns", duckdb_result_columns, 0);
-    rb_define_method(cDuckDBResult, "streaming?", duckdb_result_streaming_p, 0);
     rb_define_private_method(cDuckDBResult, "_chunk_each", duckdb_result__chunk_each, 0);
     rb_define_private_method(cDuckDBResult, "_chunk_stream", duckdb_result__chunk_stream, 0);
     rb_define_private_method(cDuckDBResult, "_column_type", duckdb_result__column_type, 1);

--- a/test/duckdb_test/result_chunk_each_test.rb
+++ b/test/duckdb_test/result_chunk_each_test.rb
@@ -173,11 +173,6 @@ module DuckDBTest
       end
     end
 
-    def test_streaming?
-      r = @con.query('SELECT 1')
-      assert_equal(false, r.streaming?)
-    end
-
     def prepare_test_table_and_data_for_exception
       @con.query('CREATE TABLE tests (col INTEGER)')
       @con.query('INSERT INTO tests VALUES (1), (2), (3)')


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Breaking Changes**
  - Removed the deprecated method for checking if a result is streaming from the user-facing API.
- **Documentation**
  - Updated the changelog to reflect the removal of the streaming check method.
- **Tests**
  - Removed tests related to the deprecated streaming check method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->