### PR TITLE
Fix autocorrectable rubocop offenses in lib

### DIFF
--- a/lib/duckdb/converter.rb
+++ b/lib/duckdb/converter.rb
@@ -186,7 +186,7 @@ module DuckDB
     end
 
     def decimal_to_hugeint(value)
-      integer_value = (value * (10 ** value.scale)).to_i
+      integer_value = (value * (10**value.scale)).to_i
       integer_to_hugeint(integer_value)
     rescue FloatDomainError => e
       raise(ArgumentError, "The argument `#{value.inspect}` must be converted to Integer. #{e.message}")

--- a/lib/duckdb/prepared_statement.rb
+++ b/lib/duckdb/prepared_statement.rb
@@ -143,7 +143,8 @@ module DuckDB
     def bind_uint64(index, val)
       return _bind_uint64(index, val) if val.between?(0, 18_446_744_073_709_551_615)
 
-      raise DuckDB::Error, "can't bind uint64(bind_uint64) to `#{val}`. The `#{val}` is out of range 0..18446744073709551615."
+      raise DuckDB::Error,
+            "can't bind uint64(bind_uint64) to `#{val}`. The `#{val}` is out of range 0..18446744073709551615."
     end
 
     # binds i-th parameter with SQL prepared statement.


### PR DESCRIPTION
## Summary
Fixes all autocorrectable rubocop offenses in the `lib` directory.

## Changes
1. **lib/duckdb/converter.rb**
   - Remove space around `**` operator per `Layout/SpaceAroundOperators` rule

2. **lib/duckdb/prepared_statement.rb**
   - Fix trailing whitespace
   - Fix line length violation by splitting long error message across multiple lines
   - Per `Layout/TrailingWhitespace`, `Layout/LineLength`, and `Layout/ArgumentAlignment` rules

## Verification
All autocorrectable offenses are now fixed:
```
$ bundle exec rubocop lib --format offenses

4   Metrics/MethodLength
2   Metrics/AbcSize
2   Metrics/ClassLength
2   Metrics/CyclomaticComplexity
2   Metrics/ParameterLists
1   Metrics/ModuleLength
--
13  Total in 4 files
```
(Remaining offenses are Metrics violations which are not autocorrectable)

```
$ bundle exec rake test
...
443 runs, 1114 assertions, 0 failures, 0 errors, 6 skips
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Minor code formatting adjustments to improve readability and maintain consistent styling conventions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->