### PR TITLE
bump ruby minor versions.

### DIFF
--- a/.github/workflows/test_on_macos.yml
+++ b/.github/workflows/test_on_macos.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        ruby: ['3.2.7', '3.3.8', '3.4.2', 'head', '3.5.0-preview1']
+        ruby: ['3.2.9', '3.3.9', '3.4.7', 'head', '3.5.0-preview1']
         duckdb: ['1.2.2', '1.3.2']
 
     steps:

--- a/.github/workflows/test_on_ubuntu.yml
+++ b/.github/workflows/test_on_ubuntu.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ['3.2.7', '3.3.8', '3.4.2', 'head', '3.5.0-preview1']
+        ruby: ['3.2.9', '3.3.9', '3.4.6', 'head', '3.5.0-preview1']
         duckdb: ['1.2.2', '1.3.2']
 
     steps:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated continuous integration to test against newer Ruby patch releases on macOS and Ubuntu (3.2.9, 3.3.9; macOS uses 3.4.7, Ubuntu uses 3.4.6), alongside head and 3.5.0-preview1.
  * Improves test coverage and confidence across supported environments without altering test logic.

* **Chores**
  * Routine maintenance of platform test matrices to keep pace with latest stable Ruby versions.
  * No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->