### PR TITLE
drop duckdb v1.1.x.

### DIFF
--- a/ext/duckdb/duckdb.c
+++ b/ext/duckdb/duckdb.c
@@ -39,7 +39,5 @@ Init_duckdb_native(void) {
     rbduckdb_init_duckdb_config();
     rbduckdb_init_duckdb_converter();
     rbduckdb_init_duckdb_extracted_statements();
-#ifdef HAVE_DUCKDB_H_GE_V1_2_0
     rbduckdb_init_duckdb_instance_cache();
-#endif
 }

--- a/ext/duckdb/extconf.rb
+++ b/ext/duckdb/extconf.rb
@@ -2,7 +2,7 @@
 
 require 'mkmf'
 
-DUCKDB_REQUIRED_VERSION = '1.1.0'
+DUCKDB_REQUIRED_VERSION = '1.2.0'
 
 def check_duckdb_header(header, version)
   found = find_header(
@@ -56,20 +56,13 @@ end
 dir_config('duckdb')
 
 check_duckdb_header('duckdb.h', DUCKDB_REQUIRED_VERSION)
-check_duckdb_library('duckdb', 'duckdb_result_error_type', DUCKDB_REQUIRED_VERSION)
-
-# check duckdb >= 1.1.0
-have_func('duckdb_result_error_type', 'duckdb.h')
+check_duckdb_library('duckdb', 'duckdb_create_instance_cache', DUCKDB_REQUIRED_VERSION)
 
 # check duckdb >= 1.2.0
 have_func('duckdb_create_instance_cache', 'duckdb.h')
 
 # check duckdb >= 1.3.0
 have_func('duckdb_get_table_names', 'duckdb.h')
-
-# Building with enabled DUCKDB_API_NO_DEPRECATED is failed with DuckDB v1.1.0 only.
-# DuckDB v1.1.1 is fixed this issue https://github.com/duckdb/duckdb/issues/13872.
-have_const('DUCKDB_TYPE_SQLNULL', 'duckdb.h')
 
 $CFLAGS << ' -DDUCKDB_API_NO_DEPRECATED' if ENV['DUCKDB_API_NO_DEPRECATED']
 

--- a/ext/duckdb/instance_cache.c
+++ b/ext/duckdb/instance_cache.c
@@ -1,6 +1,5 @@
 #include "ruby-duckdb.h"
 
-#ifdef HAVE_DUCKDB_H_GE_V1_2_0
 VALUE cDuckDBInstanceCache;
 
 static void deallocate(void * ctx);
@@ -105,4 +104,3 @@ void rbduckdb_init_duckdb_instance_cache(void) {
     rb_define_method(cDuckDBInstanceCache, "destroy", duckdb_instance_cache_destroy, 0);
     rb_define_alloc_func(cDuckDBInstanceCache, allocate);
 }
-#endif

--- a/ext/duckdb/instance_cache.h
+++ b/ext/duckdb/instance_cache.h
@@ -1,8 +1,6 @@
 #ifndef RUBY_DUCKDB_INSTANCE_CACHE_H
 #define RUBY_DUCKDB_INSTANCE_CACHE_H
 
-#ifdef HAVE_DUCKDB_H_GE_V1_2_0
-
 struct _rubyDuckDBInstanceCache {
     duckdb_instance_cache instance_cache;
 };
@@ -12,6 +10,3 @@ typedef struct _rubyDuckDBInstanceCache rubyDuckDBInstanceCache;
 void rbduckdb_init_duckdb_instance_cache(void);
 
 #endif
-
-#endif
-

--- a/ext/duckdb/result.c
+++ b/ext/duckdb/result.c
@@ -48,11 +48,8 @@ static VALUE vector_hugeint(void* vector_data, idx_t row_idx);
 static VALUE vector_uhugeint(void* vector_data, idx_t row_idx);
 static VALUE vector_decimal(duckdb_logical_type ty, void* vector_data, idx_t row_idx);
 static VALUE infinite_timestamp_value(duckdb_timestamp timestamp);
-
-#ifdef HAVE_DUCKDB_H_GE_V1_2_0
 static VALUE infinite_timestamp_s_value(duckdb_timestamp_s timestamp_s);
 static VALUE infinite_timestamp_ms_value(duckdb_timestamp_ms timestamp_ms);
-#endif
 
 static VALUE vector_timestamp_s(void* vector_data, idx_t row_idx);
 static VALUE vector_timestamp_ms(void* vector_data, idx_t row_idx);
@@ -229,14 +226,7 @@ static VALUE duckdb_result__column_type(VALUE oDuckDBResult, VALUE col_idx) {
 static VALUE duckdb_result__return_type(VALUE oDuckDBResult) {
     rubyDuckDBResult *ctx;
     TypedData_Get_Struct(oDuckDBResult, rubyDuckDBResult, &result_data_type, ctx);
-/*
- * remove this #if ... #else statement when dropping duckdb 1.1.0.
- */
-#if !defined(HAVE_DUCKDB_H_GE_V1_1_1) && defined(DUCKDB_API_NO_DEPRECATED)
-    rb_raise(eDuckDBError, "duckdb_result_return_type C-API is not available with duckdb v1.1.0 with enabled DUCKDB_API_NO_DEPRECATED.");
-#else
     return INT2FIX(duckdb_result_return_type(ctx->result));
-#endif
 }
 
 /* :nodoc: */
@@ -444,7 +434,6 @@ static VALUE infinite_timestamp_value(duckdb_timestamp timestamp) {
     return Qnil;
 }
 
-#ifdef HAVE_DUCKDB_H_GE_V1_2_0
 static VALUE infinite_timestamp_s_value(duckdb_timestamp_s timestamp_s) {
     if (duckdb_is_finite_timestamp_s(timestamp_s) == false) {
         return rb_funcall(mDuckDBConverter, id__to_infinity, 1,
@@ -453,10 +442,8 @@ static VALUE infinite_timestamp_s_value(duckdb_timestamp_s timestamp_s) {
     }
     return Qnil;
 }
-#endif
 
 static VALUE vector_timestamp_s(void* vector_data, idx_t row_idx) {
-#ifdef HAVE_DUCKDB_H_GE_V1_2_0
     duckdb_timestamp_s data = ((duckdb_timestamp_s *)vector_data)[row_idx];
     VALUE obj = infinite_timestamp_s_value(data);
     if (obj != Qnil) {
@@ -465,15 +452,8 @@ static VALUE vector_timestamp_s(void* vector_data, idx_t row_idx) {
     return rb_funcall(mDuckDBConverter, id__to_time_from_duckdb_timestamp_s, 1,
                       LL2NUM(data.seconds)
                       );
-#else
-    duckdb_timestamp data = ((duckdb_timestamp *)vector_data)[row_idx];
-    return rb_funcall(mDuckDBConverter, id__to_time_from_duckdb_timestamp_s, 1,
-                      LL2NUM(data.micros)
-                     );
-#endif
 }
 
-#ifdef HAVE_DUCKDB_H_GE_V1_2_0
 static VALUE infinite_timestamp_ms_value(duckdb_timestamp_ms timestamp_ms) {
     if (duckdb_is_finite_timestamp_ms(timestamp_ms) == false) {
         return rb_funcall(mDuckDBConverter, id__to_infinity, 1,
@@ -482,10 +462,8 @@ static VALUE infinite_timestamp_ms_value(duckdb_timestamp_ms timestamp_ms) {
     }
     return Qnil;
 }
-#endif
 
 static VALUE vector_timestamp_ms(void* vector_data, idx_t row_idx) {
-#ifdef HAVE_DUCKDB_H_GE_V1_2_0
     duckdb_timestamp_ms data = ((duckdb_timestamp_ms *)vector_data)[row_idx];
     VALUE obj = infinite_timestamp_ms_value(data);
     if (obj != Qnil) {
@@ -494,12 +472,6 @@ static VALUE vector_timestamp_ms(void* vector_data, idx_t row_idx) {
     return rb_funcall(mDuckDBConverter, id__to_time_from_duckdb_timestamp_ms, 1,
                       LL2NUM(data.millis)
                       );
-#else
-    duckdb_timestamp data = ((duckdb_timestamp *)vector_data)[row_idx];
-    return rb_funcall(mDuckDBConverter, id__to_time_from_duckdb_timestamp_ms, 1,
-                      LL2NUM(data.micros)
-                      );
-#endif
 }
 
 static VALUE vector_timestamp_ns(void* vector_data, idx_t row_idx) {

--- a/ext/duckdb/ruby-duckdb.h
+++ b/ext/duckdb/ruby-duckdb.h
@@ -8,14 +8,6 @@
 #include "ruby/thread.h"
 #include <duckdb.h>
 
-#ifdef HAVE_CONST_DUCKDB_TYPE_SQLNULL
-#define HAVE_DUCKDB_H_GE_V1_1_1 1
-#endif
-
-#ifdef HAVE_DUCKDB_CREATE_INSTANCE_CACHE
-#define HAVE_DUCKDB_H_GE_V1_2_0 1
-#endif
-
 #ifdef HAVE_DUCKDB_GET_TABLE_NAMES
 #define HAVE_DUCKDB_H_GE_V1_3_0 1
 #endif
@@ -35,10 +27,7 @@
 #include "./blob.h"
 #include "./appender.h"
 #include "./config.h"
-
-#ifdef HAVE_DUCKDB_H_GE_V1_2_0
 #include "./instance_cache.h"
-#endif
 
 extern VALUE mDuckDB;
 extern VALUE cDuckDBDatabase;
@@ -50,9 +39,6 @@ extern VALUE mDuckDBConverter;
 extern VALUE cDuckDBPreparedStatement;
 extern VALUE PositiveInfinity;
 extern VALUE NegativeInfinity;
-
-#ifdef HAVE_DUCKDB_H_GE_V1_2_0
 extern VALUE cDuckDBInstanceCache;
-#endif
 
 #endif

--- a/test/duckdb_test/prepared_statement_test.rb
+++ b/test/duckdb_test/prepared_statement_test.rb
@@ -197,22 +197,10 @@ module DuckDBTest
       assert_raises(DuckDB::Error) { stmt.parameter_name(3) }
     end
 
-    if ::DuckDBTest.duckdb_library_version >= Gem::Version.new('1.1.0')
-      def test_bind_index_number_exception
-        stmt = DuckDB::PreparedStatement.new(@con, 'SELECT * FROM a WHERE id = $2')
-        exception = assert_raises(DuckDB::Error) { stmt.bind(2, 1) }
-        assert_equal('fail to bind 2 parameter', exception.message)
-      end
-    else
-      def test_bind_index_number_exception
-        stmt = DuckDB::PreparedStatement.new(@con, 'SELECT * FROM a WHERE id = $2')
-        stmt.bind(2, 1)
-
-        exception = assert_raises(DuckDB::Error) { stmt.execute }
-        expected = 'Binder Error: Parameter/argument count mismatch for prepared statement. Expected 2, got 1'
-
-        assert_equal(expected, exception.message)
-      end
+    def test_bind_index_number_exception
+      stmt = DuckDB::PreparedStatement.new(@con, 'SELECT * FROM a WHERE id = $2')
+      exception = assert_raises(DuckDB::Error) { stmt.bind(2, 1) }
+      assert_equal('fail to bind 2 parameter', exception.message)
     end
 
     def test_bind_bool

--- a/test/duckdb_test/result_each_test.rb
+++ b/test/duckdb_test/result_each_test.rb
@@ -22,19 +22,6 @@ module DuckDBTest
     long_bits = '11111111111111111111111111111111111110101010101010101010101010101010101010101011100000000'
     timetz_expected = Time.parse(Time.now.strftime('%Y-%m-%d 12:34:56.123456+04:30'))
 
-    EXPECTED_DECIMAL_VALUE1 = if ::DuckDBTest.duckdb_library_version >= Gem::Version.new('1.1.0')
-                                BigDecimal('1.2345679')
-                              else
-                                BigDecimal('1.23456789')
-                              end
-
-    EXPECTED_DECIMAL_VALUE2 = if ::DuckDBTest.duckdb_library_version >= Gem::Version.new('1.1.0')
-                                BigDecimal('0.00123457')
-                              else
-                                BigDecimal('0.00123456')
-                              end
-    txs = ::DuckDBTest.duckdb_library_version >= Gem::Version.new('1.2.0') ? :ok : :ng
-
     TEST_TABLES = [
       #      DB Type  ,     DB declartion                  String Rep                                  Ruby Type             Ruby Value
       [:ok, 'BOOLEAN',      'BOOLEAN',                     'true',                                     TrueClass,            true                                                ],
@@ -88,15 +75,15 @@ module DuckDBTest
       [:ok, 'DECIMAL',      'DECIMAL(38, 8)',              '-2345678901234567890123.45678901',         BigDecimal,           BigDecimal('-2345678901234567890123.45678901')      ],
       [:ok, 'DECIMAL',      'DECIMAL(38, 8)',              '1.23456789',                               BigDecimal,           BigDecimal('1.23456789')                            ],
       [:ok, 'DECIMAL',      'DECIMAL(38, 8)',              '1.234567894',                              BigDecimal,           BigDecimal('1.23456789')                            ],
-      [:ok, 'DECIMAL',      'DECIMAL(38, 8)',              '1.234567895',                              BigDecimal,           EXPECTED_DECIMAL_VALUE1                             ],
+      [:ok, 'DECIMAL',      'DECIMAL(38, 8)',              '1.234567895',                              BigDecimal,           BigDecimal('1.2345679')                             ],
       [:ok, 'DECIMAL',      'DECIMAL(38, 8)',              '0.00123456489',                            BigDecimal,           BigDecimal('0.00123456')                            ],
-      [:ok, 'DECIMAL',      'DECIMAL(38, 8)',              '0.00123456589',                            BigDecimal,           EXPECTED_DECIMAL_VALUE2                             ],
+      [:ok, 'DECIMAL',      'DECIMAL(38, 8)',              '0.00123456589',                            BigDecimal,           BigDecimal('0.00123457')                            ],
       [:ok, 'TIMESTAMP_S',  'TIMESTAMP_S',                 "'2019-11-03 12:34:56.123456789'",          Time,                 Time.local(2019, 11, 3, 12, 34, 56)                 ],
-      [txs, 'TIMESTAMP_S',  'TIMESTAMP_S',                 "'infinity'",                               String,               'infinity'                                          ],
-      [txs, 'TIMESTAMP_S',  'TIMESTAMP_S',                 "'-infinity'",                              String,               '-infinity'                                         ],
+      [:ok, 'TIMESTAMP_S',  'TIMESTAMP_S',                 "'infinity'",                               String,               'infinity'                                          ],
+      [:ok, 'TIMESTAMP_S',  'TIMESTAMP_S',                 "'-infinity'",                              String,               '-infinity'                                         ],
       [:ok, 'TIMESTAMP_MS', 'TIMESTAMP_MS',                "'2019-11-03 12:34:56.123456789'",          Time,                 Time.parse('2019-11-3 12:34:56.123')                ],
-      [txs, 'TIMESTAMP_MS', 'TIMESTAMP_MS',                "'infinity'",                               String,               'infinity'                                          ],
-      [txs, 'TIMESTAMP_MS', 'TIMESTAMP_MS',                "'-infinity'",                              String,               '-infinity'                                         ],
+      [:ok, 'TIMESTAMP_MS', 'TIMESTAMP_MS',                "'infinity'",                               String,               'infinity'                                          ],
+      [:ok, 'TIMESTAMP_MS', 'TIMESTAMP_MS',                "'-infinity'",                              String,               '-infinity'                                         ],
       [:ok, 'TIMESTAMP_NS', 'TIMESTAMP_NS',                "'2019-11-03 12:34:56.123456789'",          Time,                 Time.parse('2019-11-3 12:34:56.123456')             ],
       [:ok, 'ENUM',         'mood',                        "'happy'",                                  String,               'happy'                                             ],
       [:ok, 'LIST',         'INTEGER[]',                   '[1, 2]',                                   Array,                [1, 2]                                              ],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated minimum required DuckDB version to 1.2.0, removing support for older versions.
  - Simplified codebase by eliminating conditional logic and compilation for DuckDB versions below 1.2.0.
- **Tests**
  - Streamlined tests by removing version-dependent branches and standardizing expected results and error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->