### PR TITLE
Fix RuboCop offenses in test_rows_changed

### DIFF
--- a/test/duckdb_test/result_test.rb
+++ b/test/duckdb_test/result_test.rb
@@ -110,26 +110,41 @@ module DuckDBTest
       assert_includes(DuckDB::Result.ancestors, Enumerable)
     end
 
-    def test_rows_changed
-      DuckDB::Database.open do |db|
-        db.connect do |con|
-          r = con.query('CREATE TABLE t2 (id INT)')
+    def test_rows_changed_create
+      r = @con.query('CREATE TABLE rows_changed_test_create (id INT)')
 
-          assert_equal(0, r.rows_changed)
-          r = con.query('INSERT INTO t2 VALUES (1), (2), (3)')
+      assert_equal(0, r.rows_changed)
+    end
 
-          assert_equal(3, r.rows_changed)
-          r = con.query('UPDATE t2 SET id = id + 1 WHERE id > 1')
+    def test_rows_changed_insert
+      @con.query('CREATE TABLE rows_changed_test_insert (id INT)')
+      r = @con.query('INSERT INTO rows_changed_test_insert VALUES (1), (2), (3)')
 
-          assert_equal(2, r.rows_changed)
-          r = con.query('DELETE FROM t2 WHERE id = 0')
+      assert_equal(3, r.rows_changed)
+    end
 
-          assert_equal(0, r.rows_changed)
-          r = con.query('DELETE FROM t2 WHERE id = 4')
+    def test_rows_changed_update
+      @con.query('CREATE TABLE rows_changed_test_update (id INT)')
+      @con.query('INSERT INTO rows_changed_test_update VALUES (1), (2), (3)')
+      r = @con.query('UPDATE rows_changed_test_update SET id = id + 1 WHERE id > 1')
 
-          assert_equal(1, r.rows_changed)
-        end
-      end
+      assert_equal(2, r.rows_changed)
+    end
+
+    def test_rows_changed_delete_no_match
+      @con.query('CREATE TABLE rows_changed_test_delete_no_match (id INT)')
+      @con.query('INSERT INTO rows_changed_test_delete_no_match VALUES (1), (2), (3)')
+      r = @con.query('DELETE FROM rows_changed_test_delete_no_match WHERE id = 0')
+
+      assert_equal(0, r.rows_changed)
+    end
+
+    def test_rows_changed_delete
+      @con.query('CREATE TABLE rows_changed_test_delete (id INT)')
+      @con.query('INSERT INTO rows_changed_test_delete VALUES (1), (2), (3)')
+      r = @con.query('DELETE FROM rows_changed_test_delete WHERE id = 3')
+
+      assert_equal(1, r.rows_changed)
     end
 
     def test_column_count


### PR DESCRIPTION
## Summary
This PR fixes three RuboCop offenses in `test/duckdb_test/result_test.rb`.

## Changes
- Split the monolithic `test_rows_changed` method into 5 focused test methods
- Each test now has a single assertion, following Minitest best practices
- Used descriptive table names for better clarity

## Fixed Offenses
- ✅ **Metrics/AbcSize**: Reduced from 18.38/17 to compliant
- ✅ **Metrics/MethodLength**: Reduced from 14/10 lines to compliant  
- ✅ **Minitest/MultipleAssertions**: Reduced from 5/3 assertions to 1 per test

## Test Methods Created
1. `test_rows_changed_create` - Tests CREATE returns 0
2. `test_rows_changed_insert` - Tests INSERT returns 3
3. `test_rows_changed_update` - Tests UPDATE returns 2
4. `test_rows_changed_delete_no_match` - Tests DELETE with no matches returns 0
5. `test_rows_changed_delete` - Tests DELETE returns 1

All tests pass successfully ✓

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for query result tracking across database operations including creation, insertion, updates, and deletion.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->