### PR TITLE
Fix rubocop offenses in interval_test.rb

### DIFF
--- a/test/duckdb_test/interval_test.rb
+++ b/test/duckdb_test/interval_test.rb
@@ -4,7 +4,7 @@ require 'test_helper'
 
 module DuckDBTest
   class IntervalTest < Minitest::Test
-    def test_s_iso8601_parse
+    def test_s_iso8601_parse_positive_full
       assert_equal(
         DuckDB::Interval.new(interval_months: 14, interval_days: 3, interval_micros: 14_706_700_000),
         DuckDB::Interval.iso8601_parse('P1Y2M3DT4H5M6.7S')
@@ -13,6 +13,9 @@ module DuckDBTest
         DuckDB::Interval.new(interval_months: 14, interval_days: 3, interval_micros: 14_706_000_007),
         DuckDB::Interval.iso8601_parse('P1Y2M3DT4H5M6.000007S')
       )
+    end
+
+    def test_s_iso8601_parse_negative_prefix
       assert_equal(
         DuckDB::Interval.new(interval_months: -14, interval_days: -3, interval_micros: -14_706_700_000),
         DuckDB::Interval.iso8601_parse('-P1Y2M3DT4H5M6.7S')
@@ -21,6 +24,9 @@ module DuckDBTest
         DuckDB::Interval.new(interval_months: -14, interval_days: -3, interval_micros: -14_706_000_007),
         DuckDB::Interval.iso8601_parse('-P1Y2M3DT4H5M6.000007S')
       )
+    end
+
+    def test_s_iso8601_parse_negative_components
       assert_equal(
         DuckDB::Interval.new(interval_months: -14, interval_days: -3, interval_micros: -14_706_700_000),
         DuckDB::Interval.iso8601_parse('P-1Y-2M-3DT-4H-5M-6.7S')
@@ -29,39 +35,29 @@ module DuckDBTest
         DuckDB::Interval.new(interval_months: -14, interval_days: -3, interval_micros: -14_706_000_007),
         DuckDB::Interval.iso8601_parse('P-1Y-2M-3DT-4H-5M-6.000007S')
       )
+    end
 
-      assert_equal(
-        DuckDB::Interval.new(interval_months: 12),
-        DuckDB::Interval.iso8601_parse('P1Y')
-      )
-      assert_equal(
-        DuckDB::Interval.new(interval_months: 1),
-        DuckDB::Interval.iso8601_parse('P1M')
-      )
-      assert_equal(
-        DuckDB::Interval.new(interval_days: 1),
-        DuckDB::Interval.iso8601_parse('P1D')
-      )
-      assert_equal(
-        DuckDB::Interval.new(interval_micros: 3_600_000_000),
-        DuckDB::Interval.iso8601_parse('PT1H')
-      )
-      assert_equal(
-        DuckDB::Interval.new(interval_micros: 60_000_000),
-        DuckDB::Interval.iso8601_parse('PT1M')
-      )
-      assert_equal(
-        DuckDB::Interval.new(interval_micros: 1_000_000),
-        DuckDB::Interval.iso8601_parse('PT1S')
-      )
-      assert_equal(
-        DuckDB::Interval.new(interval_micros: 1),
-        DuckDB::Interval.iso8601_parse('PT0.000001S')
-      )
+    def test_s_iso8601_parse_single_units
+      assert_equal(DuckDB::Interval.new(interval_months: 12), DuckDB::Interval.iso8601_parse('P1Y'))
+      assert_equal(DuckDB::Interval.new(interval_months: 1), DuckDB::Interval.iso8601_parse('P1M'))
+      assert_equal(DuckDB::Interval.new(interval_days: 1), DuckDB::Interval.iso8601_parse('P1D'))
+    end
+
+    def test_s_iso8601_parse_time_units
+      assert_equal(DuckDB::Interval.new(interval_micros: 3_600_000_000), DuckDB::Interval.iso8601_parse('PT1H'))
+      assert_equal(DuckDB::Interval.new(interval_micros: 60_000_000), DuckDB::Interval.iso8601_parse('PT1M'))
+      assert_equal(DuckDB::Interval.new(interval_micros: 1_000_000), DuckDB::Interval.iso8601_parse('PT1S'))
+    end
+
+    def test_s_iso8601_parse_microseconds
+      assert_equal(DuckDB::Interval.new(interval_micros: 1), DuckDB::Interval.iso8601_parse('PT0.000001S'))
+    end
+
+    def test_s_iso8601_parse_invalid
       assert_raises(ArgumentError) { DuckDB::Interval.iso8601_parse('1Y2M3DT4H5M6.7') }
     end
 
-    def test_s_mk_interval
+    def test_s_mk_interval_positive_full
       assert_equal(
         DuckDB::Interval.new(interval_months: 14, interval_days: 3, interval_micros: 14_706_700_000),
         DuckDB::Interval.mk_interval(year: 1, month: 2, day: 3, hour: 4, min: 5, sec: 6, usec: 700_000)
@@ -70,14 +66,17 @@ module DuckDBTest
         DuckDB::Interval.new(interval_months: 14, interval_days: 3, interval_micros: 14_706_000_007),
         DuckDB::Interval.mk_interval(year: 1, month: 2, day: 3, hour: 4, min: 5, sec: 6, usec: 7)
       )
+    end
+
+    def test_s_mk_interval_zero_and_empty
       assert_equal(
         DuckDB::Interval.new(interval_months: 0, interval_days: 0, interval_micros: 0),
         DuckDB::Interval.mk_interval(year: 0, month: 0, day: 0, hour: 0, min: 0, sec: 0, usec: 0)
       )
-      assert_equal(
-        DuckDB::Interval.new,
-        DuckDB::Interval.mk_interval
-      )
+      assert_equal(DuckDB::Interval.new, DuckDB::Interval.mk_interval)
+    end
+
+    def test_s_mk_interval_negative_full
       assert_equal(
         DuckDB::Interval.new(interval_months: -14, interval_days: -3, interval_micros: -14_706_700_000),
         DuckDB::Interval.mk_interval(year: -1, month: -2, day: -3, hour: -4, min: -5, sec: -6, usec: -700_000)
@@ -86,40 +85,33 @@ module DuckDBTest
         DuckDB::Interval.new(interval_months: -14, interval_days: -3, interval_micros: -14_706_000_007),
         DuckDB::Interval.mk_interval(year: -1, month: -2, day: -3, hour: -4, min: -5, sec: -6, usec: -7)
       )
-      assert_equal(
-        DuckDB::Interval.new(interval_months: 12),
-        DuckDB::Interval.mk_interval(year: 1)
-      )
-      assert_equal(
-        DuckDB::Interval.new(interval_months: 1),
-        DuckDB::Interval.mk_interval(month: 1)
-      )
-      assert_equal(
-        DuckDB::Interval.new(interval_days: 1),
-        DuckDB::Interval.mk_interval(day: 1)
-      )
-      assert_equal(
-        DuckDB::Interval.new(interval_micros: 3_600_000_000),
-        DuckDB::Interval.mk_interval(hour: 1)
-      )
-      assert_equal(
-        DuckDB::Interval.new(interval_micros: 60_000_000),
-        DuckDB::Interval.mk_interval(min: 1)
-      )
-      assert_equal(
-        DuckDB::Interval.new(interval_micros: 1_000_000),
-        DuckDB::Interval.mk_interval(sec: 1)
-      )
-      assert_equal(
-        DuckDB::Interval.new(interval_micros: 1),
-        DuckDB::Interval.mk_interval(usec: 1)
-      )
+    end
+
+    def test_s_mk_interval_single_date_units
+      assert_equal(DuckDB::Interval.new(interval_months: 12), DuckDB::Interval.mk_interval(year: 1))
+      assert_equal(DuckDB::Interval.new(interval_months: 1), DuckDB::Interval.mk_interval(month: 1))
+      assert_equal(DuckDB::Interval.new(interval_days: 1), DuckDB::Interval.mk_interval(day: 1))
+    end
+
+    def test_s_mk_interval_single_time_units
+      assert_equal(DuckDB::Interval.new(interval_micros: 3_600_000_000), DuckDB::Interval.mk_interval(hour: 1))
+      assert_equal(DuckDB::Interval.new(interval_micros: 60_000_000), DuckDB::Interval.mk_interval(min: 1))
+      assert_equal(DuckDB::Interval.new(interval_micros: 1_000_000), DuckDB::Interval.mk_interval(sec: 1))
+    end
+
+    def test_s_mk_interval_microseconds
+      assert_equal(DuckDB::Interval.new(interval_micros: 1), DuckDB::Interval.mk_interval(usec: 1))
     end
 
     def test_initialize
       interval = DuckDB::Interval.new
 
       assert_instance_of(DuckDB::Interval, interval)
+    end
+
+    def test_initialize_default_values
+      interval = DuckDB::Interval.new
+
       assert_equal(0, interval.interval_months)
       assert_equal(0, interval.interval_days)
       assert_equal(0, interval.interval_micros)


### PR DESCRIPTION
This PR fixes all rubocop offenses in `test/duckdb_test/interval_test.rb`:

## Offenses Fixed

### test_s_iso8601_parse (3 offenses)
```
- AbcSize: <0, 41, 0> 41/17 → Fixed
- MethodLength: 53/10 → Fixed
- MultipleAssertions: 14/3 → Fixed
```

### test_s_mk_interval (3 offenses)
```
- AbcSize: <0, 39, 0> 39/17 → Fixed
- MethodLength: 52/10 → Fixed
- MultipleAssertions: 13/3 → Fixed
```

### test_initialize (1 offense)
```
- MultipleAssertions: 4/3 → Fixed
```

## Changes
Split large test methods into smaller, focused tests:

**test_s_iso8601_parse** → Split into 7 tests:
- `test_s_iso8601_parse_positive_full`
- `test_s_iso8601_parse_negative_prefix`
- `test_s_iso8601_parse_negative_components`
- `test_s_iso8601_parse_single_units`
- `test_s_iso8601_parse_time_units`
- `test_s_iso8601_parse_microseconds`
- `test_s_iso8601_parse_invalid`

**test_s_mk_interval** → Split into 6 tests:
- `test_s_mk_interval_positive_full`
- `test_s_mk_interval_zero_and_empty`
- `test_s_mk_interval_negative_full`
- `test_s_mk_interval_single_date_units`
- `test_s_mk_interval_single_time_units`
- `test_s_mk_interval_microseconds`

**test_initialize** → Split into 2 tests:
- `test_initialize`
- `test_initialize_default_values`

## Verification
✅ All tests pass: `bundle exec rake test` (503 runs, 1117 assertions, 0 failures)
✅ All rubocop offenses fixed: `bundle exec rubocop test/duckdb_test/interval_test.rb` - no offenses detected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for interval parsing and creation with more granular test cases covering edge cases and variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->