### PR TITLE
Fix RuboCop cop namespace in test file

### DIFF
--- a/test/duckdb_test/result_test.rb
+++ b/test/duckdb_test/result_test.rb
@@ -163,7 +163,7 @@ module DuckDBTest
       assert_instance_of(DuckDB::Column, @result.columns.first)
     end
 
-    def test__column_type # rubocop:disable Metrics/MultipleAssertions, Metrics/AbcSize, Metrics/MethodLength
+    def test__column_type # rubocop:disable Minitest/MultipleAssertions, Metrics/AbcSize, Metrics/MethodLength
       # TODO: deprecate Result#_column_type private method.
       assert_equal(1, @result.send(:_column_type, 0))
       assert_equal(1, @result.send(:_column_type, 0))


### PR DESCRIPTION
## Summary
This PR fixes a RuboCop cop namespace warning by updating the deprecated `Metrics/MultipleAssertions` to `Minitest/MultipleAssertions`.

## Changes
- Replace `Metrics/MultipleAssertions` with `Minitest/MultipleAssertions` in `test/duckdb_test/result_test.rb`

## Background
The `Metrics/MultipleAssertions` cop was deprecated and moved to the Minitest namespace when using the `rubocop-minitest` plugin. This project already uses `rubocop-minitest`, so the correct namespace should be used.

## Error Fixed
```
test/duckdb_test/result_test.rb: Metrics/MultipleAssertions has the wrong namespace - replace it with Minitest/MultipleAssertions
```

## Testing
- ✅ All tests pass: 591 runs, 1120 assertions, 0 failures, 0 errors
- ✅ RuboCop: 59 files inspected, 0 offenses detected

## Impact
- Minimal change - only updating cop namespace in inline comment
- No functional changes
- Removes warning message from RuboCop output