### PR TITLE
Fix RuboCop offenses in test_bind_hugeint

### DIFF
--- a/test/duckdb_test/prepared_statement_test.rb
+++ b/test/duckdb_test/prepared_statement_test.rb
@@ -388,28 +388,35 @@ module DuckDBTest
       assert_equal(expected_row, stmt.execute.each.first)
     end
 
-    def test_bind_hugeint
+    def test_bind_hugeint_with_smallint
       stmt = DuckDB::PreparedStatement.new(@con, 'SELECT * FROM a WHERE col_smallint = $1')
-
       stmt.bind_hugeint(1, 32_767)
 
       assert_equal(expected_row, stmt.execute.each.first)
+    end
 
+    def test_bind_hugeint_with_integer
       stmt = DuckDB::PreparedStatement.new(@con, 'SELECT * FROM a WHERE col_integer = $1')
       stmt.bind_hugeint(1, 2_147_483_647)
 
       assert_equal(expected_row, stmt.execute.each.first)
+    end
 
+    def test_bind_hugeint_with_bigint
       stmt = DuckDB::PreparedStatement.new(@con, 'SELECT * FROM a WHERE col_bigint = $1')
       stmt.bind_hugeint(1, 9_223_372_036_854_775_807)
 
       assert_equal(expected_row, stmt.execute.each.first)
+    end
 
+    def test_bind_hugeint
       stmt = DuckDB::PreparedStatement.new(@con, 'SELECT * FROM a WHERE col_hugeint = $1')
       stmt.bind_hugeint(1, 170_141_183_460_469_231_731_687_303_715_884_105_727)
 
       assert_equal(expected_row, stmt.execute.each.first)
+    end
 
+    def test_bind_hugeint_with_invalid_type
       stmt = DuckDB::PreparedStatement.new(@con, 'SELECT * FROM a WHERE col_hugeint = $1')
       e = assert_raises(ArgumentError) { stmt.bind_hugeint(1, 1.5) }
       assert_equal('2nd argument `1.5` must be Integer.', e.message)


### PR DESCRIPTION
Fixes three RuboCop offenses in `test_bind_hugeint`:
```
test/duckdb_test/prepared_statement_test.rb:391:5: C: Metrics/AbcSize: Assignment Branch Condition size for test_bind_hugeint is too high. [<6, 33, 0> 33.54/17]
test/duckdb_test/prepared_statement_test.rb:391:5: C: Metrics/MethodLength: Method has too many lines. [15/10]
test/duckdb_test/prepared_statement_test.rb:391:5: C: Minitest/MultipleAssertions: Test case has too many assertions [6/3].
```

## Changes
Split `test_bind_hugeint` into five focused tests, each testing a different integer size or validation:
- `test_bind_hugeint_with_smallint`: Tests binding to SMALLINT column
- `test_bind_hugeint_with_integer`: Tests binding to INTEGER column
- `test_bind_hugeint_with_bigint`: Tests binding to BIGINT column
- `test_bind_hugeint`: Tests binding to HUGEINT column
- `test_bind_hugeint_with_invalid_type`: Tests type validation (ArgumentError)

This approach:
- Reduces ABC complexity from 33.54 to within the limit of 17
- Reduces method length from 15 lines to within the limit of 10
- Reduces assertions per test from 6 to 1-2 (within the limit of 3)

## Testing
- ✅ `bundle exec rubocop test/duckdb_test/prepared_statement_test.rb` - All three offenses resolved
- ✅ `bundle exec rake test` - All tests pass (474 runs, 1117 assertions, 0 failures)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced prepared statement integer binding validation across multiple integer types (smallint, integer, bigint) for improved reliability.
  * Added error handling tests for invalid type inputs to binding operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->