### PR TITLE
Fix rubocop offenses in test_bind_date

### DIFF
--- a/test/duckdb_test/prepared_statement_test.rb
+++ b/test/duckdb_test/prepared_statement_test.rb
@@ -602,22 +602,38 @@ module DuckDBTest
       result = stmt.execute
 
       assert_equal(1, result.each.first[0])
+    end
+
+    def test_bind_date_with_time
+      stmt = DuckDB::PreparedStatement.new(@con, 'SELECT * FROM a WHERE col_date = $1')
 
       stmt.bind_date(1, Time.now)
       result = stmt.execute
 
       assert_equal(1, result.each.first[0])
+    end
+
+    def test_bind_date_with_string
+      stmt = DuckDB::PreparedStatement.new(@con, 'SELECT * FROM a WHERE col_date = $1')
 
       date_str = Bar.new.to_str
       stmt.bind_date(1, date_str)
       result = stmt.execute
 
       assert_equal(1, result.each.first[0])
+    end
+
+    def test_bind_date_with_object
+      stmt = DuckDB::PreparedStatement.new(@con, 'SELECT * FROM a WHERE col_date = $1')
 
       stmt.bind_date(1, Bar.new)
       result = stmt.execute
 
       assert_equal(1, result.each.first[0])
+    end
+
+    def test_bind_date_with_invalid_argument
+      stmt = DuckDB::PreparedStatement.new(@con, 'SELECT * FROM a WHERE col_date = $1')
 
       e = assert_raises(ArgumentError) { stmt.bind_date(1, Foo.new) }
       assert_match(/Cannot parse `#<DuckDBTest::PreparedStatementTest::Foo/, e.message)


### PR DESCRIPTION
Fixes rubocop offenses:
- `test/duckdb_test/prepared_statement_test.rb:597:5: C: Metrics/AbcSize: Assignment Branch Condition size for test_bind_date is too high. [<8, 35, 0> 35.9/17]`
- `test/duckdb_test/prepared_statement_test.rb:597:5: C: Metrics/MethodLength: Method has too many lines. [17/10]`
- `test/duckdb_test/prepared_statement_test.rb:597:5: C: Minitest/MultipleAssertions: Test case has too many assertions [6/3]`

Split `test_bind_date` into five separate test methods:
- `test_bind_date`: Tests binding with Date object (1 assertion)
- `test_bind_date_with_time`: Tests binding with Time object (1 assertion)
- `test_bind_date_with_string`: Tests binding with string value (1 assertion)
- `test_bind_date_with_object`: Tests binding with custom object (1 assertion)
- `test_bind_date_with_invalid_argument`: Tests error handling (2 assertions)

All tests pass successfully (5 runs, 7 assertions, 0 failures).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Extended test coverage for date value binding operations, validating handling of various input types and error-handling scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->