### PR TITLE
drop v1.1.x on CI

### DIFF
--- a/.github/workflows/test_on_macos.yml
+++ b/.github/workflows/test_on_macos.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         ruby: ['3.2.7', '3.3.8', '3.4.2', 'head', '3.5.0-preview1']
-        duckdb: ['1.2.2', '1.1.3', '1.1.1', '1.3.1']
+        duckdb: ['1.2.2', '1.3.1']
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test_on_ubuntu.yml
+++ b/.github/workflows/test_on_ubuntu.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         ruby: ['3.2.7', '3.3.8', '3.4.2', 'head', '3.5.0-preview1']
-        duckdb: ['1.2.2', '1.1.3', '1.1.1', '1.3.1']
+        duckdb: ['1.2.2', '1.3.1']
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test_on_windows.yml
+++ b/.github/workflows/test_on_windows.yml
@@ -16,8 +16,7 @@ jobs:
     strategy:
       matrix:
         ruby: ['3.2.6', '3.3.8', '3.4.1', 'ucrt', 'mingw', 'mswin', 'head']
-        # ruby: ['3.2.6', '3.3.8', '3.4.1', 'ucrt', 'mingw', 'mswin']
-        duckdb: ['1.2.2', '1.1.3', '1.1.1', '1.3.1']
+        duckdb: ['1.2.2', '1.3.1']
 
     steps:
     - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 # Unreleased
 - Support TIMESTAMP_S, TIMESTAMP_MS infinity, -infinity value when duckdb version is 1.2.0 or later.
 - bump duckdb to 1.3.1 on CI.
+- drop dcukdb v1.1.x.
 
 # 1.3.0.0 - 2025-05-31
 - bump duckdb to 1.3.0 on CI.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated test workflows to only run against DuckDB versions 1.2.2 and 1.3.1 on all platforms.
- **Documentation**
  - Updated the changelog to note that support for DuckDB version 1.1.x has been dropped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->