### PR TITLE
Fix RuboCop Metrics/AbcSize offense in test_bind_int32

### DIFF
--- a/test/duckdb_test/prepared_statement_test.rb
+++ b/test/duckdb_test/prepared_statement_test.rb
@@ -296,18 +296,21 @@ module DuckDBTest
       assert_raises(DuckDB::Error) { stmt.bind_uint16(1, -1) }
     end
 
-    def test_bind_int32
+    def test_bind_int32_with_smallint
       stmt = DuckDB::PreparedStatement.new(@con, 'SELECT * FROM a WHERE col_smallint = $1')
-
       stmt.bind_int32(1, 32_767)
 
       assert_equal(expected_row, stmt.execute.each.first)
+    end
 
+    def test_bind_int32
       stmt = DuckDB::PreparedStatement.new(@con, 'SELECT * FROM a WHERE col_integer = $1')
       stmt.bind_int32(1, 2_147_483_647)
 
       assert_equal(expected_row, stmt.execute.each.first)
+    end
 
+    def test_bind_int32_with_bigint
       stmt = DuckDB::PreparedStatement.new(@con, 'SELECT * FROM a WHERE col_bigint = $1')
       stmt.bind_int32(1, 2_147_483_647)
 


### PR DESCRIPTION
Fixes the RuboCop offense:
```
test/duckdb_test/prepared_statement_test.rb:299:5: C: Metrics/AbcSize: Assignment Branch Condition size for test_bind_int32 is too high. [<3, 20, 0> 20.22/17]
```

## Changes
Split `test_bind_int32` into three focused tests, each testing binding to a different integer column type:
- `test_bind_int32_with_smallint`: Tests INT32 binding to SMALLINT column
- `test_bind_int32`: Tests INT32 binding to INTEGER column (main use case)
- `test_bind_int32_with_bigint`: Tests INT32 binding to BIGINT column

This approach reduces the ABC complexity from 20.22 to within the limit of 17, making each test simpler and more focused.

## Testing
- ✅ `bundle exec rubocop test/duckdb_test/prepared_statement_test.rb` - Offense resolved (9 → 8 offenses)
- ✅ `bundle exec rake test` - All tests pass (478 runs, 1117 assertions, 0 failures)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for integer type binding across SMALLINT, INTEGER, and BIGINT columns to ensure improved compatibility and type handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->