### PR TITLE
Fix RuboCop Minitest/MultipleAssertions offense in test_bind_parameter_name

### DIFF
--- a/test/duckdb_test/prepared_statement_test.rb
+++ b/test/duckdb_test/prepared_statement_test.rb
@@ -200,6 +200,13 @@ module DuckDBTest
 
       assert_equal('id', stmt.parameter_name(1))
       assert_equal('col_boolean', stmt.parameter_name(2))
+    end
+
+    def test_bind_parameter_name_with_invalid_index
+      stmt = DuckDB::PreparedStatement.new(
+        @con,
+        'SELECT * FROM a WHERE id = $id AND col_boolean = $col_boolean AND id = $id'
+      )
 
       assert_raises(ArgumentError) { stmt.parameter_name(0) }
       assert_raises(DuckDB::Error) { stmt.parameter_name(3) }


### PR DESCRIPTION
Fixes the RuboCop offense:
```
test/duckdb_test/prepared_statement_test.rb:195:5: C: Minitest/MultipleAssertions: Test case has too many assertions [4/3].
```

## Changes
Split `test_bind_parameter_name` into two focused tests to reduce assertions per test:
- `test_bind_parameter_name`: Tests retrieving valid parameter names (2 assertions)
- `test_bind_parameter_name_with_invalid_index`: Tests index validation (ArgumentError and DuckDB::Error)

This approach reduces assertions from 4 to 2 per test, within the limit of 3.

## Testing
- ✅ `bundle exec rubocop test/duckdb_test/prepared_statement_test.rb` - Offense resolved (5 → 4 offenses)
- ✅ `bundle exec rake test` - All tests pass (484 runs, 1117 assertions, 0 failures)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for error handling when accessing invalid parameter name indices on prepared statements, ensuring proper exception handling for edge cases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->