### PR TITLE
feat: Add DuckDB::LogicalType.new

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 - bump duckdb to 1.3.2 on CI.
 - add `DuckDB::ValueImpl` class. This class is under construction. You must not use this class directly.
 - add `DuckDB::ScalarFunction` class. This class is under construction.
+- add `DuckDB::LogicalType.new(type_id)` to create a logical type from a type ID.
 
 # 1.3.1.0 - 2025-06-28
 - Support TIMESTAMP_S, TIMESTAMP_MS infinity, -infinity value.

--- a/test/duckdb_test/logical_type_test.rb
+++ b/test/duckdb_test/logical_type_test.rb
@@ -244,6 +244,26 @@ module DuckDBTest
       assert_equal(["sad", "ok", "happy", "𝘾𝝾օɭ 😎"], dictionary_values)
     end
 
+    # This test is for the new DuckDB::LogicalType.new method.
+    def test_new
+      # DUCKDB_TYPE_INTEGER = 4
+      int_type = DuckDB::LogicalType.new(4)
+      assert_instance_of(DuckDB::LogicalType, int_type)
+      assert_equal(:integer, int_type.type)
+
+      # DUCKDB_TYPE_VARCHAR = 17
+      varchar_type = DuckDB::LogicalType.new(17)
+      assert_instance_of(DuckDB::LogicalType, varchar_type)
+      assert_equal(:varchar, varchar_type.type)
+    end
+
+    def test_new_with_invalid_type
+      # Using a currently unassigned integer value
+      assert_raises(ArgumentError) do
+        DuckDB::LogicalType.new(999)
+      end
+    end
+
     private
 
     def create_data(con)


### PR DESCRIPTION
This commit introduces the `DuckDB::LogicalType.new` method, allowing for the creation of logical type objects from a primitive type ID.

The implementation includes:
- A C-level `initialize` function for the `LogicalType` class that accepts an integer type ID.
- Validation to ensure that only valid and supported type IDs can be used, raising an `ArgumentError` for invalid IDs.
- Unit tests to verify the correct creation of logical types and the proper handling of invalid inputs.