### PR TITLE
Disable Minitest/MultipleAssertions cop in RuboCop config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,6 +17,9 @@ Metrics/BlockLength:
     - 'test/**/*'
     - 'duckdb.gemspec'
 
+Minitest/MultipleAssertions:
+  Enabled: false
+
 Style/Documentation:
   Enabled: false
 


### PR DESCRIPTION
This PR disables the Minitest/MultipleAssertions cop to allow tests with more than 3 assertions.

Changes:
- Add `Enabled: false` for `Minitest/MultipleAssertions` in `.rubocop.yml`

Benefits:
- Reduces RuboCop offenses in `result_test.rb` from 11 to 8
- Allows comprehensive test methods without artificially splitting assertions
- Improves test readability by keeping related assertions together

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development linting configuration settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->