### PR TITLE
bump duckdb 1.4.2

### DIFF
--- a/.github/workflows/test_on_macos.yml
+++ b/.github/workflows/test_on_macos.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         ruby: ['3.2.9', '3.3.10', '3.4.7', 'head', '3.5.0-preview1']
-        duckdb: ['1.4.1', '1.3.2']
+        duckdb: ['1.4.2', '1.3.2']
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test_on_ubuntu.yml
+++ b/.github/workflows/test_on_ubuntu.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         ruby: ['3.2.9', '3.3.10', '3.4.7', 'head', '3.5.0-preview1']
-        duckdb: ['1.4.1', '1.3.2']
+        duckdb: ['1.4.2', '1.3.2']
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test_on_windows.yml
+++ b/.github/workflows/test_on_windows.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         ruby: ['3.2.9', '3.3.10', '3.4.7', 'ucrt', 'mingw', 'mswin', 'head']
-        duckdb: ['1.4.1', '1.3.2']
+        duckdb: ['1.4.2', '1.3.2']
 
     steps:
     - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 # Unreleased
 - drop duckdb v1.2.x.
 - bump duckdb to 1.3.0.
+- bump duckdb to 1.4.2 on CI.
 
 # 1.4.1.1 - 2025-11-03
 - DuckDB::Connection#appender_from_query accepts block.

--- a/test/duckdb_test/database_test.rb
+++ b/test/duckdb_test/database_test.rb
@@ -39,7 +39,7 @@ module DuckDBTest
 
     def test_s_open_with_config
       library_version = Gem::Version.new(DuckDB::LIBRARY_VERSION)
-      skip 'config test' if %w[1.4.0 1.4.1].include?(library_version.to_s)
+      skip 'config test' if %w[1.4.0 1.4.1 1.4.2].include?(library_version.to_s)
 
       config = DuckDB::Config.new
       config['default_order'] = 'DESC'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated DuckDB to version 1.4.2 in CI test workflows
  * Updated test configuration to support the new DuckDB version

<!-- end of auto-generated comment: release notes by coderabbit.ai -->