### PR TITLE
Fix rubocop offenses in test/duckdb_test/scalar_function_test.rb

### DIFF
--- a/test/duckdb_test/scalar_function_test.rb
+++ b/test/duckdb_test/scalar_function_test.rb
@@ -4,6 +4,16 @@ require 'test_helper'
 
 module DuckDBTest
   class ScalarFunctionTest < Minitest::Test
+    def setup
+      @db = DuckDB::Database.open
+      @con = @db.connect
+    end
+
+    def teardown
+      @con&.close
+      @db&.close
+    end
+
     def test_initialize
       sf = DuckDB::ScalarFunction.new
 
@@ -45,31 +55,22 @@ module DuckDBTest
     end
 
     def test_register_scalar_function
-      db = DuckDB::Database.open
-      con = db.connect
-
       # Scalar functions with Ruby callbacks require single-threaded execution
-      con.execute('SET threads=1')
+      @con.execute('SET threads=1')
 
       sf = DuckDB::ScalarFunction.new
       sf.name = 'foo'
       sf.return_type = DuckDB::LogicalType.new(4) # INTEGER
       sf.set_function { 1 }
 
-      con.register_scalar_function(sf)
+      @con.register_scalar_function(sf)
 
-      result = con.execute('SELECT foo()')
+      result = @con.execute('SELECT foo()')
 
       assert_equal 1, result.first.first
-    ensure
-      con&.close
-      db&.close
     end
 
     def test_register_scalar_function_raises_error_without_single_thread
-      db = DuckDB::Database.open
-      con = db.connect
-
       sf = DuckDB::ScalarFunction.new
       sf.name = 'will_fail'
       sf.return_type = DuckDB::LogicalType.new(4) # INTEGER
@@ -77,14 +78,11 @@ module DuckDBTest
 
       # Should raise error because threads is not 1
       error = assert_raises(DuckDB::Error) do
-        con.register_scalar_function(sf)
+        @con.register_scalar_function(sf)
       end
 
       assert_match(/single-threaded execution/, error.message)
       assert_match(/SET threads=1/, error.message)
-    ensure
-      con&.close
-      db&.close
     end
   end
 end


### PR DESCRIPTION
## Summary
Fixes all rubocop offenses in `test/duckdb_test/scalar_function_test.rb` by refactoring to use setup/teardown methods.

## Changes
Refactored test methods to use setup/teardown for database and connection management:

**Before:**
- Each test method opened database and connection inline
- Used ensure blocks for cleanup
- Methods exceeded 10-line limit (Metrics/MethodLength violations)

**After:**
- `setup` method opens database and creates connection as instance variables
- `teardown` method closes connection and database
- Tests use `@db` and `@con` instance variables
- No ensure blocks needed
- All test methods now within 10-line limit

**Method length reductions:**
- `test_register_scalar_function`: 13 lines → 10 lines
- `test_register_scalar_function_raises_error_without_single_thread`: 14 lines → 10 lines

This approach is cleaner, more maintainable, and follows Minitest best practices.

## Verification
```
$ bundle exec rubocop test/duckdb_test/scalar_function_test.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
```

```
$ bundle exec rake test
...
443 runs, 1117 assertions, 0 failures, 0 errors, 6 skips
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Optimized test infrastructure by implementing shared database connection lifecycle management, reducing resource allocation overhead across test execution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->