### PR TITLE
Fix getduckdb.sh with DuckDB >= 1.3.0

### DIFF
--- a/getduckdb.sh
+++ b/getduckdb.sh
@@ -3,8 +3,16 @@
 MACHINE=`uname -m`
 
 case "$MACHINE" in
-  "x86_64" ) ARC=amd64 ;;
-  "aarch64" ) ARC=aarch64 ;;
+  "x86_64")
+    ARCH=amd64
+    ;;
+  "aarch64")
+    if printf '%s\n' '1.3.0' "$DUCKDB_VERSION" | sort -C -V; then
+      ARCH=arm64
+    else
+      ARCH=aarch64
+    fi
+    ;;
 esac
 
-wget -O duckdb.zip "https://github.com/duckdb/duckdb/releases/download/v$DUCKDB_VERSION/libduckdb-linux-$ARC.zip"
+wget -O duckdb.zip "https://github.com/duckdb/duckdb/releases/download/v$DUCKDB_VERSION/libduckdb-linux-$ARCH.zip"


### PR DESCRIPTION
Since https://github.com/duckdb/duckdb/pull/16119 in [DuckDB 1.3.0](https://github.com/duckdb/duckdb/releases/tag/v1.3.0), assets use `arm64` prefix for Linux instead of `aarch64`. This change fixes `getduckdb.sh` to support both.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved architecture detection and handling for different machine types, including better support for `aarch64` and version-specific adjustments.  
* **Chores**
  * Updated script for clearer variable naming and improved compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->