### PR TITLE
Fix Minitest/MultipleAssertions rubocop offense

### DIFF
--- a/test/duckdb_test/prepared_statement_test.rb
+++ b/test/duckdb_test/prepared_statement_test.rb
@@ -99,10 +99,19 @@ module DuckDBTest
 
     def test_s_new
       assert_instance_of(DuckDB::PreparedStatement, DuckDB::PreparedStatement.new(@con, 'SELECT * FROM a'))
+    end
+
+    def test_s_new_argument_errors
       assert_raises(ArgumentError) { DuckDB::PreparedStatement.new(@con) }
       assert_raises(ArgumentError) { DuckDB::PreparedStatement.new }
+    end
+
+    def test_s_new_type_errors
       assert_raises(TypeError) { DuckDB::PreparedStatement.new(@con, 1) }
       assert_raises(TypeError) { DuckDB::PreparedStatement.new(1, 1) }
+    end
+
+    def test_s_new_invalid_sql
       assert_raises(DuckDB::Error) { DuckDB::PreparedStatement.new(@con, 'SELECT * FROM') }
     end
 


### PR DESCRIPTION
This PR fixes the rubocop offense in `test/duckdb_test/prepared_statement_test.rb`:

```
test/duckdb_test/prepared_statement_test.rb:100:5: C: Minitest/MultipleAssertions: Test case has too many assertions [6/3].
```

## Changes
Split the `test_s_new` method into 4 separate test methods to comply with rubocop's maximum of 3 assertions per test case:

- `test_s_new`: basic instance creation
- `test_s_new_argument_errors`: argument validation
- `test_s_new_type_errors`: type validation  
- `test_s_new_invalid_sql`: SQL error handling

## Verification
✅ All tests pass: `bundle exec rake test` (488 runs, 1117 assertions, 0 failures)
✅ Rubocop offense fixed (other offenses unrelated to this change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added tests to verify proper error handling during prepared statement initialization, ensuring the system correctly handles invalid inputs, argument errors, and SQL syntax issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->