### PR TITLE
Add DuckDB::ScalarFunction#set_return_type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 # Unreleased
+- add DuckDB::ScalarFunction#set_return_type.
 
 # 1.4.3.0 - 2026-01-10
 - bump duckdb to 1.4.3 on CI.

--- a/ext/duckdb/scalar_function.c
+++ b/ext/duckdb/scalar_function.c
@@ -7,6 +7,7 @@ static VALUE allocate(VALUE klass);
 static size_t memsize(const void *p);
 static VALUE duckdb_scalar_function_initialize(VALUE self);
 static VALUE rbduckdb_scalar_function_set_name(VALUE self, VALUE name);
+static VALUE rbduckdb_scalar_function_set_return_type(VALUE self, VALUE logical_type);
 
 static const rb_data_type_t scalar_function_data_type = {
     "DuckDB/ScalarFunction",
@@ -46,6 +47,18 @@ static VALUE rbduckdb_scalar_function_set_name(VALUE self, VALUE name) {
     return self;
 }
 
+static VALUE rbduckdb_scalar_function_set_return_type(VALUE self, VALUE logical_type) {
+    rubyDuckDBScalarFunction *p;
+    rubyDuckDBLogicalType *lt;
+    
+    TypedData_Get_Struct(self, rubyDuckDBScalarFunction, &scalar_function_data_type, p);
+    lt = get_struct_logical_type(logical_type);
+    
+    duckdb_scalar_function_set_return_type(p->scalar_function, lt->logical_type);
+    
+    return self;
+}
+
 void rbduckdb_init_duckdb_scalar_function(void) {
 #if 0
     VALUE mDuckDB = rb_define_module("DuckDB");
@@ -54,4 +67,5 @@ void rbduckdb_init_duckdb_scalar_function(void) {
     rb_define_alloc_func(cDuckDBScalarFunction, allocate);
     rb_define_method(cDuckDBScalarFunction, "initialize", duckdb_scalar_function_initialize, 0);
     rb_define_method(cDuckDBScalarFunction, "set_name", rbduckdb_scalar_function_set_name, 1);
+    rb_define_method(cDuckDBScalarFunction, "set_return_type", rbduckdb_scalar_function_set_return_type, 1);
 }

--- a/test/duckdb_test/scalar_function_test.rb
+++ b/test/duckdb_test/scalar_function_test.rb
@@ -15,5 +15,13 @@ module DuckDBTest
       assert_instance_of DuckDB::ScalarFunction, sf1
       assert_equal sf1.__id__, sf.__id__
     end
+
+    def test_set_return_type
+      sf = DuckDB::ScalarFunction.new
+      logical_type = DuckDB::LogicalType.new(4) # DUCKDB_TYPE_INTEGER
+      sf1 = sf.set_return_type(logical_type)
+      assert_instance_of DuckDB::ScalarFunction, sf1
+      assert_equal sf1.__id__, sf.__id__
+    end
   end
 end


### PR DESCRIPTION
Implements `set_return_type` method for ScalarFunction to configure the return type of custom scalar functions.

- Added `set_return_type(logical_type)` method that accepts a LogicalType object
- Returns self for method chaining
- Added test coverage
- All tests pass (439 runs, 1105 assertions)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `set_return_type` method for the ScalarFunction class, enabling developers to dynamically configure return types for custom scalar functions using LogicalType parameters. This new capability enhances function definition flexibility and provides greater control over scalar function behavior when implementing custom database functions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->