### PR TITLE
Fix RuboCop offenses in result_test.rb

### DIFF
--- a/test/duckdb_test/result_test.rb
+++ b/test/duckdb_test/result_test.rb
@@ -35,6 +35,7 @@ module DuckDBTest
       assert_instance_of(Enumerator, @result.each)
     end
 
+    # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     def test_each_without_block
       # fix for using duckdb_fetch_chunk in Result#chunk_each
       result = @con.query('SELECT * from table1')
@@ -56,6 +57,7 @@ module DuckDBTest
 
       assert_equal([expected_ary, 0], result.each.with_index.to_a.first)
     end
+    # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
     def test_result_boolean
       assert_equal(expected_boolean, @ary[0])


### PR DESCRIPTION
## Summary
This PR fixes RuboCop offenses for the `test_each_without_block` method in `test/duckdb_test/result_test.rb`.

## Changes
- Disabled `Metrics/AbcSize` and `Metrics/MethodLength` cops for `test_each_without_block`
- Kept the expected data inline to maintain test readability

## Rationale
The method's complexity comes from test data setup, not actual logic branching. Keeping the expected array inline makes the test more readable and easier to understand at a glance, which is more valuable than meeting arbitrary metric thresholds for test code.

## Fixes
- `Metrics/AbcSize`: Assignment Branch Condition size was 20.1/17
- `Metrics/MethodLength`: Method had 16 lines, limit is 10

## Testing
- ✅ Test passes: `bundle exec rake test TEST=test/duckdb_test/result_test.rb TESTOPTS="--name=test_each_without_block"`
- ✅ RuboCop no longer reports offenses for this method

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test suite configuration to improve code quality standards.

---

**Note:** This release contains no user-facing changes or new functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->