### PR TITLE
Fix rubocop offenses in test_bind_decimal

### DIFF
--- a/test/duckdb_test/prepared_statement_test.rb
+++ b/test/duckdb_test/prepared_statement_test.rb
@@ -465,23 +465,40 @@ module DuckDBTest
     def test_bind_decimal
       stmt = DuckDB::PreparedStatement.new(@con, 'SELECT * FROM a WHERE col_decimal = $1')
 
-      assert_raises(ArgumentError) { stmt.bind_decimal(0, BigDecimal('98765.4321')) }
-      assert_raises(DuckDB::Error) { stmt.bind_decimal(2, BigDecimal('98765.4321')) }
-
-      e = assert_raises(ArgumentError) { stmt.bind_decimal(1, 'parse_error') }
-      assert_equal('Cannot parse `"parse_error"` to BigDecimal object. invalid value for BigDecimal(): "parse_error"',
-                   e.message)
-      e = assert_raises(ArgumentError) { stmt.bind_decimal(1, BigDecimal('Infinity')) }
-      assert_equal('The argument `Infinity` must be converted to Integer. Computation results in \'Infinity\'',
-                   e.message)
-
       stmt.bind_decimal(1, 98_765.4321)
 
       assert_equal(expected_row, stmt.execute.each.first)
+    end
+
+    def test_bind_decimal_with_bigdecimal
+      stmt = DuckDB::PreparedStatement.new(@con, 'SELECT * FROM a WHERE col_decimal = $1')
 
       stmt.bind_decimal(1, BigDecimal('98765.4321'))
 
       assert_equal(expected_row, stmt.execute.each.first)
+    end
+
+    def test_bind_decimal_with_invalid_index
+      stmt = DuckDB::PreparedStatement.new(@con, 'SELECT * FROM a WHERE col_decimal = $1')
+
+      assert_raises(ArgumentError) { stmt.bind_decimal(0, BigDecimal('98765.4321')) }
+      assert_raises(DuckDB::Error) { stmt.bind_decimal(2, BigDecimal('98765.4321')) }
+    end
+
+    def test_bind_decimal_with_invalid_value
+      stmt = DuckDB::PreparedStatement.new(@con, 'SELECT * FROM a WHERE col_decimal = $1')
+
+      e = assert_raises(ArgumentError) { stmt.bind_decimal(1, 'parse_error') }
+      assert_equal('Cannot parse `"parse_error"` to BigDecimal object. invalid value for BigDecimal(): "parse_error"',
+                   e.message)
+    end
+
+    def test_bind_decimal_with_infinity
+      stmt = DuckDB::PreparedStatement.new(@con, 'SELECT * FROM a WHERE col_decimal = $1')
+
+      e = assert_raises(ArgumentError) { stmt.bind_decimal(1, BigDecimal('Infinity')) }
+      assert_equal('The argument `Infinity` must be converted to Integer. Computation results in \'Infinity\'',
+                   e.message)
     end
 
     def test_bind_varchar


### PR DESCRIPTION
Fixes rubocop offenses:
- `test/duckdb_test/prepared_statement_test.rb:465:5: C: Metrics/AbcSize: Assignment Branch Condition size for test_bind_decimal is too high. [<3, 29, 0> 29.15/17]`
- `test/duckdb_test/prepared_statement_test.rb:465:5: C: Metrics/MethodLength: Method has too many lines. [13/10]`
- `test/duckdb_test/prepared_statement_test.rb:465:5: C: Minitest/MultipleAssertions: Test case has too many assertions [8/3]`

Split `test_bind_decimal` into five separate test methods:
- `test_bind_decimal`: Tests binding with Float value (1 assertion)
- `test_bind_decimal_with_bigdecimal`: Tests binding with BigDecimal object (1 assertion)
- `test_bind_decimal_with_invalid_index`: Tests error handling for invalid index (2 assertions)
- `test_bind_decimal_with_invalid_value`: Tests error handling for parse error (2 assertions)
- `test_bind_decimal_with_infinity`: Tests error handling for Infinity value (2 assertions)

All tests pass successfully (5 runs, 8 assertions, 0 failures).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for decimal value binding in prepared statements, validating behavior with float and BigDecimal types, error handling for invalid parameter indices and parsing errors, and edge case handling for infinity values.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->