### PR TITLE
Disable Metrics/ClassLength rubocop offense for test files

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,6 +17,10 @@ Metrics/BlockLength:
     - 'test/**/*'
     - 'duckdb.gemspec'
 
+Metrics/ClassLength:
+  Exclude:
+    - 'test/**/*_test.rb'
+
 Style/Documentation:
   Enabled: false
 


### PR DESCRIPTION
Excludes test/**/*_test.rb from Metrics/ClassLength rubocop checks to allow test classes to grow as needed without triggering length warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated code quality configuration to adjust class-length checks, excluding test files from that specific rule to refine linting behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->