### PR TITLE
Fix RuboCop Minitest/MultipleAssertions offense in test_bind_float

### DIFF
--- a/test/duckdb_test/prepared_statement_test.rb
+++ b/test/duckdb_test/prepared_statement_test.rb
@@ -432,12 +432,20 @@ module DuckDBTest
     def test_bind_float
       stmt = DuckDB::PreparedStatement.new(@con, 'SELECT * FROM a WHERE col_real = $1')
 
-      assert_raises(ArgumentError) { stmt.bind_float(0, 12_345.375) }
-      assert_raises(DuckDB::Error) { stmt.bind_float(2, 12_345.375) }
-
       stmt.bind_float(1, 12_345.375)
 
       assert_equal(expected_row, stmt.execute.each.first)
+    end
+
+    def test_bind_float_with_invalid_index
+      stmt = DuckDB::PreparedStatement.new(@con, 'SELECT * FROM a WHERE col_real = $1')
+
+      assert_raises(ArgumentError) { stmt.bind_float(0, 12_345.375) }
+      assert_raises(DuckDB::Error) { stmt.bind_float(2, 12_345.375) }
+    end
+
+    def test_bind_float_with_invalid_type
+      stmt = DuckDB::PreparedStatement.new(@con, 'SELECT * FROM a WHERE col_real = $1')
 
       assert_raises(TypeError) { stmt.bind_float(1, 'invalid_float_val') }
     end


### PR DESCRIPTION
Fixes the RuboCop offense:
```
test/duckdb_test/prepared_statement_test.rb:432:5: C: Minitest/MultipleAssertions: Test case has too many assertions [4/3].
```

## Changes
Split `test_bind_float` into three focused tests to reduce assertions per test from 4 to 3 or fewer:
- `test_bind_float`: Tests valid float binding
- `test_bind_float_with_invalid_index`: Tests index validation (ArgumentError and DuckDB::Error)
- `test_bind_float_with_invalid_type`: Tests type validation (TypeError)

## Testing
- ✅ `bundle exec rubocop` - Confirmed the specific offense is resolved
- ✅ `bundle exec rake test` - All tests pass (470 runs, 1117 assertions, 0 failures)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for prepared statement bind_float operation, including error scenarios for invalid indices and parameter types.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->