### PR TITLE
Fix rubocop offenses in test_bind_with_blob

### DIFF
--- a/test/duckdb_test/prepared_statement_test.rb
+++ b/test/duckdb_test/prepared_statement_test.rb
@@ -842,7 +842,10 @@ module DuckDBTest
       result = @con.execute('SELECT col_blob FROM a WHERE id IS NULL')
 
       assert_equal("\0\1\2\3\4\5".encode(Encoding::BINARY), result.first.first)
+    end
 
+    def test_bind_with_blob_binary_string
+      stmt = DuckDB::PreparedStatement.new(@con, 'INSERT INTO a(id, col_blob) VALUES (NULL, $1)')
       stmt.bind(1, "\0\1\2\3\4\5".encode(Encoding::BINARY))
 
       assert_instance_of(DuckDB::Result, stmt.execute)


### PR DESCRIPTION
Fixes rubocop offenses:
- `test/duckdb_test/prepared_statement_test.rb:837:5: C: Metrics/AbcSize: Assignment Branch Condition size for test_bind_with_blob is too high. [<3, 19, 0> 19.24/17]`
- `test/duckdb_test/prepared_statement_test.rb:837:5: C: Minitest/MultipleAssertions: Test case has too many assertions [4/3]`

Split `test_bind_with_blob` into two separate test methods:
- `test_bind_with_blob`: Tests binding with `DuckDB::Blob` object (2 assertions)
- `test_bind_with_blob_binary_string`: Tests binding with binary string (2 assertions)

Both tests pass successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for binding binary string data as BLOB parameters in prepared statements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->