### PR TITLE
Add UDF (AKA scalar functions) support

### DIFF
--- a/ext/duckdb/connection.c
+++ b/ext/duckdb/connection.c
@@ -10,6 +10,7 @@ static VALUE duckdb_connection_interrupt(VALUE self);
 static VALUE duckdb_connection_query_progress(VALUE self);
 static VALUE duckdb_connection_connect(VALUE self, VALUE oDuckDBDatabase);
 static VALUE duckdb_connection_query_sql(VALUE self, VALUE str);
+static VALUE duckdb_connection_register_scalar_function(VALUE self, VALUE funcDef);
 
 static const rb_data_type_t connection_data_type = {
     "DuckDB/Connection",
@@ -152,6 +153,219 @@ static VALUE duckdb_connection_query_sql(VALUE self, VALUE str) {
     return result;
 }
 
+typedef struct {
+    VALUE rb_impl_val;
+    duckdb_type duckdb_return_type_id;
+    long duckdb_parameter_len;
+    duckdb_type *duckdb_parameter_type_ids;
+} scalar_function_impl_wrapper_extra_info;
+
+static const int MAX_SCALAR_FUNCTION_PARAMETERS = 16;
+
+/* :nodoc: */
+static VALUE scalar_function_impl_wrapper_impl(VALUE args) {
+    VALUE *argv = (VALUE*)args;
+    VALUE recv = argv[0];
+    ID mid = (ID)argv[1];
+    int argc = (int)argv[2];
+    VALUE *func_args = (VALUE*)argv[3];
+
+    return rb_funcallv(recv, mid, argc, func_args);
+}
+
+/* :nodoc: */
+static void scalar_function_impl_wrapper(duckdb_function_info function_info, duckdb_data_chunk input, duckdb_vector output) {
+	idx_t chunkSize = duckdb_data_chunk_get_size(input);
+
+    scalar_function_impl_wrapper_extra_info *extra_info = duckdb_scalar_function_get_extra_info(function_info);
+
+    VALUE ruby_call_args[MAX_SCALAR_FUNCTION_PARAMETERS];
+    ID call_kw = rb_intern("call");
+
+    void *input_vectors_data[MAX_SCALAR_FUNCTION_PARAMETERS];
+    for (long j = 0; j < extra_info->duckdb_parameter_len; j++) {
+        input_vectors_data[j] = duckdb_vector_get_data(duckdb_data_chunk_get_vector(input, j));
+    }
+
+    void *output_vector_data = duckdb_vector_get_data(output);
+
+	for(idx_t i = 0; i < chunkSize; i++) {
+	    // Extract parameters
+	    for (long j = 0; j < extra_info->duckdb_parameter_len; j++) {
+            // TODO: extract in its own function
+            switch(extra_info->duckdb_parameter_type_ids[j]) {
+                case DUCKDB_TYPE_VARCHAR: {
+                    duckdb_string_t duckdb_string = ((duckdb_string_t*)(input_vectors_data[j]))[i];
+                    const char *c_string = duckdb_string_t_data(&duckdb_string);
+                    VALUE ruby_string = rb_str_new_cstr(c_string);
+                    ruby_call_args[j] = ruby_string;
+                    break;
+                }
+                case DUCKDB_TYPE_INTEGER: {
+                    int32_t value = ((int32_t*)(input_vectors_data[j]))[i];
+                    ruby_call_args[j] = INT2NUM(value);
+                    break;
+                }
+                default: {
+                    // TODO: add `j` and `extra_info->duckdb_parameter_type_ids[j]` in error log
+                    duckdb_scalar_function_set_error(
+                        function_info,
+                        "Internal ruby-duckdb error: unexpected duckdb_type while handling parameter"
+                    );
+                    return;
+                }
+            }
+	    }
+
+	    int ruby_call_error;
+        VALUE args[4] = {
+            extra_info->rb_impl_val,
+            (VALUE)call_kw,
+            (VALUE)((int)(extra_info->duckdb_parameter_len)),
+            (VALUE)ruby_call_args
+        };
+        VALUE ruby_result_val = rb_protect(scalar_function_impl_wrapper_impl, (VALUE)args, &ruby_call_error);
+
+        if (ruby_call_error) {
+            VALUE ruby_err = rb_errinfo();
+            VALUE ruby_err_msg = rb_funcall(ruby_err, rb_intern("message"), 0);
+            const char* ruby_err_msg_cstr = StringValueCStr(ruby_err_msg);
+
+            const char* duckdb_error_msg_prefix = "Ruby error raise while executing the UDF: ";
+            char* duckdb_error_msg = malloc(strlen(duckdb_error_msg_prefix) + strlen(ruby_err_msg_cstr) + 1);
+            strcpy(duckdb_error_msg, duckdb_error_msg_prefix);
+            strcat(duckdb_error_msg, ruby_err_msg_cstr);
+
+            duckdb_scalar_function_set_error(function_info, duckdb_error_msg);
+            return;
+        }
+
+        if (NIL_P(ruby_result_val)) {
+            duckdb_vector_ensure_validity_writable(output);
+
+            uint64_t *validity_mask = duckdb_vector_get_validity(output);
+            duckdb_validity_set_row_invalid(validity_mask, i);
+            return;
+        }
+
+        // Convert result and store in output vector
+        // TODO: extract in its own function
+        switch(extra_info->duckdb_return_type_id) {
+            case DUCKDB_TYPE_VARCHAR: {
+                if (!RB_TYPE_P(ruby_result_val, T_STRING)) {
+                    duckdb_scalar_function_set_error(function_info, "Returned value from UDF is not a text");
+                }
+                else {
+                    duckdb_vector_assign_string_element(output, i, StringValueCStr(ruby_result_val));
+                }
+                break;
+            }
+            case DUCKDB_TYPE_INTEGER: {
+                if (!RB_TYPE_P(ruby_result_val, T_FIXNUM)) {
+                    duckdb_scalar_function_set_error(function_info, "Returned value from UDF is not an integer");
+                }
+                else {
+                    int32_t *result_data = output_vector_data;
+                    result_data[i] = NUM2INT(ruby_result_val);
+                }
+                break;
+            }
+            default: {
+                // TODO: add `extra_info->duckdb_return_type_id` in error log
+                duckdb_scalar_function_set_error(
+                    function_info,
+                    "Internal ruby-duckdb error: unexpected duckdb_type while setting output value"
+                );
+            }
+        }
+	}
+}
+
+/* :nodoc: */
+static duckdb_logical_type sym_to_duckdb_logical_type(VALUE sym) {
+    if (SYM2ID(sym) == rb_intern("text")) {
+        return duckdb_create_logical_type(DUCKDB_TYPE_VARCHAR);
+    }
+    else if (SYM2ID(sym) == rb_intern("integer")) {
+        return duckdb_create_logical_type(DUCKDB_TYPE_INTEGER);
+    }
+    else {
+        // TODO: better name
+        rb_raise(rb_eRuntimeError, "Unknown DuckDB logical type for the symbol");
+    }
+}
+
+/* :nodoc: */
+static void scalar_function_extra_info_delete_callback(void *raw_extra_info) {
+    scalar_function_impl_wrapper_extra_info *extra_info = raw_extra_info;
+
+    free(extra_info->duckdb_parameter_type_ids);
+    free(raw_extra_info);
+}
+
+/* :nodoc: */
+static VALUE duckdb_connection_register_scalar_function(VALUE self, VALUE funcDef) {
+    // Inspired from https://github.com/duckdb/duckdb/blob/8a67a5450dad6b33709b16037f775e800b147ed9/extension/demo_capi/add_numbers.cpp
+
+    rubyDuckDBConnection *ctx;
+
+    TypedData_Get_Struct(self, rubyDuckDBConnection, &connection_data_type, ctx);
+
+    VALUE scalarFuncNameVal = rb_hash_aref(funcDef, ID2SYM(rb_intern("name")));
+    VALUE scalarFuncImplVal = rb_hash_aref(funcDef, ID2SYM(rb_intern("impl")));
+    VALUE scalarFuncReturnTypeVal = rb_hash_aref(funcDef, ID2SYM(rb_intern("return_type")));
+    VALUE scalarFuncParameterTypesVal = rb_hash_aref(funcDef, ID2SYM(rb_intern("parameter_types")));
+    VALUE scalarFuncVolatileVal = rb_hash_aref(funcDef, ID2SYM(rb_intern("volatile")));
+
+    duckdb_scalar_function scalarFunc = duckdb_create_scalar_function();
+    duckdb_scalar_function_set_name(scalarFunc, StringValueCStr(scalarFuncNameVal));
+    duckdb_scalar_function_set_function(scalarFunc, scalar_function_impl_wrapper);
+
+    // Set volatile if required
+    if (scalarFuncVolatileVal == Qtrue) {
+        duckdb_scalar_function_set_volatile(scalarFunc);
+    }
+
+    // Set return type
+    duckdb_logical_type return_type = sym_to_duckdb_logical_type(scalarFuncReturnTypeVal);
+    duckdb_scalar_function_set_return_type(scalarFunc, return_type);
+
+    // Set extra information
+    scalar_function_impl_wrapper_extra_info *extra_info = malloc(sizeof(scalar_function_impl_wrapper_extra_info));
+    extra_info->rb_impl_val = scalarFuncImplVal;
+    // Is `rb_gc_mark(extra_info->rb_impl_val)` needed?
+    extra_info->duckdb_return_type_id = duckdb_get_type_id(return_type);
+    duckdb_scalar_function_set_extra_info(scalarFunc, extra_info, scalar_function_extra_info_delete_callback);
+
+    duckdb_destroy_logical_type(&return_type);
+
+    // Set parameters
+    long parameterTypesLen = RARRAY_LEN(scalarFuncParameterTypesVal);
+    if (parameterTypesLen > MAX_SCALAR_FUNCTION_PARAMETERS) {
+        rb_raise(rb_eTypeError, "Too much parameters added to the scalar function (ruby-duckdb internal limit)");
+    }
+
+    extra_info->duckdb_parameter_len = parameterTypesLen;
+    extra_info->duckdb_parameter_type_ids = malloc(parameterTypesLen * sizeof(duckdb_type));
+    for (long i = 0; i < parameterTypesLen; i++) {
+        VALUE scalarFuncParameterTypeIVal = RARRAY_AREF(scalarFuncParameterTypesVal, i);
+        duckdb_logical_type parameter_type_i = sym_to_duckdb_logical_type(scalarFuncParameterTypeIVal);
+        duckdb_scalar_function_add_parameter(scalarFunc, parameter_type_i);
+        extra_info->duckdb_parameter_type_ids[i] = duckdb_get_type_id(parameter_type_i);
+
+        duckdb_destroy_logical_type(&parameter_type_i);
+    }
+
+    // Register function
+    if (duckdb_register_scalar_function(ctx->con, scalarFunc) != DuckDBSuccess) {
+        rb_raise(rb_eTypeError, "Unable to register scalar function");
+    }
+
+    duckdb_destroy_scalar_function(&scalarFunc);
+
+    return Qnil;
+}
+
 void rbduckdb_init_duckdb_connection(void) {
 #if 0
     VALUE mDuckDB = rb_define_module("DuckDB");
@@ -165,4 +379,5 @@ void rbduckdb_init_duckdb_connection(void) {
     rb_define_private_method(cDuckDBConnection, "_connect", duckdb_connection_connect, 1);
     /* TODO: query_sql => _query_sql */
     rb_define_private_method(cDuckDBConnection, "query_sql", duckdb_connection_query_sql, 1);
+    rb_define_private_method(cDuckDBConnection, "_register_scalar_function", duckdb_connection_register_scalar_function, 1);
 }

--- a/lib/duckdb/connection.rb
+++ b/lib/duckdb/connection.rb
@@ -136,6 +136,16 @@ module DuckDB
       appender.close
     end
 
+    def register_scalar_function(name, callable = nil, return_type:, parameter_types: [], volatile: false, &block)
+      _register_scalar_function({
+        name:,
+        impl: callable || block,
+        return_type:,
+        parameter_types:,
+        volatile:
+      })
+    end
+
     private
 
     def create_appender(table)

--- a/test/duckdb_test/scalar_functions_test.rb
+++ b/test/duckdb_test/scalar_functions_test.rb
@@ -1,0 +1,206 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module DuckDBTest
+  class ScalarFunctionsTest < Minitest::Test
+    # Parameters count
+    def test_nullary_scalar_function_returning_text
+      DuckDB::Database.open do |db|
+        db.connect do |con|
+          con.register_scalar_function("my_func", return_type: :text) do
+            'Hello from ruby-duckdb'
+          end
+
+          result = con.query('SELECT my_func()')
+          assert_equal(result.column_count, 1)
+          assert_equal(result.to_a, [["Hello from ruby-duckdb"]])
+        end
+      end
+    end
+
+    def test_binary_scalar_function_returning_text
+      DuckDB::Database.open do |db|
+        db.connect do |con|
+          con.register_scalar_function("my_func", return_type: :text, parameter_types: [:text, :text]) do |x1, x2|
+            [x1, x1, x2].join("-")
+          end
+
+          result = con.query("SELECT my_func('A', 'B')")
+          assert_equal(result.column_count, 1)
+          assert_equal(result.to_a, [["A-A-B"]])
+        end
+      end
+    end
+
+    def test_binary_scalar_function_returning_integer
+      DuckDB::Database.open do |db|
+        db.connect do |con|
+          con.register_scalar_function("my_func", return_type: :integer, parameter_types: [:integer, :integer]) do |x1, x2|
+            (x1 + x1) * x2
+          end
+
+          result = con.query("SELECT my_func(2, 5)")
+          assert_equal(result.column_count, 1)
+          assert_equal(result.to_a, [[20]])
+        end
+      end
+    end
+
+    def test_scalar_with_too_much_parameters
+      DuckDB::Database.open do |db|
+        db.connect do |con|
+          error = assert_raises(StandardError) do
+            con.register_scalar_function("my_func", return_type: :integer, parameter_types: Array.new(17, :text)) do
+              nil
+            end
+          end
+          assert_equal 'Too much parameters added to the scalar function (ruby-duckdb internal limit)', error.message
+        end
+      end
+    end
+
+    # NULL handling
+    def test_binary_scalar_function_returning_null_text
+      DuckDB::Database.open do |db|
+        db.connect do |con|
+          con.register_scalar_function("my_func", return_type: :text, parameter_types: [:text, :text]) do |x1, x2|
+            nil
+          end
+
+          result = con.query("SELECT my_func('A', 'B')")
+          assert_equal(result.column_count, 1)
+          assert_equal(result.to_a, [[nil]])
+        end
+      end
+    end
+
+    # Implementation shape
+    def test_scalar_function_defined_in_a_block
+      DuckDB::Database.open do |db|
+        db.connect do |con|
+          con.register_scalar_function("my_func", return_type: :text) do
+            'From a block'
+          end
+
+          result = con.query('SELECT my_func()')
+          assert_equal(result.column_count, 1)
+          assert_equal(result.to_a, [["From a block"]])
+        end
+      end
+    end
+
+    def test_scalar_function_defined_in_a_proc
+      DuckDB::Database.open do |db|
+        db.connect do |con|
+          my_func_impl = Proc.new do
+            "From a Proc"
+          end
+
+          con.register_scalar_function("my_func", my_func_impl, return_type: :text)
+
+          result = con.query('SELECT my_func()')
+          assert_equal(result.column_count, 1)
+          assert_equal(result.to_a, [["From a Proc"]])
+        end
+      end
+    end
+
+    # Raised error during execution
+    def test_scalar_function_raising_an_error
+      DuckDB::Database.open do |db|
+        db.connect do |con|
+          con.register_scalar_function("my_func", return_type: :integer) do
+            raise StandardError, 'BOOM'
+          end
+
+          error = assert_raises(StandardError) { con.query("SELECT my_func()") }
+          assert_equal 'Invalid Input Error: Ruby error raise while executing the UDF: BOOM', error.message
+        end
+      end
+    end
+
+    # VOLATILE
+    def test_scalar_function_are_not_volatile_by_default
+      DuckDB::Database.open do |db|
+        db.connect do |con|
+          i = -3
+          con.register_scalar_function("my_func", return_type: :integer) do
+            i += 1
+          end
+
+          result = con.query("SELECT my_func() FROM range(2)")
+          assert_equal(result.column_count, 1)
+          assert_equal(result.to_a, [[-2], [-2]])
+        end
+      end
+    end
+
+    def test_scalar_function_can_be_marked_as_volatile
+      DuckDB::Database.open do |db|
+        db.connect do |con|
+          i = -3
+          con.register_scalar_function("my_func", return_type: :integer, volatile: true) do
+            i += 1
+          end
+
+          result = con.query("SELECT my_func() FROM range(2)")
+          assert_equal(result.column_count, 1)
+          assert_equal(result.to_a, [[-2], [-1]])
+        end
+      end
+    end
+
+    # TEXT type
+    def test_scalar_function_with_text_as_input_output
+      DuckDB::Database.open do |db|
+        db.connect do |con|
+          con.register_scalar_function("my_func", return_type: :text, parameter_types: [:text]) do |x1|
+            "#{x1}-world"
+          end
+
+          result = con.query("SELECT my_func('hello')")
+          assert_equal(result.column_count, 1)
+          assert_equal(result.to_a, [['hello-world']])
+        end
+      end
+    end
+
+    def test_scalar_function_invalid_text_returned
+      DuckDB::Database.open do |db|
+        db.connect do |con|
+          con.register_scalar_function("my_func", return_type: :text) { 6 }
+
+          error = assert_raises(StandardError) { con.query("SELECT my_func()") }
+          assert_equal 'Invalid Input Error: Returned value from UDF is not a text', error.message
+        end
+      end
+    end
+    
+    # INTEGER type
+    def test_scalar_function_with_integer_as_input_output
+      DuckDB::Database.open do |db|
+        db.connect do |con|
+          con.register_scalar_function("my_func", return_type: :integer, parameter_types: [:integer]) do |x1|
+            x1 + 10
+          end
+
+          result = con.query("SELECT my_func(8)")
+          assert_equal(result.column_count, 1)
+          assert_equal(result.to_a, [[18]])
+        end
+      end
+    end
+
+    def test_scalar_function_invalid_integer_returned
+      DuckDB::Database.open do |db|
+        db.connect do |con|
+          con.register_scalar_function("my_func", return_type: :integer) { 'ABC' }
+
+          error = assert_raises(StandardError) { con.query("SELECT my_func()") }
+          assert_equal 'Invalid Input Error: Returned value from UDF is not an integer', error.message
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Here is a PoC adding support for Ruby UDFs (AKA known as scalar functions, referenced in the issue https://github.com/suketa/ruby-duckdb/issues/751). It is highly inspired from the official C API [example](https://github.com/duckdb/duckdb/blob/8a67a5450dad6b33709b16037f775e800b147ed9/extension/demo_capi/add_numbers.cpp).

The API is inspired from the [Python API](https://duckdb.org/docs/stable/clients/python/function)
```ruby
DuckDB::Database.open do |db|
  db.connect do |con|
    con.register_scalar_function(
      "my_func", return_type: :integer, parameter_types: [:integer, :integer]
    ) do |x1, x2|
      (x1 + x1) * x2
    end

    result = con.query("SELECT my_func(2, 5)")
    assert_equal(result.column_count, 1)
    assert_equal(result.to_a, [[20]])
  end
end
```

More basic examples are available in `test/duckdb_test/scalar_functions_test.rb`.

The code change is more a WIP than anything else, but if you are interested about it then I would be happy to make it production ready (and if you are OK with the general structure of the change). Feedback is more than welcome.

Remaining tasks:
- [x] Support returning `nil`
- [x] Remove dynamic allocations in C function handler by fixing a maximum number of parameters
- [x] Support volatile functions
- [ ] Types support
  - [x] TEXT
  - [x] INTEGER
  - [ ] DATE
  - [ ] BOOL
  - [ ] UUID
  - [ ] ARRAY
  - [ ] STRUCT
  - [ ] MAP
- [ ] Resolve remaining TODOs

EDIT: It seems there are some segfaults in the CI, I have tested it only on macOS so far. It seems to happen only when there is an exception raised in the UDF. It can be reproduced with a IRB terminal (with `./bin/console`), with LLDB attached to it using the following script:
```rb
(0..1000).each do |n|
  DuckDB::Database.open do |db|
    db.connect do |con|
      con.register_scalar_function("my_func", return_type: :integer) do
        raise StandardError, 'BOOM'
      end

      begin
        result = con.query('SELECT my_func()')
      rescue
        nil
      end

      puts "#{Time.now} - #{n} - #{result.to_a}"
    end
  end
end
```