### PR TITLE
Fix rubocop offense in lib/duckdb/extracted_statements.rb

### DIFF
--- a/lib/duckdb/extracted_statements.rb
+++ b/lib/duckdb/extracted_statements.rb
@@ -6,7 +6,7 @@ module DuckDB
 
     def initialize(con, sql)
       @con = con
-      super(con, sql)
+      super
     end
 
     def each


### PR DESCRIPTION
## Summary
Fixes rubocop offense in `lib/duckdb/extracted_statements.rb`.

## Changes
- Use `super` without arguments in `initialize` method when the signature is identical
- This follows the rubocop `Style/SuperArguments` rule

## Verification
```
$ bundle exec rubocop lib/duckdb/extracted_statements.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
```

```
$ bundle exec rake test
...
443 runs, 1114 assertions, 0 failures, 0 errors, 6 skips
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal refactoring of statement initialization to improve code maintainability.

---

**Note:** This release contains no user-facing changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->