### PR TITLE
remove use_chunck_each.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,13 @@ All notable changes to this project will be documented in this file.
 - bump duckdb to 1.3.0 on CI.
 
 ## Breaking changes
-- `DuckDB::Result#streaming?` is deplicated.
+- `DuckDB::Result#streaming?` is deprecated.
 - The second argument of `DuckDB::PendingResult.new` is now meaningless. The result is the same when it is set to true.
 - `DuckDB::PreparedStatement#pending_prepared` behaves the same as `DuckDB::PreparedStatement#pending_prepared_stream`.
    - `DuckDB::PreparedStatement#pending_prepared_stream` will be depreacted. Use `pending_prepared` instead.
 - `DuckDB::Connection#async_query` behaves the same as `DuckDB::Connection#async_query_stream`.
-   - `DuckDB::Connection#async_query_stream` will be deplicated. Use `async_query` instead.
-- remove `DuckDB::Result#chunk_each`, `DuckDB::Result.use_chunk_each`.
+   - `DuckDB::Connection#async_query_stream` will be deprecated. Use `async_query` instead.
+- `DuckDB::Result#chunk_each`, `DuckDB::Result.use_chunk_each`, `DuckDB::Result.use_chunk_each?` are deprecated.
 
 # 1.2.2.0 - 2025-05-11
 - drop Ruby 3.1.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,9 @@ All notable changes to this project will be documented in this file.
 - `DuckDB::Result#streaming?` is deprecated.
 - The second argument of `DuckDB::PendingResult.new` is now meaningless. The result is the same when it is set to true.
 - `DuckDB::PreparedStatement#pending_prepared` behaves the same as `DuckDB::PreparedStatement#pending_prepared_stream`.
-   - `DuckDB::PreparedStatement#pending_prepared_stream` will be depreacted. Use `pending_prepared` instead.
+  - `DuckDB::PreparedStatement#pending_prepared_stream` will be depreacted. Use `pending_prepared` instead.
 - `DuckDB::Connection#async_query` behaves the same as `DuckDB::Connection#async_query_stream`.
-   - `DuckDB::Connection#async_query_stream` will be deprecated. Use `async_query` instead.
+  - `DuckDB::Connection#async_query_stream` will be deprecated. Use `async_query` instead.
 - `DuckDB::Result#chunk_each`, `DuckDB::Result.use_chunk_each`, `DuckDB::Result.use_chunk_each?` are deprecated.
 
 # 1.2.2.0 - 2025-05-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
    - `DuckDB::PreparedStatement#pending_prepared_stream` will be depreacted. Use `pending_prepared` instead.
 - `DuckDB::Connection#async_query` behaves the same as `DuckDB::Connection#async_query_stream`.
    - `DuckDB::Connection#async_query_stream` will be deplicated. Use `async_query` instead.
+- remove `DuckDB::Result#chunk_each`, `DuckDB::Result.use_chunk_each`.
 
 # 1.2.2.0 - 2025-05-11
 - drop Ruby 3.1.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,13 @@ All notable changes to this project will be documented in this file.
 - bump duckdb to 1.3.0 on CI.
 
 ## Breaking changes
-- `DuckDB::Result#streaming?` is deprecated.
+- `DuckDB::Result#streaming?` is deplicated.
 - The second argument of `DuckDB::PendingResult.new` is now meaningless. The result is the same when it is set to true.
 - `DuckDB::PreparedStatement#pending_prepared` behaves the same as `DuckDB::PreparedStatement#pending_prepared_stream`.
-   - `DuckDB::PreparedStatement#pending_prepared_stream` will be deprecated. Use `pending_prepared` instead.
+   - `DuckDB::PreparedStatement#pending_prepared_stream` will be depreacted. Use `pending_prepared` instead.
 - `DuckDB::Connection#async_query` behaves the same as `DuckDB::Connection#async_query_stream`.
-   - `DuckDB::Connection#async_query_stream` will be deprecated. Use `async_query` instead.
-- `DuckDB::Result#chunk_each`, `DuckDB::Result.use_chunk_each=` `DuckDB::Result.use_chunk_each?` are deprecated.
+   - `DuckDB::Connection#async_query_stream` will be deplicated. Use `async_query` instead.
+- remove `DuckDB::Result#chunk_each`, `DuckDB::Result.use_chunk_each`.
 
 # 1.2.2.0 - 2025-05-11
 - drop Ruby 3.1.
@@ -58,10 +58,10 @@ All notable changes to this project will be documented in this file.
 - bump ruby in CI. use 3.4.2 on MacOS and Ubuntu, 3.4.1 on Windows.
 
 ## Breaking changes
-- `DuckDB::Result#row_count`, `DuckDB::Result#row_size` are ecated.
-- `DuckDB::Result#use_chunk_each?`, `DuckDB::Result#use_chunk_each=` are ecated.
-- `DuckDB::Result#chunk_each` is ecated.
--  `DuckDB::Result#each` only works at first time because duckdb_chunk_each C-API is ecated.
+- `DuckDB::Result#row_count`, `DuckDB::Result#row_size` are deprecated.
+- `DuckDB::Result#use_chunk_each?`, `DuckDB::Result#use_chunk_each=` are deprecated.
+- `DuckDB::Result#chunk_each` is deprecated.
+-  `DuckDB::Result#each` only works at first time because duckdb_chunk_each C-API is deprecated.
    Calling `DuckDB::Result#each` twice or more does not work.
    ```ruby
    result = con.query('SELECT * FROM table')
@@ -86,7 +86,7 @@ All notable changes to this project will be documented in this file.
      p record # <= this works fine.
    end
    ```
-- `DuckDB::Result#streaming?` will be ecated.
+- `DuckDB::Result#streaming?` will be deprecated.
 
 # 1.1.3.1 - 2024-11-27
 - fix to `DuckDB::Connection#query` with multiple SQL statements. Calling PreparedStatement#destroy after each statement executed.
@@ -148,7 +148,7 @@ All notable changes to this project will be documented in this file.
     `:logical_plan`, `:attach`, `:detach`, `:multi`.
 - Add `DuckDB::Result#return_type` to get the return type of the result.
   - The return value is one of the `:invalid`, `:query_result`, `:rows_changed`, `:nothing`.
-- The following method will be ecated.
+- The following method will be deprecated.
   - `DuckDB::Result#use_chunk_each?`
   - `DuckDB::Result#use_chunk_each=`
 
@@ -204,7 +204,7 @@ All notable changes to this project will be documented in this file.
 - add `DuckDB::ExtractedStatements#size`.
 - add `DuckDB::ExtractedStatements#prepared_statement`.
 - raise error when `DuckDB::ExtractedStatements#new` is called with invalid SQL.
-- The following public/private methods will be ecated.
+- The following public/private methods will be deprecated.
   - `DuckDB::Result#streaming?`
   - `DuckDB::Result#_null?`
   - `DuckDB::Result#_to_boolean`
@@ -304,7 +304,7 @@ All notable changes to this project will be documented in this file.
 - bump duckdb to 0.9.0.
 
 ## Breaking Changes
-- ecation warning when `DuckDB::Result.each` calling with `DuckDB::Result.use_chunk_each` is false.
+- deprecation warning when `DuckDB::Result.each` calling with `DuckDB::Result.use_chunk_each` is false.
   The `each` behavior will be same as `DuckDB::Result.chunk_each` in the future.
   set `DuckDB::Result.use_chunk_each = true` to suppress the warning.
 - `DuckDB::Result#chunk_each` returns `DuckDB::Interval` class when the column type is INTERVAL.
@@ -378,7 +378,7 @@ All notable changes to this project will be documented in this file.
 
 # 0.6.1
 - bump Ruby to 3.2.0 on CI
-- fix ected warning (double_heap is deprecated in GC.verify_compaction_references) with Ruby 3.2.0 on CI
+- fix deprected warning (double_heap is deprecated in GC.verify_compaction_references) with Ruby 3.2.0 on CI
 - bump duckdb to 0.6.1 on CI
 - add DuckDB::PreparedStatement#bind_hugeint_internal
 - fix gem install error on M1 MacOS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,13 @@ All notable changes to this project will be documented in this file.
 - bump duckdb to 1.3.0 on CI.
 
 ## Breaking changes
-- `DuckDB::Result#streaming?` is deplicated.
+- `DuckDB::Result#streaming?` is deprecated.
 - The second argument of `DuckDB::PendingResult.new` is now meaningless. The result is the same when it is set to true.
 - `DuckDB::PreparedStatement#pending_prepared` behaves the same as `DuckDB::PreparedStatement#pending_prepared_stream`.
-   - `DuckDB::PreparedStatement#pending_prepared_stream` will be depreacted. Use `pending_prepared` instead.
+   - `DuckDB::PreparedStatement#pending_prepared_stream` will be deprecated. Use `pending_prepared` instead.
 - `DuckDB::Connection#async_query` behaves the same as `DuckDB::Connection#async_query_stream`.
-   - `DuckDB::Connection#async_query_stream` will be deplicated. Use `async_query` instead.
-- remove `DuckDB::Result#chunk_each`, `DuckDB::Result.use_chunk_each`.
+   - `DuckDB::Connection#async_query_stream` will be deprecated. Use `async_query` instead.
+- `DuckDB::Result#chunk_each`, `DuckDB::Result.use_chunk_each=` `DuckDB::Result.use_chunk_each?` are deprecated.
 
 # 1.2.2.0 - 2025-05-11
 - drop Ruby 3.1.
@@ -58,10 +58,10 @@ All notable changes to this project will be documented in this file.
 - bump ruby in CI. use 3.4.2 on MacOS and Ubuntu, 3.4.1 on Windows.
 
 ## Breaking changes
-- `DuckDB::Result#row_count`, `DuckDB::Result#row_size` are deprecated.
-- `DuckDB::Result#use_chunk_each?`, `DuckDB::Result#use_chunk_each=` are deprecated.
-- `DuckDB::Result#chunk_each` is deprecated.
--  `DuckDB::Result#each` only works at first time because duckdb_chunk_each C-API is deprecated.
+- `DuckDB::Result#row_count`, `DuckDB::Result#row_size` are ecated.
+- `DuckDB::Result#use_chunk_each?`, `DuckDB::Result#use_chunk_each=` are ecated.
+- `DuckDB::Result#chunk_each` is ecated.
+-  `DuckDB::Result#each` only works at first time because duckdb_chunk_each C-API is ecated.
    Calling `DuckDB::Result#each` twice or more does not work.
    ```ruby
    result = con.query('SELECT * FROM table')
@@ -86,7 +86,7 @@ All notable changes to this project will be documented in this file.
      p record # <= this works fine.
    end
    ```
-- `DuckDB::Result#streaming?` will be deprecated.
+- `DuckDB::Result#streaming?` will be ecated.
 
 # 1.1.3.1 - 2024-11-27
 - fix to `DuckDB::Connection#query` with multiple SQL statements. Calling PreparedStatement#destroy after each statement executed.
@@ -148,7 +148,7 @@ All notable changes to this project will be documented in this file.
     `:logical_plan`, `:attach`, `:detach`, `:multi`.
 - Add `DuckDB::Result#return_type` to get the return type of the result.
   - The return value is one of the `:invalid`, `:query_result`, `:rows_changed`, `:nothing`.
-- The following method will be deprecated.
+- The following method will be ecated.
   - `DuckDB::Result#use_chunk_each?`
   - `DuckDB::Result#use_chunk_each=`
 
@@ -204,7 +204,7 @@ All notable changes to this project will be documented in this file.
 - add `DuckDB::ExtractedStatements#size`.
 - add `DuckDB::ExtractedStatements#prepared_statement`.
 - raise error when `DuckDB::ExtractedStatements#new` is called with invalid SQL.
-- The following public/private methods will be deprecated.
+- The following public/private methods will be ecated.
   - `DuckDB::Result#streaming?`
   - `DuckDB::Result#_null?`
   - `DuckDB::Result#_to_boolean`
@@ -304,7 +304,7 @@ All notable changes to this project will be documented in this file.
 - bump duckdb to 0.9.0.
 
 ## Breaking Changes
-- deprecation warning when `DuckDB::Result.each` calling with `DuckDB::Result.use_chunk_each` is false.
+- ecation warning when `DuckDB::Result.each` calling with `DuckDB::Result.use_chunk_each` is false.
   The `each` behavior will be same as `DuckDB::Result.chunk_each` in the future.
   set `DuckDB::Result.use_chunk_each = true` to suppress the warning.
 - `DuckDB::Result#chunk_each` returns `DuckDB::Interval` class when the column type is INTERVAL.
@@ -378,7 +378,7 @@ All notable changes to this project will be documented in this file.
 
 # 0.6.1
 - bump Ruby to 3.2.0 on CI
-- fix deprected warning (double_heap is deprecated in GC.verify_compaction_references) with Ruby 3.2.0 on CI
+- fix ected warning (double_heap is deprecated in GC.verify_compaction_references) with Ruby 3.2.0 on CI
 - bump duckdb to 0.6.1 on CI
 - add DuckDB::PreparedStatement#bind_hugeint_internal
 - fix gem install error on M1 MacOS

--- a/lib/duckdb/result.rb
+++ b/lib/duckdb/result.rb
@@ -28,36 +28,16 @@ module DuckDB
 
     alias column_size column_count
 
-    @use_chunk_each = false
-
     class << self
       def new
         raise DuckDB::Error, 'DuckDB::Result cannot be instantiated directly.'
       end
-
-      attr_writer :use_chunk_each
-
-      def use_chunk_each?
-        @use_chunk_each
-      end
     end
 
     def each(&)
-      if self.class.use_chunk_each?
-        return chunk_each unless block_given?
+      return _chunk_stream unless block_given?
 
-        chunk_each(&)
-      else
-        return _chunk_stream unless block_given?
-
-        _chunk_stream(&)
-      end
-    end
-
-    # :nodoc:
-    def chunk_each(&)
-      warn 'DuckDB::Result#chunk_each will be deprecated.'
-      _chunk_each(&)
+      _chunk_stream(&)
     end
 
     # returns return type. The return value is one of the following symbols:

--- a/test/duckdb_test/result_test.rb
+++ b/test/duckdb_test/result_test.rb
@@ -30,16 +30,6 @@ module DuckDBTest
       assert_instance_of(Enumerator, @result.each)
     end
 
-    # If using duckdb_fetch_chunk in Result#chunk_each
-    # then this test will fail.
-    def test_each_using_duckdb_fetch_chunk
-      DuckDB::Result.use_chunk_each = true
-      ary = @result.to_a # fetch again
-      assert(ary.first, 'FAILED because of using duckdb_fetch_chunk in Result#chunk_each')
-    ensure
-      DuckDB::Result.use_chunk_each = false
-    end
-
     def test_each_without_block
       # fix for using duckdb_fetch_chunk in Result#chunk_each
       result = @@con.query('SELECT * from table1')


### PR DESCRIPTION
ruby-duckdb always use duckdb_chunk_stream to read data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Breaking Changes**
	- Removed support for the `chunk_each` iteration method and the related configuration option in result handling.
- **Documentation**
	- Corrected typographical errors and added a deprecation notice in the changelog.
- **Tests**
	- Removed tests related to the `chunk_each` method and its configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->