### PR TITLE
Fix rubocop offenses in lib/duckdb/connection.rb

### DIFF
--- a/lib/duckdb/connection.rb
+++ b/lib/duckdb/connection.rb
@@ -80,10 +80,10 @@ module DuckDB
     #   pending_result.execute_task while pending_result.state == :not_ready
     #   result = pending_result.execute_pending
     #   result.each.first
-    def async_query_stream(sql, *args, **kwargs)
+    def async_query_stream(sql, *, **)
       warn("`#{self.class}#{__method__}` will be deprecated. Use `#{self.class}#async_query` instead.")
 
-      async_query(sql, *args, **kwargs)
+      async_query(sql, *, **)
     end
 
     # connects DuckDB database


### PR DESCRIPTION
## Summary
Fixes all rubocop offenses in `lib/duckdb/connection.rb`.

## Changes
- Use anonymous argument forwarding (`*` and `**`) instead of named arguments (`*args` and `**kwargs`) in `async_query_stream` method
- This follows the rubocop `Style/ArgumentsForwarding` rule

## Verification
```
$ bundle exec rubocop lib/duckdb/connection.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
```

```
$ bundle exec rake test
...
443 runs, 1114 assertions, 0 failures, 0 errors, 6 skips
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated async streaming method to enforce keyword-only arguments instead of accepting positional parameters. A deprecation warning guides users toward the updated calling convention, requiring code adjustments for continued compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->