### PR TITLE
Fix rubocop offense in test_bind_double

### DIFF
--- a/test/duckdb_test/prepared_statement_test.rb
+++ b/test/duckdb_test/prepared_statement_test.rb
@@ -445,12 +445,20 @@ module DuckDBTest
     def test_bind_double
       stmt = DuckDB::PreparedStatement.new(@con, 'SELECT * FROM a WHERE col_double = $1')
 
-      assert_raises(ArgumentError) { stmt.bind_double(0, 12_345.6789) }
-      assert_raises(DuckDB::Error) { stmt.bind_double(2, 12_345.6789) }
-
       stmt.bind_double(1, 12_345.6789)
 
       assert_equal(expected_row, stmt.execute.each.first)
+    end
+
+    def test_bind_double_with_invalid_index
+      stmt = DuckDB::PreparedStatement.new(@con, 'SELECT * FROM a WHERE col_double = $1')
+
+      assert_raises(ArgumentError) { stmt.bind_double(0, 12_345.6789) }
+      assert_raises(DuckDB::Error) { stmt.bind_double(2, 12_345.6789) }
+    end
+
+    def test_bind_double_with_invalid_type
+      stmt = DuckDB::PreparedStatement.new(@con, 'SELECT * FROM a WHERE col_double = $1')
 
       assert_raises(TypeError) { stmt.bind_double(1, 'invalid_double_val') }
     end


### PR DESCRIPTION
Fixes rubocop offense:
- `test/duckdb_test/prepared_statement_test.rb:445:5: C: Minitest/MultipleAssertions: Test case has too many assertions [4/3]`

Split `test_bind_double` into three separate test methods:
- `test_bind_double`: Tests basic double binding (1 assertion)
- `test_bind_double_with_invalid_index`: Tests error handling for invalid index (2 assertions)
- `test_bind_double_with_invalid_type`: Tests error handling for invalid type (1 assertion)

All tests pass successfully (3 runs, 4 assertions, 0 failures).