### PR TITLE
add DuckDB::ScalarFunction#set_name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 - bump duckdb to 1.3.2 on CI.
 - add `DuckDB::ValueImpl` class. This class is under construction. You must not use this class directly.
 - add `DuckDB::ScalarFunction` class. This class is under construction.
+- add `DuckDB::ScalarFunction#set_name`.
 
 # 1.3.1.0 - 2025-06-28
 - Support TIMESTAMP_S, TIMESTAMP_MS infinity, -infinity value.

--- a/ext/duckdb/scalar_function.c
+++ b/ext/duckdb/scalar_function.c
@@ -6,6 +6,7 @@ static void deallocate(void *);
 static VALUE allocate(VALUE klass);
 static size_t memsize(const void *p);
 static VALUE duckdb_scalar_function_initialize(VALUE self);
+static VALUE rbduckdb_scalar_function_set_name(VALUE self, VALUE name);
 
 static const rb_data_type_t scalar_function_data_type = {
     "DuckDB/ScalarFunction",
@@ -35,6 +36,16 @@ static VALUE duckdb_scalar_function_initialize(VALUE self) {
     return self;
 }
 
+static VALUE rbduckdb_scalar_function_set_name(VALUE self, VALUE name) {
+    rubyDuckDBScalarFunction *p;
+    TypedData_Get_Struct(self, rubyDuckDBScalarFunction, &scalar_function_data_type, p);
+
+    const char *str = StringValuePtr(name);
+    duckdb_scalar_function_set_name(p->scalar_function, str);
+
+    return self;
+}
+
 void rbduckdb_init_duckdb_scalar_function(void) {
 #if 0
     VALUE mDuckDB = rb_define_module("DuckDB");
@@ -42,4 +53,5 @@ void rbduckdb_init_duckdb_scalar_function(void) {
     cDuckDBScalarFunction = rb_define_class_under(mDuckDB, "ScalarFunction", rb_cObject);
     rb_define_alloc_func(cDuckDBScalarFunction, allocate);
     rb_define_method(cDuckDBScalarFunction, "initialize", duckdb_scalar_function_initialize, 0);
+    rb_define_method(cDuckDBScalarFunction, "set_name", rbduckdb_scalar_function_set_name, 1);
 }

--- a/test/duckdb_test/scalar_function_test.rb
+++ b/test/duckdb_test/scalar_function_test.rb
@@ -8,5 +8,12 @@ module DuckDBTest
       sf = DuckDB::ScalarFunction.new
       assert_instance_of DuckDB::ScalarFunction, sf
     end
+
+    def test_set_name
+      sf = DuckDB::ScalarFunction.new
+      sf1 = sf.set_name('test_function')
+      assert_instance_of DuckDB::ScalarFunction, sf1
+      assert_equal sf1.__id__, sf.__id__
+    end
   end
 end


### PR DESCRIPTION
Thin wrapper of duckdb_scalar_function_set_name duckdb CAPI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new method to set the name of scalar functions.
* **Documentation**
  * Updated the changelog to include the new scalar function naming feature.
* **Tests**
  * Added tests to verify the new scalar function naming capability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->