### PR TITLE
Fix RuboCop violations in Gemfile and Rakefile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 # Specify your gem's dependencies in duckdb.gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,12 +1,13 @@
+# frozen_string_literal: true
+
 require 'bundler/gem_tasks'
 require 'rake/testtask'
 ruby_memcheck_avaiable = begin
-                           require 'ruby_memcheck'
-                           true
-                         rescue LoadError
-                           false
-                         end
-
+  require 'ruby_memcheck'
+  true
+rescue LoadError
+  false
+end
 
 if ruby_memcheck_avaiable
   RubyMemcheck.config(
@@ -31,6 +32,7 @@ end
 
 require 'rake/extensiontask'
 
+desc 'Build the gem'
 task build: :compile
 
 Rake::ExtensionTask.new('duckdb_native') do |ext|


### PR DESCRIPTION
This PR fixes RuboCop violations in Gemfile and Rakefile.

## Changes
- Added frozen_string_literal comments to both files
- Fixed indentation in begin-rescue-end block in Rakefile
- Added description to the build task in Rakefile

All RuboCop checks now pass for these files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build system configuration and internal tooling.

* **Style**
  * Applied code formatting improvements for consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->