### PR TITLE
Add ruby duckdb_api for inclusion in PRAGMA user_agent

### DIFF
--- a/test/duckdb_test/config_test.rb
+++ b/test/duckdb_test/config_test.rb
@@ -55,5 +55,25 @@ module DuckDBTest
         DuckDB::Database.open(nil, config)
       end
     end
+
+    def test_duckdb_api_config_set_to_ruby
+      # Test with default database (no config)
+      db = DuckDB::Database.open
+      conn = db.connect
+      result = conn.query('PRAGMA user_agent')
+      user_agent = result.first[0]
+      assert_includes(user_agent.downcase, 'ruby', "User agent should contain 'ruby', but got: #{user_agent}")
+      db.close
+
+      # Test with custom config
+      config = DuckDB::Config.new
+      config.set_config('threads', '2')
+      db = DuckDB::Database.open(nil, config)
+      conn = db.connect
+      result = conn.query('PRAGMA user_agent')
+      user_agent = result.first[0]
+      assert_includes(user_agent.downcase, 'ruby', "User agent should contain 'ruby' even with custom config, but got: #{user_agent}")
+      db.close
+    end
   end
 end


### PR DESCRIPTION
DuckDB has had `PRAGMA user_agent` for a while, with all language APIs built on the C API showing up as a generic `capi` (full user_agent would be `duckdb/v1.3.1(linux_amd64) capi`. After this PR, the user_agent is `duckdb/v1.3.2(linux_amd64) ruby`.

Another possible implementation here would be to have `duckdb_database_s_open_ext()` delegate to `duckdb_database_s_open()` if the configuration is missing. That would make `need_destroy_config` unnecessary, but the two open methods are completely separate right now, and I opted to keep the current code structure.
