### PR TITLE
Fix RuboCop Metrics/AbcSize offense in test_bind_int64

### DIFF
--- a/test/duckdb_test/prepared_statement_test.rb
+++ b/test/duckdb_test/prepared_statement_test.rb
@@ -335,18 +335,21 @@ module DuckDBTest
       assert_raises(DuckDB::Error) { stmt.bind_uint32(1, -1) }
     end
 
-    def test_bind_int64
+    def test_bind_int64_with_smallint
       stmt = DuckDB::PreparedStatement.new(@con, 'SELECT * FROM a WHERE col_smallint = $1')
-
       stmt.bind_int64(1, 32_767)
 
       assert_equal(expected_row, stmt.execute.each.first)
+    end
 
+    def test_bind_int64_with_integer
       stmt = DuckDB::PreparedStatement.new(@con, 'SELECT * FROM a WHERE col_integer = $1')
       stmt.bind_int64(1, 2_147_483_647)
 
       assert_equal(expected_row, stmt.execute.each.first)
+    end
 
+    def test_bind_int64
       stmt = DuckDB::PreparedStatement.new(@con, 'SELECT * FROM a WHERE col_bigint = $1')
       stmt.bind_int64(1, 9_223_372_036_854_775_807)
 


### PR DESCRIPTION
Fixes the RuboCop offense:
```
test/duckdb_test/prepared_statement_test.rb:338:5: C: Metrics/AbcSize: Assignment Branch Condition size for test_bind_int64 is too high. [<3, 21, 0> 21.21/17]
```

## Changes
Split `test_bind_int64` into three focused tests, each testing binding to a different integer column type:
- `test_bind_int64_with_smallint`: Tests INT64 binding to SMALLINT column
- `test_bind_int64_with_integer`: Tests INT64 binding to INTEGER column
- `test_bind_int64`: Tests INT64 binding to BIGINT column (main use case)

This approach reduces the ABC complexity from 21.21 to within the limit of 17, making each test simpler and more focused.

## Testing
- ✅ `bundle exec rubocop test/duckdb_test/prepared_statement_test.rb` - Offense resolved
- ✅ `bundle exec rake test` - All tests pass (476 runs, 1117 assertions, 0 failures)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded prepared statement test coverage for integer binding across different column types (SMALLINT, INTEGER, BIGINT).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->