### PR TITLE
Add BIGINT support to ScalarFunction return type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 # Unreleased
+- add BIGINT support to DuckDB::ScalarFunction return type.
 - refactor DuckDB::ScalarFunction to use vector_set_value_at helper.
 - fix DuckDB::ScalarFunction NULL input handling.
 - fix DuckDB::ScalarFunction INTEGER output type (int32 vs int64).

--- a/ext/duckdb/scalar_function.c
+++ b/ext/duckdb/scalar_function.c
@@ -231,6 +231,9 @@ static void vector_set_value_at(duckdb_vector vector, duckdb_logical_type elemen
         case DUCKDB_TYPE_INTEGER:
             ((int32_t *)vector_data)[index] = NUM2INT(value);
             break;
+        case DUCKDB_TYPE_BIGINT:
+            ((int64_t *)vector_data)[index] = NUM2LL(value);
+            break;
         default:
             rb_raise(rb_eArgError, "Unsupported return type for scalar function");
             break;

--- a/lib/duckdb/scalar_function.rb
+++ b/lib/duckdb/scalar_function.rb
@@ -4,16 +4,18 @@ module DuckDB
   # DuckDB::ScalarFunction encapsulates DuckDB's scalar function
   class ScalarFunction
     # Sets the return type for the scalar function.
-    # Currently only INTEGER type is supported.
+    # Currently supports INTEGER and BIGINT types.
     #
     # @param logical_type [DuckDB::LogicalType] the return type
     # @return [DuckDB::ScalarFunction] self
-    # @raise [DuckDB::Error] if the type is not INTEGER
+    # @raise [DuckDB::Error] if the type is not INTEGER or BIGINT
     def return_type=(logical_type)
       raise DuckDB::Error, 'logical_type must be a DuckDB::LogicalType' unless logical_type.is_a?(DuckDB::LogicalType)
 
-      # Check if the type is INTEGER
-      raise DuckDB::Error, 'Only INTEGER return type is currently supported' unless logical_type.type == :integer
+      # Check if the type is supported
+      unless %i[integer bigint].include?(logical_type.type)
+        raise DuckDB::Error, 'Only INTEGER and BIGINT return types are currently supported'
+      end
 
       _set_return_type(logical_type)
     end

--- a/test/duckdb_test/scalar_function_test.rb
+++ b/test/duckdb_test/scalar_function_test.rb
@@ -146,5 +146,22 @@ module DuckDBTest
 
       assert_equal [[10], [30], [nil]], result.to_a
     end
+
+    def test_scalar_function_bigint_return_type # rubocop:disable Metrics/MethodLength
+      @con.execute('SET threads=1')
+      @con.execute('CREATE TABLE test_table (value BIGINT)')
+      @con.execute('INSERT INTO test_table VALUES (9223372036854775807)') # Max int64
+
+      sf = DuckDB::ScalarFunction.new
+      sf.name = 'subtract_one'
+      sf.add_parameter(DuckDB::LogicalType.new(5)) # BIGINT
+      sf.return_type = DuckDB::LogicalType.new(5) # BIGINT
+      sf.set_function { |v| v - 1 } # Subtract to avoid overflow
+
+      @con.register_scalar_function(sf)
+      result = @con.execute('SELECT subtract_one(value) FROM test_table')
+
+      assert_equal 9_223_372_036_854_775_806, result.first.first
+    end
   end
 end


### PR DESCRIPTION
## Summary
Extends `vector_set_value_at()` to support **BIGINT** (int64_t) return values for scalar functions.

Part of the plan to add multiple type support (Phase 1.1 - BIGINT).

## Changes

### C Extension (`ext/duckdb/scalar_function.c`)
Added BIGINT case to `vector_set_value_at()` switch statement:
```c
case DUCKDB_TYPE_BIGINT:
    ((int64_t *)vector_data)[index] = NUM2LL(value);
    break;
```

### Ruby Validation (`lib/duckdb/scalar_function.rb`)
- Updated type validation to allow `:bigint` in addition to `:integer`
- Changed from single type check to array inclusion: `%i[integer bigint].include?(logical_type.type)`
- Updated documentation and error messages

### Test Coverage (`test/duckdb_test/scalar_function_test.rb`)
Added `test_scalar_function_bigint_return_type`:
- Tests with max int64 value: 9,223,372,036,854,775,807
- Verifies scalar function can return BIGINT values correctly
- Uses subtraction to avoid overflow

## Type Conversion

| Direction | Macro | Type |
|-----------|-------|------|
| Ruby → DuckDB | `NUM2LL` | `int64_t` |
| DuckDB → Ruby | `LL2NUM` | Already supported in `rbduckdb_vector_value_at()` |

## TDD Process ✅

1. **RED**: Added failing test → Error: "Only INTEGER return type is currently supported"
2. **GREEN**: Added BIGINT to C switch statement
3. **GREEN**: Updated Ruby type validation  
4. **Verify**: All 12 tests pass (20 assertions)
5. **Commit**: Clean, focused commit

## Testing

```bash
bundle exec ruby -Ilib:test test/duckdb_test/scalar_function_test.rb
# 12 runs, 20 assertions, 0 failures, 0 errors, 0 skips
```

### Example Usage
```ruby
con.execute('SET threads=1')
con.execute('CREATE TABLE t (value BIGINT)')
con.execute('INSERT INTO t VALUES (9223372036854775807)')

sf = DuckDB::ScalarFunction.new
sf.name = 'subtract_one'
sf.add_parameter(DuckDB::LogicalType.new(5)) # BIGINT
sf.return_type = DuckDB::LogicalType.new(5)  # BIGINT ✨ NEW
sf.set_function { |v| v - 1 }

con.register_scalar_function(sf)
result = con.execute('SELECT subtract_one(value) FROM t')
# => 9223372036854775806
```

## Related

- **Plan**: `~/mywork/ruby-duckdb-copilot/extend-vector-set-value-at-types.md` Phase 1.1
- **Next**: Phase 1.2 (DOUBLE), 1.3 (BOOLEAN), 1.4 (FLOAT)
- **Previous PRs**: #1068 (vector_set_value_at refactor), #1069 (warning fix)

## Checklist

- ✅ Test added and passing
- ✅ All existing tests pass
- ✅ RuboCop clean
- ✅ CHANGELOG.md updated
- ✅ Documentation updated
- ✅ Following TDD baby steps approach

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added BIGINT support to scalar functions for handling larger 64-bit integer values.
  * Exposed new API methods for configuring scalar functions: `add_parameter` and `set_return_type`.

* **Tests**
  * Added test coverage for BIGINT return type functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->