### PR TITLE
Add teardown method to properly close resources in result_test.rb

### DIFF
--- a/test/duckdb_test/result_test.rb
+++ b/test/duckdb_test/result_test.rb
@@ -5,13 +5,18 @@ require 'test_helper'
 module DuckDBTest
   class ResultTest < Minitest::Test
     def setup
-      @con ||= create_data
+      @con = create_data
       @result = @con.query('SELECT * from table1')
 
       # fix for using duckdb_fetch_chunk in Result#chunk_each
       @all_records = @result.to_a
 
       @ary = first_record
+    end
+
+    def teardown
+      @con&.close
+      @db&.close
     end
 
     def test_s_new
@@ -180,7 +185,7 @@ module DuckDBTest
     private
 
     def create_data
-      @db ||= DuckDB::Database.open # FIXME
+      @db = DuckDB::Database.open
       con = @db.connect
       con.query(create_table_sql)
       con.query(insert_sql)


### PR DESCRIPTION
This PR adds a teardown method to ensure proper cleanup of database connections and database instances after each test.

Changes:
- Add `teardown` method to close `@con` and `@db`
- Replace `||=` with `=` in `setup` and `create_data` methods since resources are now properly cleaned up
- Remove FIXME comment as the resource cleanup issue is now resolved

All tests pass successfully (443 runs, 1117 assertions, 0 failures, 0 errors).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test resource management and cleanup procedures to ensure database connections are properly closed after tests execute.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->