### PR TITLE
Fix rubocop offenses in database_test.rb

### DIFF
--- a/test/duckdb_test/database_test.rb
+++ b/test/duckdb_test/database_test.rb
@@ -28,14 +28,16 @@ module DuckDBTest
 
       assert_instance_of(DuckDB::Database, db)
       db.close
+    end
 
+    def test_s_open_type_errors
       assert_raises(TypeError) { DuckDB::Database.open('foo', 'bar') }
       assert_raises(TypeError) { DuckDB::Database.open(1) }
+    end
 
-      assert_raises(DuckDB::Error) do
-        not_exist_path = "#{create_path}/#{create_path}"
-        DuckDB::Database.open(not_exist_path)
-      end
+    def test_s_open_invalid_path
+      not_exist_path = "#{create_path}/#{create_path}"
+      assert_raises(DuckDB::Error) { DuckDB::Database.open(not_exist_path) }
     end
 
     def test_s_open_with_config


### PR DESCRIPTION
This PR fixes all rubocop offenses in `test/duckdb_test/database_test.rb`:

## Offenses Fixed

### test_s_open_argument (2 offenses)
```
- Minitest/MultipleAssertions: Test case has too many assertions [4/3] → Fixed
- Minitest/AssertRaisesCompoundBody: Reduce assert_raises block body → Fixed
```

## Changes
Split `test_s_open_argument` into 3 separate test methods:

- **test_s_open_argument**: Test opening database with valid path (1 assertion)
- **test_s_open_type_errors**: Test type error handling (2 assertions)
- **test_s_open_invalid_path**: Test invalid path error handling (1 assertion)

This also fixes the `AssertRaisesCompoundBody` offense by moving variable assignment outside the `assert_raises` block, keeping only the raising code inside.

## Verification
✅ All tests pass: `bundle exec rake test` (505 runs, 1117 assertions, 0 failures)
✅ All rubocop offenses fixed: `bundle exec rubocop test/duckdb_test/database_test.rb` - no offenses detected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for database initialization with improved error validation for invalid input types and file paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->