### PR TITLE
Fix RuboCop offenses in test_bind_bool

### DIFF
--- a/test/duckdb_test/prepared_statement_test.rb
+++ b/test/duckdb_test/prepared_statement_test.rb
@@ -211,19 +211,29 @@ module DuckDBTest
       assert_equal('fail to bind 2 parameter', exception.message)
     end
 
-    def test_bind_bool
+    def test_bind_bool_with_invalid_index
       stmt = DuckDB::PreparedStatement.new(@con, 'SELECT * FROM a WHERE col_boolean = $1')
 
       assert_raises(ArgumentError) { stmt.bind_bool(0, true) }
       assert_raises(DuckDB::Error) { stmt.bind_bool(2, true) }
+    end
 
+    def test_bind_bool_with_true
+      stmt = DuckDB::PreparedStatement.new(@con, 'SELECT * FROM a WHERE col_boolean = $1')
       stmt.bind_bool(1, true)
 
       assert_equal(expected_row, stmt.execute.each.first)
+    end
 
+    def test_bind_bool_with_false
+      stmt = DuckDB::PreparedStatement.new(@con, 'SELECT * FROM a WHERE col_boolean = $1')
       stmt.bind_bool(1, false)
 
       assert_nil(stmt.execute.each.first)
+    end
+
+    def test_bind_bool_with_invalid_type
+      stmt = DuckDB::PreparedStatement.new(@con, 'SELECT * FROM a WHERE col_boolean = $1')
 
       assert_raises(ArgumentError) { stmt.bind_bool(1, 'True') }
     end


### PR DESCRIPTION
Fixes two RuboCop offenses in `test_bind_bool`:
```
test/duckdb_test/prepared_statement_test.rb:214:5: C: Metrics/AbcSize: Assignment Branch Condition size for test_bind_bool is too high. [<1, 18, 0> 18.03/17]
test/duckdb_test/prepared_statement_test.rb:214:5: C: Minitest/MultipleAssertions: Test case has too many assertions [5/3].
```

## Changes
Split `test_bind_bool` into four focused tests, each testing a specific scenario:
- `test_bind_bool_with_invalid_index`: Tests index validation (ArgumentError and DuckDB::Error)
- `test_bind_bool_with_true`: Tests binding `true` value
- `test_bind_bool_with_false`: Tests binding `false` value
- `test_bind_bool_with_invalid_type`: Tests type validation (ArgumentError)

This approach:
- Reduces ABC complexity from 18.03 to within the limit of 17
- Reduces assertions per test from 5 to 1-2 (within the limit of 3)
- Makes each test more focused and easier to understand

## Testing
- ✅ `bundle exec rubocop test/duckdb_test/prepared_statement_test.rb` - Both offenses resolved (7 → 5 offenses)
- ✅ `bundle exec rake test` - All tests pass (483 runs, 1117 assertions, 0 failures)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for boolean parameter binding, including validation for true/false values and type checking to ensure non-boolean types are properly rejected.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->