### PR TITLE
Fix rubocop offenses in lib/duckdb/logical_type.rb

### DIFF
--- a/lib/duckdb/logical_type.rb
+++ b/lib/duckdb/logical_type.rb
@@ -104,7 +104,7 @@ module DuckDB
     #   names = union_logical_type.each_member_name.to_a
     #   # => ["member1", "member2"]
     def each_member_name
-      return to_enum(__method__) {member_count} unless block_given?
+      return to_enum(__method__) { member_count } unless block_given?
 
       member_count.times do |i|
         yield member_name_at(i)
@@ -126,7 +126,7 @@ module DuckDB
     #   names = union_logical_type.each_member_type.map(&:type)
     #   # => [:varchar, :integer]
     def each_member_type
-      return to_enum(__method__) {member_count} unless block_given?
+      return to_enum(__method__) { member_count } unless block_given?
 
       member_count.times do |i|
         yield member_type_at(i)
@@ -148,7 +148,7 @@ module DuckDB
     #   names = struct_logical_type.each_child_name.to_a
     #   # => ["child1", "child2"]
     def each_child_name
-      return to_enum(__method__) {child_count} unless block_given?
+      return to_enum(__method__) { child_count } unless block_given?
 
       child_count.times do |i|
         yield child_name_at(i)
@@ -170,7 +170,7 @@ module DuckDB
     #   types = struct_logical_type.each_child_type.map(&:type)
     #   # => [:integer, :varchar]
     def each_child_type
-      return to_enum(__method__) {child_count} unless block_given?
+      return to_enum(__method__) { child_count } unless block_given?
 
       child_count.times do |i|
         yield child_type_at(i)
@@ -192,7 +192,7 @@ module DuckDB
     #   values = enum_logical_type.each_value.to_a
     #   # => ["happy", "sad"]
     def each_dictionary_value
-      return to_enum(__method__) {dictionary_size} unless block_given?
+      return to_enum(__method__) { dictionary_size } unless block_given?
 
       dictionary_size.times do |i|
         yield dictionary_value_at(i)


### PR DESCRIPTION
## Summary
Fixes all rubocop offenses in `lib/duckdb/logical_type.rb`.

## Changes
- Add spaces inside block braces in `to_enum` calls
- This follows the rubocop `Layout/SpaceInsideBlockBraces` rule
- Fixed in 5 methods: `each_member_name`, `each_member_type`, `each_child_name`, `each_child_type`, and `each_dictionary_value`

## Verification
```
$ bundle exec rubocop lib/duckdb/logical_type.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
```

```
$ bundle exec rake test
...
443 runs, 1114 assertions, 0 failures, 0 errors, 6 skips
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Code formatting improvements for consistency and readability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->