### PR TITLE
Fix RuboCop offences in extracted_statements_test.rb

### DIFF
--- a/test/duckdb_test/extracted_statements_test.rb
+++ b/test/duckdb_test/extracted_statements_test.rb
@@ -40,7 +40,7 @@ module DuckDBTest
       assert_equal 3, stmts.size
     end
 
-    def test_prepared_statement
+    def test_prepared_statement_first
       stmts = DuckDB::ExtractedStatements.new(@con, 'SELECT 1; SELECT 2; SELECT 3')
       stmt = stmts.prepared_statement(@con, 0)
 
@@ -48,28 +48,39 @@ module DuckDBTest
       r = stmt.execute
 
       assert_equal([[1]], r.to_a)
+    end
 
+    def test_prepared_statement_second
+      stmts = DuckDB::ExtractedStatements.new(@con, 'SELECT 1; SELECT 2; SELECT 3')
       stmt = stmts.prepared_statement(@con, 1)
       r = stmt.execute
 
       assert_equal([[2]], r.to_a)
+    end
 
+    def test_prepared_statement_third
+      stmts = DuckDB::ExtractedStatements.new(@con, 'SELECT 1; SELECT 2; SELECT 3')
       stmt = stmts.prepared_statement(@con, 2)
       r = stmt.execute
 
       assert_equal([[3]], r.to_a)
     end
 
-    def test_prepared_statement_with_invalid_index
+    def test_prepared_statement_with_invalid_positive_index
       stmts = DuckDB::ExtractedStatements.new(@con, 'SELECT 1; SELECT 2; SELECT 3')
       ex = assert_raises DuckDB::Error do
         stmts.prepared_statement(@con, 3)
       end
-      assert_equal 'Failed to create DuckDB::PreparedStatement object.', ex.message
 
+      assert_equal 'Failed to create DuckDB::PreparedStatement object.', ex.message
+    end
+
+    def test_prepared_statement_with_invalid_negative_index
+      stmts = DuckDB::ExtractedStatements.new(@con, 'SELECT 1; SELECT 2; SELECT 3')
       ex = assert_raises DuckDB::Error do
         stmts.prepared_statement(@con, -1)
       end
+
       assert_equal 'Failed to create DuckDB::PreparedStatement object.', ex.message
     end
 


### PR DESCRIPTION
This PR fixes RuboCop offences in extracted_statements_test.rb:

**Changes:**
- **Metrics/MethodLength & Minitest/MultipleAssertions**: Split `test_prepared_statement` into 3 separate tests:
  - `test_prepared_statement_first`
  - `test_prepared_statement_second`
  - `test_prepared_statement_third`
  
- **Minitest/MultipleAssertions**: Split `test_prepared_statement_with_invalid_index` into 2 tests:
  - `test_prepared_statement_with_invalid_positive_index`
  - `test_prepared_statement_with_invalid_negative_index`

All tests pass successfully (506 runs, 1117 assertions, 0 failures).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for prepared statements with additional test cases and improved test organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->