### PR TITLE
Fix rubocop offenses in duckdb.gemspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,12 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in duckdb.gemspec
 gemspec
 
+gem 'bundler', '~> 4.0'
+gem 'irb'
+gem 'minitest', '~> 6.0'
+gem 'rake', '~> 13.0'
+gem 'rake-compiler'
+
 if /(linux|darwin)/ =~ RUBY_PLATFORM
   gem 'benchmark-ips'
   gem 'stackprof'

--- a/duckdb.gemspec
+++ b/duckdb.gemspec
@@ -11,7 +11,8 @@ Gem::Specification.new do |spec|
   spec.email         = ['masaki.suketa@nifty.ne.jp']
 
   spec.summary       = 'This module is Ruby binding for DuckDB database engine.'
-  spec.description   = 'This module is Ruby binding for DuckDB database engine. You must have the DuckDB engine installed to build/use this module.'
+  spec.description   = 'This module is Ruby binding for DuckDB database engine. ' \
+                       'You must have the DuckDB engine installed to build/use this module.'
   spec.homepage      = 'https://github.com/suketa/ruby-duckdb'
   spec.license       = 'MIT'
 
@@ -29,10 +30,4 @@ Gem::Specification.new do |spec|
   spec.extensions    = ['ext/duckdb/extconf.rb']
   spec.required_ruby_version = '>= 3.2.0'
   spec.add_dependency 'bigdecimal', '>= 3.1.4'
-
-  spec.add_development_dependency 'bundler', '~> 4.0'
-  spec.add_development_dependency 'irb'
-  spec.add_development_dependency 'minitest', '~> 6.0'
-  spec.add_development_dependency 'rake', '~> 13.0'
-  spec.add_development_dependency 'rake-compiler'
 end


### PR DESCRIPTION
## Summary
Fixes all rubocop offenses in `duckdb.gemspec`.

## Changes
1. **Moved development dependencies to Gemfile**
   - Moved `bundler`, `irb`, `minitest`, `rake`, and `rake-compiler` from gemspec to Gemfile
   - This follows the rubocop `Gemspec/DevelopmentDependencies` rule

2. **Fixed line length violation**
   - Split long `spec.description` into multiple lines to meet 120 character limit

## Verification
```
$ bundle exec rubocop duckdb.gemspec
Inspecting 1 file
.

1 file inspected, no offenses detected
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized development dependency configuration.
  * Updated gem description formatting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->