### PR TITLE
Add RuboCop for code style checking

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,24 @@
+plugins:
+  - rubocop-minitest
+  - rubocop-rake
+
+AllCops:
+  NewCops: enable
+  TargetRubyVersion: 3.2
+  Exclude:
+    - 'vendor/**/*'
+    - 'tmp/**/*'
+    - 'pkg/**/*'
+    - 'ext/**/*'
+    - 'benchmark/**/*'
+
+Metrics/BlockLength:
+  Exclude:
+    - 'test/**/*'
+    - 'duckdb.gemspec'
+
+Style/Documentation:
+  Enabled: false
+
+Layout/LineLength:
+  Max: 120

--- a/Gemfile
+++ b/Gemfile
@@ -11,3 +11,7 @@ end
 if /linux/ =~ RUBY_PLATFORM
   gem 'ruby_memcheck'
 end
+
+gem 'rubocop', require: false
+gem 'rubocop-minitest', require: false
+gem 'rubocop-rake', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,8 +7,12 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    ast (2.4.3)
     benchmark-ips (2.14.0)
     bigdecimal (4.0.1)
+    json (2.18.0)
+    language_server-protocol (3.17.0.5)
+    lint_roller (1.1.0)
     mini_portile2 (2.8.9)
     minitest (6.0.1)
       prism (~> 1.5)
@@ -25,14 +29,45 @@ GEM
       racc (~> 1.4)
     nokogiri (1.19.0-x86_64-linux-gnu)
       racc (~> 1.4)
+    parallel (1.27.0)
+    parser (3.3.10.1)
+      ast (~> 2.4.1)
+      racc
     prism (1.8.0)
     racc (1.8.1)
+    rainbow (3.1.1)
     rake (13.3.1)
     rake-compiler (1.3.1)
       rake
+    regexp_parser (2.11.3)
+    rubocop (1.82.1)
+      json (~> 2.3)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.1.0)
+      parallel (~> 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 2.9.3, < 3.0)
+      rubocop-ast (>= 1.48.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 4.0)
+    rubocop-ast (1.49.0)
+      parser (>= 3.3.7.2)
+      prism (~> 1.7)
+    rubocop-minitest (0.38.2)
+      lint_roller (~> 1.1)
+      rubocop (>= 1.75.0, < 2.0)
+      rubocop-ast (>= 1.38.0, < 2.0)
+    rubocop-rake (0.7.1)
+      lint_roller (~> 1.1)
+      rubocop (>= 1.72.1)
+    ruby-progressbar (1.13.0)
     ruby_memcheck (3.0.1)
       nokogiri
     stackprof (0.2.27)
+    unicode-display_width (3.2.0)
+      unicode-emoji (~> 4.1)
+    unicode-emoji (4.2.0)
 
 PLATFORMS
   aarch64-linux
@@ -49,6 +84,9 @@ DEPENDENCIES
   minitest (~> 6.0)
   rake (~> 13.0)
   rake-compiler
+  rubocop
+  rubocop-minitest
+  rubocop-rake
   ruby_memcheck
   stackprof
 


### PR DESCRIPTION
This PR adds RuboCop to the project for automated code style checking.

## Changes
- Added `rubocop`, `rubocop-minitest`, and `rubocop-rake` gems to Gemfile
- Created `.rubocop.yml` configuration file with project-specific settings
- Configured to target Ruby 3.2
- Excluded `ext/`, `benchmark/`, `tmp/`, `pkg/`, and `vendor/` directories from checks
- Set max line length to 120 characters
- Disabled documentation checks
- Allowed longer blocks in tests and gemspec

Note: Fixing existing RuboCop violations will be handled in a separate PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added code linting and static analysis tooling to enforce development standards and improve code quality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->