### PR TITLE
Fix RuboCop Metrics/AbcSize offense in test_bind_int16

### DIFF
--- a/test/duckdb_test/prepared_statement_test.rb
+++ b/test/duckdb_test/prepared_statement_test.rb
@@ -259,16 +259,19 @@ module DuckDBTest
 
     def test_bind_int16
       stmt = DuckDB::PreparedStatement.new(@con, 'SELECT * FROM a WHERE col_smallint = $1')
-
       stmt.bind_int16(1, 32_767)
 
       assert_equal(expected_row, stmt.execute.each.first)
+    end
 
+    def test_bind_int16_with_integer
       stmt = DuckDB::PreparedStatement.new(@con, 'SELECT * FROM a WHERE col_integer = $1')
       stmt.bind_int16(1, 32_767)
 
       assert_nil(stmt.execute.each.first)
+    end
 
+    def test_bind_int16_with_bigint
       stmt = DuckDB::PreparedStatement.new(@con, 'SELECT * FROM a WHERE col_bigint = $1')
       stmt.bind_int16(1, 32_767)
 


### PR DESCRIPTION
Fixes the RuboCop offense:
```
test/duckdb_test/prepared_statement_test.rb:260:5: C: Metrics/AbcSize: Assignment Branch Condition size for test_bind_int16 is too high. [<3, 19, 0> 19.24/17]
```

## Changes
Split `test_bind_int16` into three focused tests, each testing binding to a different integer column type:
- `test_bind_int16`: Tests INT16 binding to SMALLINT column (main use case)
- `test_bind_int16_with_integer`: Tests INT16 binding to INTEGER column
- `test_bind_int16_with_bigint`: Tests INT16 binding to BIGINT column

This approach reduces the ABC complexity from 19.24 to within the limit of 17, making each test simpler and more focused.

## Testing
- ✅ `bundle exec rubocop test/duckdb_test/prepared_statement_test.rb` - Offense resolved (8 → 7 offenses)
- ✅ `bundle exec rake test` - All tests pass (480 runs, 1117 assertions, 0 failures)