### PR TITLE
bump duckdb v1.3.2 on CI

### DIFF
--- a/.github/workflows/test_on_macos.yml
+++ b/.github/workflows/test_on_macos.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         ruby: ['3.2.7', '3.3.8', '3.4.2', 'head', '3.5.0-preview1']
-        duckdb: ['1.2.2', '1.3.1']
+        duckdb: ['1.2.2', '1.3.2']
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test_on_ubuntu.yml
+++ b/.github/workflows/test_on_ubuntu.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         ruby: ['3.2.7', '3.3.8', '3.4.2', 'head', '3.5.0-preview1']
-        duckdb: ['1.2.2', '1.3.1']
+        duckdb: ['1.2.2', '1.3.2']
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test_on_windows.yml
+++ b/.github/workflows/test_on_windows.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         ruby: ['3.2.6', '3.3.8', '3.4.1', 'ucrt', 'mingw', 'mswin', 'head']
-        duckdb: ['1.2.2', '1.3.1']
+        duckdb: ['1.2.2', '1.3.2']
 
     steps:
     - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 # Unreleased
 - Support TIMESTAMP_NS infinity, -infinity value.
+- bump duckdb to 1.3.2 on CI.
 
 # 1.3.1.0 - 2025-06-28
 - Support TIMESTAMP_S, TIMESTAMP_MS infinity, -infinity value.


### PR DESCRIPTION
bump duckdb v1.3.2 on CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflows to use DuckDB version 1.3.2 on macOS, Ubuntu, and Windows.
  * Updated the changelog to reflect the change in DuckDB version used in CI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->