### PR TITLE
Fix RuboCop Metrics/ParameterLists offence in Interval#mk_interval

### DIFF
--- a/lib/duckdb/interval.rb
+++ b/lib/duckdb/interval.rb
@@ -62,7 +62,7 @@ module DuckDB
       #
       #   DuckDB::Interval.mk_interval(year: 1, month: 2, day: 3, hour: 4, min: 5, sec: 6, usec: 123456)
       #   => #<DuckDB::Interval:0x00007f9b9c0b3b60 @interval_months=14, @interval_days=3, @interval_micros=14706123456>
-      def mk_interval(year: 0, month: 0, day: 0, hour: 0, min: 0, sec: 0, usec: 0)
+      def mk_interval(year: 0, month: 0, day: 0, hour: 0, min: 0, sec: 0, usec: 0) # rubocop:disable Metrics/ParameterLists
         Interval.new(
           interval_months: (year * 12) + month,
           interval_days: day,


### PR DESCRIPTION
This PR fixes the RuboCop offence in `lib/duckdb/interval.rb`.

## Changes
- Added inline comment to disable `Metrics/ParameterLists` cop for the `mk_interval` method

## Rationale
The `mk_interval` method legitimately needs 7 keyword parameters (year, month, day, hour, min, sec, usec) to represent all date/time components in a clean, intuitive API. Using an inline disable comment is appropriate here rather than restructuring the API or increasing the global parameter limit.

## Testing
- ✅ RuboCop passes: `bundle exec rubocop lib/duckdb/interval.rb`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal code quality improvements

---

**Note:** This release contains no user-facing changes. Updates are limited to internal code maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->