### PR TITLE
Fix rubocop offenses in test_bind_with_time

### DIFF
--- a/test/duckdb_test/prepared_statement_test.rb
+++ b/test/duckdb_test/prepared_statement_test.rb
@@ -800,22 +800,36 @@ module DuckDBTest
     end
 
     def test_bind_with_time
-      now = Time.now
       stmt = DuckDB::PreparedStatement.new(@con, 'SELECT * FROM a WHERE col_timestamp = $1')
 
       stmt.bind(1, Time.mktime(2019, 11, 9, 12, 34, 56, 0))
 
       assert_equal(expected_row, stmt.execute.each.first)
+    end
+
+    def test_bind_with_time_microseconds
+      stmt = DuckDB::PreparedStatement.new(@con, 'SELECT * FROM a WHERE col_timestamp = $1')
 
       stmt.bind(1, Time.mktime(2019, 11, 9, 12, 34, 56, 123_456))
 
       assert_nil(stmt.execute.each.first)
+    end
+
+    def test_bind_with_time_now
+      now = Time.now
+      stmt = DuckDB::PreparedStatement.new(@con, 'SELECT * FROM a WHERE col_timestamp = $1')
 
       @con.query("UPDATE a SET col_timestamp = '#{now.strftime('%Y/%m/%d %H:%M:%S.%N')}'")
       stmt.bind(1, now)
 
       assert_equal(1, stmt.execute.each.first.first)
+    end
 
+    def test_bind_with_time_string
+      now = Time.now
+      stmt = DuckDB::PreparedStatement.new(@con, 'SELECT * FROM a WHERE col_timestamp = $1')
+
+      @con.query("UPDATE a SET col_timestamp = '#{now.strftime('%Y/%m/%d %H:%M:%S.%N')}'")
       stmt.bind(1, now.strftime('%Y/%m/%d %H:%M:%S') + ".#{now.nsec + 1_000_000}")
 
       assert_nil(stmt.execute.each.first)


### PR DESCRIPTION
Fixes rubocop offenses:
- `test/duckdb_test/prepared_statement_test.rb:802:5: C: Metrics/AbcSize: Assignment Branch Condition size for test_bind_with_time is too high. [<2, 32, 0> 32.06/17]`
- `test/duckdb_test/prepared_statement_test.rb:802:5: C: Metrics/MethodLength: Method has too many lines. [11/10]`
- `test/duckdb_test/prepared_statement_test.rb:802:5: C: Minitest/MultipleAssertions: Test case has too many assertions [4/3]`

Split `test_bind_with_time` into four separate test methods:
- `test_bind_with_time`: Tests binding with Time object (exact match)
- `test_bind_with_time_microseconds`: Tests binding with microseconds
- `test_bind_with_time_now`: Tests binding with current time
- `test_bind_with_time_string`: Tests binding with time string value

All tests pass successfully (4 runs, 4 assertions, 0 failures).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for time and timestamp parameter binding.
  * Added tests for handling microseconds, current time, and string-formatted time values.
  * Ensures reliable handling of various time formats in database queries.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->