### PR TITLE
add DuckDB::ScalarFunction class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 - Support TIMESTAMP_NS infinity, -infinity value.
 - bump duckdb to 1.3.2 on CI.
 - add `DuckDB::ValueImpl` class. This class is under construction. You must not use this class directly.
+- add `DuckDB::ScalarFunction` class. This class is under construction.
 
 # 1.3.1.0 - 2025-06-28
 - Support TIMESTAMP_S, TIMESTAMP_MS infinity, -infinity value.

--- a/ext/duckdb/duckdb.c
+++ b/ext/duckdb/duckdb.c
@@ -41,4 +41,5 @@ Init_duckdb_native(void) {
     rbduckdb_init_duckdb_extracted_statements();
     rbduckdb_init_duckdb_instance_cache();
     rbduckdb_init_duckdb_value_impl();
+    rbduckdb_init_duckdb_scalar_function();
 }

--- a/ext/duckdb/ruby-duckdb.h
+++ b/ext/duckdb/ruby-duckdb.h
@@ -29,6 +29,7 @@
 #include "./config.h"
 #include "./instance_cache.h"
 #include "./value_impl.h"
+#include "./scalar_function.h"
 
 extern VALUE mDuckDB;
 extern VALUE cDuckDBDatabase;
@@ -42,5 +43,6 @@ extern VALUE PositiveInfinity;
 extern VALUE NegativeInfinity;
 extern VALUE cDuckDBInstanceCache;
 extern VALUE cDuckDBValueImpl;
+extern VALUE cDuckDBScalarFunction;
 
 #endif

--- a/ext/duckdb/scalar_function.c
+++ b/ext/duckdb/scalar_function.c
@@ -1,0 +1,36 @@
+#include "ruby-duckdb.h"
+
+VALUE cDuckDBScalarFunction;
+
+static void deallocate(void *);
+static VALUE allocate(VALUE klass);
+static size_t memsize(const void *p);
+
+static const rb_data_type_t scalar_function_data_type = {
+    "DuckDB/ScalarFunction",
+    {NULL, deallocate, memsize,},
+    0, 0, RUBY_TYPED_FREE_IMMEDIATELY
+};
+
+static void deallocate(void * ctx) {
+    rubyDuckDBScalarFunction *p = (rubyDuckDBScalarFunction *)ctx;
+    duckdb_destroy_scalar_function(&(p->scalar_function));
+    xfree(p);
+}
+
+static VALUE allocate(VALUE klass) {
+    rubyDuckDBScalarFunction *ctx = xcalloc((size_t)1, sizeof(rubyDuckDBScalarFunction));
+    return TypedData_Wrap_Struct(klass, &scalar_function_data_type, ctx);
+}
+
+static size_t memsize(const void *p) {
+    return sizeof(rubyDuckDBScalarFunction);
+}
+
+void rbduckdb_init_duckdb_scalar_function(void) {
+#if 0
+    VALUE mDuckDB = rb_define_module("DuckDB");
+#endif
+    cDuckDBScalarFunction = rb_define_class_under(mDuckDB, "ScalarFunction", rb_cObject);
+    rb_define_alloc_func(cDuckDBScalarFunction, allocate);
+}

--- a/ext/duckdb/scalar_function.h
+++ b/ext/duckdb/scalar_function.h
@@ -1,0 +1,14 @@
+#ifndef RUBY_DUCKDB_SCALAR_FUNCTION_H
+#define RUBY_DUCKDB_SCALAR_FUNCTION_H
+
+struct _rubyDuckDBScalarFunction {
+    duckdb_scalar_function scalar_function;
+};
+
+typedef struct _rubyDuckDBScalarFunction rubyDuckDBScalarFunction;
+
+void rbduckdb_init_duckdb_scalar_function(void);
+
+#endif
+
+


### PR DESCRIPTION
This is the first step of DuckDB::ScalarFunction class. Currently, this class does nothing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced the `DuckDB::ScalarFunction` class (currently under construction) to the Ruby extension, laying the groundwork for future scalar function support.

* **Documentation**
  * Updated the changelog to include the addition of the `DuckDB::ScalarFunction` class.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->