### PR TITLE
bump ruby 3.4.7 on ubuntu

### DIFF
--- a/.github/workflows/test_on_ubuntu.yml
+++ b/.github/workflows/test_on_ubuntu.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ['3.2.9', '3.3.9', '3.4.6', 'head', '3.5.0-preview1']
+        ruby: ['3.2.9', '3.3.9', '3.4.7', 'head', '3.5.0-preview1']
         duckdb: ['1.4.1', '1.3.2']
 
     steps:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Ubuntu-based CI workflow to use Ruby 3.4.7 for test runs, aligning with the latest patch level.
  * No user-facing changes; improves test environment consistency and stability across builds.
  * All other workflow steps remain unchanged, ensuring continued coverage while keeping the pipeline up to date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->