### PR TITLE
Fix compilation warning: unused variable 'j' in scalar_function.c

### DIFF
--- a/ext/duckdb/scalar_function.c
+++ b/ext/duckdb/scalar_function.c
@@ -100,7 +100,7 @@ static VALUE rbduckdb_scalar_function_add_parameter(VALUE self, VALUE logical_ty
 
 static void scalar_function_callback(duckdb_function_info info, duckdb_data_chunk input, duckdb_vector output) {
     rubyDuckDBScalarFunction *ctx;
-    idx_t i, j;
+    idx_t i;
     struct callback_arg arg;
 
     ctx = (rubyDuckDBScalarFunction *)duckdb_scalar_function_get_extra_info(info);


### PR DESCRIPTION
## Summary
Removes unused variable `j` from `scalar_function_callback()` to fix compilation warning.

## Issue
```
scalar_function.c:103:14: warning: unused variable 'j' [-Wunused-variable]
```

## Root Cause
The variable `j` was used in the original code to iterate over input columns during allocation. In PR #1068 (commit e25cdd9), we moved the allocation loop into `process_rows()` to ensure exception-safe cleanup. The variable `j` was left behind in `scalar_function_callback()` but is no longer needed there.

## Change
- Removed `idx_t i, j;` declaration
- Changed to `idx_t i;`
- The variable `j` is still used in `process_rows()` where it belongs

## Testing
- ✅ All 11 scalar function tests pass
- ✅ Compilation now clean with no warnings

## Impact
- Cosmetic fix only, no behavior change
- Improves code cleanliness

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed unused variable declaration from internal code to improve code clarity and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->