### PR TITLE
Support TIMESTAMP_NS infinite, -infinite value.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+# Unreleased
+- Support TIMESTAMP_NS infinity, -infinity value.
+
 # 1.3.1.0 - 2025-06-28
 - Support TIMESTAMP_S, TIMESTAMP_MS infinity, -infinity value.
 - bump duckdb to 1.3.1 on CI.

--- a/ext/duckdb/result.c
+++ b/ext/duckdb/result.c
@@ -50,6 +50,7 @@ static VALUE vector_decimal(duckdb_logical_type ty, void* vector_data, idx_t row
 static VALUE infinite_timestamp_value(duckdb_timestamp timestamp);
 static VALUE infinite_timestamp_s_value(duckdb_timestamp_s timestamp_s);
 static VALUE infinite_timestamp_ms_value(duckdb_timestamp_ms timestamp_ms);
+static VALUE infinite_timestamp_ns_value(duckdb_timestamp_ns timestamp_ns);
 
 static VALUE vector_timestamp_s(void* vector_data, idx_t row_idx);
 static VALUE vector_timestamp_ms(void* vector_data, idx_t row_idx);
@@ -474,10 +475,23 @@ static VALUE vector_timestamp_ms(void* vector_data, idx_t row_idx) {
                       );
 }
 
+static VALUE infinite_timestamp_ns_value(duckdb_timestamp_ns timestamp_ns) {
+    if (duckdb_is_finite_timestamp_ns(timestamp_ns) == false) {
+        return rb_funcall(mDuckDBConverter, id__to_infinity, 1,
+                          LL2NUM(timestamp_ns.nanos)
+                         );
+    }
+    return Qnil;
+}
+
 static VALUE vector_timestamp_ns(void* vector_data, idx_t row_idx) {
-    duckdb_timestamp data = ((duckdb_timestamp *)vector_data)[row_idx];
+    duckdb_timestamp_ns data = ((duckdb_timestamp_ns *)vector_data)[row_idx];
+    VALUE obj = infinite_timestamp_ns_value(data);
+    if (obj != Qnil) {
+        return obj;
+    }
     return rb_funcall(mDuckDBConverter, id__to_time_from_duckdb_timestamp_ns, 1,
-                      LL2NUM(data.micros)
+                      LL2NUM(data.nanos)
                       );
 }
 

--- a/test/duckdb_test/result_each_test.rb
+++ b/test/duckdb_test/result_each_test.rb
@@ -85,6 +85,8 @@ module DuckDBTest
       [:ok, 'TIMESTAMP_MS', 'TIMESTAMP_MS',                "'infinity'",                               String,               'infinity'                                          ],
       [:ok, 'TIMESTAMP_MS', 'TIMESTAMP_MS',                "'-infinity'",                              String,               '-infinity'                                         ],
       [:ok, 'TIMESTAMP_NS', 'TIMESTAMP_NS',                "'2019-11-03 12:34:56.123456789'",          Time,                 Time.parse('2019-11-3 12:34:56.123456')             ],
+      [:ok, 'TIMESTAMP_NS', 'TIMESTAMP_NS',                "'infinity'",                               String,               'infinity'                                          ],
+      [:ok, 'TIMESTAMP_NS', 'TIMESTAMP_NS',                "'-infinity'",                              String,               '-infinity'                                         ],
       [:ok, 'ENUM',         'mood',                        "'happy'",                                  String,               'happy'                                             ],
       [:ok, 'LIST',         'INTEGER[]',                   '[1, 2]',                                   Array,                [1, 2]                                              ],
       [:ok, 'LIST',         'INTEGER[][]',                 '[[1, 2], [3, 4]]',                         Array,                [[1, 2], [3, 4]]                                    ],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for handling TIMESTAMP_NS values representing infinity and -infinity.

* **Bug Fixes**
  * Improved conversion of infinite TIMESTAMP_NS values to appropriate Ruby representations.

* **Tests**
  * Added tests to verify correct handling of TIMESTAMP_NS infinity and -infinity values.

* **Documentation**
  * Updated changelog with details about TIMESTAMP_NS infinity support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->