### PR TITLE
Fix rubocop offense in lib/duckdb/result.rb

### DIFF
--- a/lib/duckdb/result.rb
+++ b/lib/duckdb/result.rb
@@ -24,6 +24,7 @@ module DuckDB
   #   end
   class Result
     include Enumerable
+
     RETURN_TYPES = %i[invalid changed_rows nothing query_result].freeze
 
     alias column_size column_count


### PR DESCRIPTION
## Summary
Fixes rubocop offense in `lib/duckdb/result.rb`.

## Changes
- Add empty line after `include Enumerable`
- This follows the rubocop `Layout/EmptyLinesAfterModuleInclusion` rule

## Verification
```
$ bundle exec rubocop lib/duckdb/result.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
```

```
$ bundle exec rake test
...
443 runs, 1114 assertions, 0 failures, 0 errors, 6 skips
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Minor formatting adjustment with no functional impact on application behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->