### PR TITLE
check duckdb >= 1.3.0 in extconf.h

### DIFF
--- a/ext/duckdb/extconf.rb
+++ b/ext/duckdb/extconf.rb
@@ -64,6 +64,9 @@ have_func('duckdb_result_error_type', 'duckdb.h')
 # check duckdb >= 1.2.0
 have_func('duckdb_create_instance_cache', 'duckdb.h')
 
+# check duckdb >= 1.3.0
+have_func('duckdb_get_table_names', 'duckdb.h')
+
 # Building with enabled DUCKDB_API_NO_DEPRECATED is failed with DuckDB v1.1.0 only.
 # DuckDB v1.1.1 is fixed this issue https://github.com/duckdb/duckdb/issues/13872.
 have_const('DUCKDB_TYPE_SQLNULL', 'duckdb.h')

--- a/ext/duckdb/ruby-duckdb.h
+++ b/ext/duckdb/ruby-duckdb.h
@@ -16,6 +16,10 @@
 #define HAVE_DUCKDB_H_GE_V1_2_0 1
 #endif
 
+#ifdef HAVE_DUCKDB_GET_TABLE_NAMES
+#define HAVE_DUCKDB_H_GE_V1_3_0 1
+#endif
+
 #include "./error.h"
 #include "./database.h"
 #include "./connection.h"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved version detection for DuckDB 1.3.0 or later, ensuring better compatibility with newer DuckDB features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->