### PR TITLE
Use vector_value_at for scalar function parameter conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to this project will be documented in this file.
 
 # Unreleased
+- fix DuckDB::ScalarFunction NULL input handling.
+- fix DuckDB::ScalarFunction INTEGER output type (int32 vs int64).
 - add DuckDB::ScalarFunction#add_parameter.
 - add DuckDB::ScalarFunction#set_return_type.
 - bump bundler 4.0 in duckdb.gemspec.

--- a/ext/duckdb/result.h
+++ b/ext/duckdb/result.h
@@ -10,6 +10,7 @@ typedef struct _rubyDuckDBResult rubyDuckDBResult;
 rubyDuckDBResult *get_struct_result(VALUE obj);
 void rbduckdb_init_duckdb_result(void);
 VALUE rbduckdb_create_result(void);
+VALUE rbduckdb_vector_value_at(duckdb_vector vector, duckdb_logical_type element_type, idx_t index);
 
 #endif
 


### PR DESCRIPTION
## Summary
Refactors scalar function parameter conversion to use the existing `vector_value_at` function from result.c, which fixes NULL handling and prepares for multi-type support.

## Problem Solved
PR #1066 had a critical bug: when input columns contained NULL values, the code would read uninitialized/garbage data from the vector's data array, causing errors or incorrect results.

## Solution
Reuse the battle-tested `rbduckdb_vector_value_at()` function that already:
- ✅ Correctly handles NULL values (checks validity before reading data)
- ✅ Supports all DuckDB data types (not just INTEGER)
- ✅ Has proper type conversion for each type
- ✅ Is already thoroughly tested in result handling

## Changes
1. **Exposed `rbduckdb_vector_value_at()`** from result.c (renamed from static `vector_value_at`)
2. **Updated scalar_function.c** to use `rbduckdb_vector_value_at()` for parameter conversion
3. **Fixed INTEGER output type** - use `int32_t` instead of `int64_t` (DuckDB INTEGER is 32-bit)
4. **Simplified code** - removed manual validity checking and data reading logic

## Benefits
- 🐛 **Fixes NULL handling bug** - no longer reads garbage data for NULL inputs
- 🎯 **Code reuse** - uses existing, tested type conversion logic  
- 🧹 **Cleaner code** - removed ~20 lines of manual conversion logic
- 🚀 **Foundation for all types** - `vector_value_at` already supports VARCHAR, DOUBLE, TIMESTAMP, etc.

## Testing
- ✅ New test: `test_scalar_function_with_null_input` - passes!
- ✅ All existing scalar function tests pass
- ✅ RuboCop: no offenses

## Example - Now Works Correctly
```ruby
con.execute('SET threads=1')
con.execute('CREATE TABLE t (value INTEGER)')
con.execute('INSERT INTO t VALUES (5), (NULL), (15)')

sf = DuckDB::ScalarFunction.new
sf.name = 'double'
sf.add_parameter(DuckDB::LogicalType.new(4))
sf.return_type = DuckDB::LogicalType.new(4)
sf.set_function { |v| v.nil? ? nil : 2 * v }

con.register_scalar_function(sf)
con.execute('SELECT double(value) FROM t ORDER BY value')
# => [[10], [30], [nil]]  ✅ Works correctly!
```

## Related
- Fixes: Bug introduced in PR #1066
- Depends on: PR #1065 (add_parameter method)
- Part of: Phase 2 - Parameter Support

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed NULL input handling to ensure scalar functions gracefully process NULL values
  * Corrected integer output type handling for scalar function results

* **Tests**
  * Added test coverage for NULL input scenarios in scalar functions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->