### PR TITLE
add DuckDB::ValueImpl class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 # Unreleased
 - Support TIMESTAMP_NS infinity, -infinity value.
 - bump duckdb to 1.3.2 on CI.
+- add `DuckDB::ValueImpl` class. This class is under construction. You must not use this class directly.
 
 # 1.3.1.0 - 2025-06-28
 - Support TIMESTAMP_S, TIMESTAMP_MS infinity, -infinity value.

--- a/ext/duckdb/duckdb.c
+++ b/ext/duckdb/duckdb.c
@@ -40,4 +40,5 @@ Init_duckdb_native(void) {
     rbduckdb_init_duckdb_converter();
     rbduckdb_init_duckdb_extracted_statements();
     rbduckdb_init_duckdb_instance_cache();
+    rbduckdb_init_duckdb_value_impl();
 }

--- a/ext/duckdb/ruby-duckdb.h
+++ b/ext/duckdb/ruby-duckdb.h
@@ -28,6 +28,7 @@
 #include "./appender.h"
 #include "./config.h"
 #include "./instance_cache.h"
+#include "./value_impl.h"
 
 extern VALUE mDuckDB;
 extern VALUE cDuckDBDatabase;
@@ -40,5 +41,6 @@ extern VALUE cDuckDBPreparedStatement;
 extern VALUE PositiveInfinity;
 extern VALUE NegativeInfinity;
 extern VALUE cDuckDBInstanceCache;
+extern VALUE cDuckDBValueImpl;
 
 #endif

--- a/ext/duckdb/value_impl.c
+++ b/ext/duckdb/value_impl.c
@@ -1,0 +1,38 @@
+#include "ruby-duckdb.h"
+
+VALUE cDuckDBValueImpl;
+
+static void deallocate(void *);
+static VALUE allocate(VALUE klass);
+static size_t memsize(const void *p);
+
+static const rb_data_type_t value_impl_data_type = {
+    "DuckDB/ValueImpl",
+    {NULL, deallocate, memsize,},
+    0, 0, RUBY_TYPED_FREE_IMMEDIATELY
+};
+
+static void deallocate(void * ctx) {
+    rubyDuckDBValueImpl *p = (rubyDuckDBValueImpl *)ctx;
+
+    duckdb_destroy_value(&(p->value));
+    xfree(p);
+}
+
+static VALUE allocate(VALUE klass) {
+    rubyDuckDBValueImpl *ctx = xcalloc((size_t)1, sizeof(rubyDuckDBValueImpl));
+    return TypedData_Wrap_Struct(klass, &value_impl_data_type, ctx);
+}
+
+static size_t memsize(const void *p) {
+    return sizeof(rubyDuckDBValueImpl);
+}
+
+void rbduckdb_init_duckdb_value_impl(void) {
+#if 0
+    VALUE mDuckDB = rb_define_module("DuckDB");
+#endif
+    cDuckDBValueImpl = rb_define_class_under(mDuckDB, "ValueImpl", rb_cObject);
+    rb_define_alloc_func(cDuckDBValueImpl, allocate);
+}
+

--- a/ext/duckdb/value_impl.h
+++ b/ext/duckdb/value_impl.h
@@ -1,0 +1,13 @@
+#ifndef RUBY_DUCKDB_VALUE_IMPL_H
+#define RUBY_DUCKDB_VALUE_IMPL_H
+
+struct _rubyDuckDBValueImpl {
+    duckdb_value value;
+};
+
+typedef struct _rubyDuckDBValueImpl rubyDuckDBValueImpl;
+
+void rbduckdb_init_duckdb_value_impl(void);
+
+#endif
+


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new internal class, DuckDB::ValueImpl, as part of the DuckDB Ruby extension. This class is currently under construction and not intended for direct user interaction.

* **Documentation**
  * Updated the changelog to reflect the addition of DuckDB::ValueImpl.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->