### PR TITLE
use logging_level to test open with config.

### DIFF
--- a/test/duckdb_test/database_test.rb
+++ b/test/duckdb_test/database_test.rb
@@ -39,27 +39,19 @@ module DuckDBTest
     end
 
     def test_s_open_with_config
-      library_version = Gem::Version.new(DuckDB::LIBRARY_VERSION)
-      skip 'config test' if %w[1.4.0 1.4.1 1.4.2 1.4.3].include?(library_version.to_s)
-
       config = DuckDB::Config.new
-      config['default_order'] = 'DESC'
       db = DuckDB::Database.open(nil, config)
       conn = db.connect
-      conn.execute('CREATE TABLE t (col1 INTEGER);')
-      conn.execute('INSERT INTO t VALUES(3),(1),(4),(2);')
-      r = conn.execute('SELECT * FROM t ORDER BY col1')
+      r = conn.execute("SELECT CURRENT_SETTING('logging_level');")
 
-      assert_equal([4], r.first)
+      assert_equal('INFO', r.first.first)
 
-      config['default_order'] = 'ASC'
+      config['logging_level'] = 'DEBUG'
       db = DuckDB::Database.open(nil, config)
       conn = db.connect
-      conn.execute('CREATE TABLE t (col1 INTEGER);')
-      conn.execute('INSERT INTO t VALUES(3),(1),(4),(2);')
-      r = conn.execute('SELECT * FROM t ORDER BY col1')
+      r = conn.execute("SELECT CURRENT_SETTING('logging_level');")
 
-      assert_equal([1], r.first)
+      assert_equal('DEBUG', r.first.first)
     end
 
     def test_s_open_block


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Simplified configuration testing by removing version compatibility checks and table setup operations
  * Test now directly validates logging level configuration settings instead of previous ordering-based assertions

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->