### PR TITLE
Fix RuboCop Minitest/MultipleAssertions offense in test_clear_bindings

### DIFF
--- a/test/duckdb_test/prepared_statement_test.rb
+++ b/test/duckdb_test/prepared_statement_test.rb
@@ -157,13 +157,15 @@ module DuckDBTest
       assert_equal(:invalid, stmt.param_type(2))
     end
 
-    def test_clear_bindings
+    def test_clear_bindings_with_positional_parameter
       stmt = DuckDB::PreparedStatement.new(@con, 'SELECT * FROM a WHERE id = $1')
       stmt.bind(1, 1)
       stmt.clear_bindings
       res = assert_raises(DuckDB::Error) { stmt.execute }
       assert_match(/Values were not provided for the following prepared.*: 1/, res.message)
+    end
 
+    def test_clear_bindings_with_named_parameter
       stmt = DuckDB::PreparedStatement.new(@con, 'SELECT * FROM a WHERE id = $id')
       stmt.bind(:id, 1)
       stmt.clear_bindings


### PR DESCRIPTION
Fixes the RuboCop offense:
```
test/duckdb_test/prepared_statement_test.rb:160:5: C: Minitest/MultipleAssertions: Test case has too many assertions [4/3].
```

## Changes
Split `test_clear_bindings` into two focused tests, each testing a different parameter binding style:
- `test_clear_bindings_with_positional_parameter`: Tests clearing bindings with positional parameter ($1)
- `test_clear_bindings_with_named_parameter`: Tests clearing bindings with named parameter ($id)

Both tests verify that `clear_bindings` properly removes bound values, causing an error when executing without rebinding.

This approach reduces assertions from 4 to 2 per test, within the limit of 3.

## Testing
- ✅ `bundle exec rubocop test/duckdb_test/prepared_statement_test.rb` - Offense resolved (4 → 3 offenses)
- ✅ `bundle exec rake test` - All tests pass (485 runs, 1117 assertions, 0 failures)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for prepared statement parameter binding scenarios, including positional and named parameters.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->