### PR TITLE
Support TIMESTAMP_S infinity, -infinity value.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 # Unreleased
+- Support TIMESTAMP_S infinity, -infinity value when duckdb version is 1.2.0 or later.
 
 # 1.3.0.0 - 2025-05-31
 - bump duckdb to 1.3.0 on CI.

--- a/test/duckdb_test/result_each_test.rb
+++ b/test/duckdb_test/result_each_test.rb
@@ -91,6 +91,8 @@ module DuckDBTest
       [:ok, 'DECIMAL',      'DECIMAL(38, 8)',              '0.00123456489',                            BigDecimal,           BigDecimal('0.00123456')                            ],
       [:ok, 'DECIMAL',      'DECIMAL(38, 8)',              '0.00123456589',                            BigDecimal,           EXPECTED_DECIMAL_VALUE2                             ],
       [:ok, 'TIMESTAMP_S',  'TIMESTAMP_S',                 "'2019-11-03 12:34:56.123456789'",          Time,                 Time.local(2019, 11, 3, 12, 34, 56)                 ],
+      [:ng, 'TIMESTAMP_S',  'TIMESTAMP_S',                 "'infinity'",                               String,               'infinity'                                          ],
+      [:ng, 'TIMESTAMP_S',  'TIMESTAMP_S',                 "'-infinity'",                              String,               '-infinity'                                         ],
       [:ok, 'TIMESTAMP_MS', 'TIMESTAMP_MS',                "'2019-11-03 12:34:56.123456789'",          Time,                 Time.parse('2019-11-3 12:34:56.123')                ],
       [:ok, 'TIMESTAMP_NS', 'TIMESTAMP_NS',                "'2019-11-03 12:34:56.123456789'",          Time,                 Time.parse('2019-11-3 12:34:56.123456')             ],
       [:ok, 'ENUM',         'mood',                        "'happy'",                                  String,               'happy'                                             ],

--- a/test/duckdb_test/result_timestamp_s_test.rb
+++ b/test/duckdb_test/result_timestamp_s_test.rb
@@ -17,6 +17,30 @@ module DuckDBTest
       assert_equal([[Time.local(2019, 1, 2, 12, 34, 56)]], ary)
     end
 
+    def test_result_timestamp_s_infinity
+      if ::DuckDBTest.duckdb_library_version >= Gem::Version.new('1.2.0')
+        @conn.execute('CREATE TABLE test (value TIMESTAMP_S);')
+        @conn.execute("INSERT INTO test VALUES ('infinity');")
+        result = @conn.execute('SELECT value FROM test;')
+        ary = result.each.to_a
+        assert_equal([[DuckDB::Infinity::POSITIVE]], ary)
+      else
+        skip 'DuckDB version < 1.2.0 does not support infinity for TIMESTAMP_S'
+      end
+    end
+
+    def test_result_timestamp_s_negative_infinity
+      if ::DuckDBTest.duckdb_library_version >= Gem::Version.new('1.2.0')
+        @conn.execute('CREATE TABLE test (value TIMESTAMP_S);')
+        @conn.execute("INSERT INTO test VALUES ('-infinity');")
+        result = @conn.execute('SELECT value FROM test;')
+        ary = result.each.to_a
+        assert_equal([[DuckDB::Infinity::NEGATIVE]], ary)
+      else
+        skip 'DuckDB version < 1.2.0 does not support infinity for TIMESTAMP_S'
+      end
+    end
+
     def teardown
       @conn.execute('DROP TABLE test;')
       @conn.close


### PR DESCRIPTION
infinity and -infinity are available only when duckdb version is 1.2.0 or later.