### PR TITLE
Add DOUBLE support to ScalarFunction return type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 # Unreleased
+- add DOUBLE support to DuckDB::ScalarFunction return type.
 - add BIGINT support to DuckDB::ScalarFunction return type.
 - refactor DuckDB::ScalarFunction to use vector_set_value_at helper.
 - fix DuckDB::ScalarFunction NULL input handling.

--- a/ext/duckdb/scalar_function.c
+++ b/ext/duckdb/scalar_function.c
@@ -234,6 +234,9 @@ static void vector_set_value_at(duckdb_vector vector, duckdb_logical_type elemen
         case DUCKDB_TYPE_BIGINT:
             ((int64_t *)vector_data)[index] = NUM2LL(value);
             break;
+        case DUCKDB_TYPE_DOUBLE:
+            ((double *)vector_data)[index] = NUM2DBL(value);
+            break;
         default:
             rb_raise(rb_eArgError, "Unsupported return type for scalar function");
             break;

--- a/lib/duckdb/scalar_function.rb
+++ b/lib/duckdb/scalar_function.rb
@@ -4,17 +4,17 @@ module DuckDB
   # DuckDB::ScalarFunction encapsulates DuckDB's scalar function
   class ScalarFunction
     # Sets the return type for the scalar function.
-    # Currently supports INTEGER and BIGINT types.
+    # Currently supports INTEGER, BIGINT, and DOUBLE types.
     #
     # @param logical_type [DuckDB::LogicalType] the return type
     # @return [DuckDB::ScalarFunction] self
-    # @raise [DuckDB::Error] if the type is not INTEGER or BIGINT
+    # @raise [DuckDB::Error] if the type is not supported
     def return_type=(logical_type)
       raise DuckDB::Error, 'logical_type must be a DuckDB::LogicalType' unless logical_type.is_a?(DuckDB::LogicalType)
 
       # Check if the type is supported
-      unless %i[integer bigint].include?(logical_type.type)
-        raise DuckDB::Error, 'Only INTEGER and BIGINT return types are currently supported'
+      unless %i[integer bigint double].include?(logical_type.type)
+        raise DuckDB::Error, 'Only INTEGER, BIGINT, and DOUBLE return types are currently supported'
       end
 
       _set_return_type(logical_type)


### PR DESCRIPTION
## Summary
Extends `vector_set_value_at()` to support **DOUBLE** (double precision floating-point) return values for scalar functions.

Part of the plan to add multiple type support (Phase 1.2 - DOUBLE).

## Changes

### C Extension (`ext/duckdb/scalar_function.c`)
Added DOUBLE case to `vector_set_value_at()` switch statement:
```c
case DUCKDB_TYPE_DOUBLE:
    ((double *)vector_data)[index] = NUM2DBL(value);
    break;
```

### Ruby Validation (`lib/duckdb/scalar_function.rb`)
- Updated type validation to allow `:double` in addition to `:integer` and `:bigint`
- Changed to: `%i[integer bigint double].include?(logical_type.type)`
- Updated documentation and error messages

### Test Coverage (`test/duckdb_test/scalar_function_test.rb`)
Added `test_scalar_function_double_return_type`:
- Tests with floating-point value: 3.14159 × 2 = 6.28318
- Uses `assert_in_delta` for floating-point comparison (tolerance 0.00001)
- Verifies scalar function can return DOUBLE values correctly

## Type Conversion

| Direction | Macro | Type |
|-----------|-------|------|
| Ruby → DuckDB | `NUM2DBL` | `double` |
| DuckDB → Ruby | `DBL2NUM` | Already supported in `rbduckdb_vector_value_at()` |

## Type ID Reference

- INTEGER: 4 (int32_t)
- BIGINT: 5 (int64_t)
- DOUBLE: **11** (double) ← New
- FLOAT: 7 (float) - Coming in Phase 1.4

## TDD Process ✅

1. **RED**: Added failing test → Error: "Only INTEGER and BIGINT return types are currently supported"
2. **GREEN**: Added DOUBLE to C switch statement
3. **GREEN**: Updated Ruby type validation  
4. **Verify**: All 13 tests pass (21 assertions)
5. **Commit**: Clean, focused commit

## Testing

```bash
bundle exec ruby -Ilib:test test/duckdb_test/scalar_function_test.rb
# 13 runs, 21 assertions, 0 failures, 0 errors, 0 skips
```

### Example Usage
```ruby
con.execute('SET threads=1')
con.execute('CREATE TABLE t (value DOUBLE)')
con.execute('INSERT INTO t VALUES (3.14159)')

sf = DuckDB::ScalarFunction.new
sf.name = 'multiply_by_two'
sf.add_parameter(DuckDB::LogicalType.new(11)) # DOUBLE
sf.return_type = DuckDB::LogicalType.new(11)  # DOUBLE ✨ NEW
sf.set_function { |v| v * 2 }

con.register_scalar_function(sf)
result = con.execute('SELECT multiply_by_two(value) FROM t')
# => 6.28318
```

## Related

- **Plan**: `~/mywork/ruby-duckdb-copilot/extend-vector-set-value-at-types.md` Phase 1.2
- **Next**: Phase 1.3 (BOOLEAN), 1.4 (FLOAT)
- **Previous PRs**: #1070 (BIGINT), #1068 (vector_set_value_at refactor)

## Checklist

- ✅ Test added and passing
- ✅ All existing tests pass (13 tests, 21 assertions)
- ✅ RuboCop clean
- ✅ CHANGELOG.md updated
- ✅ Documentation updated
- ✅ Following TDD baby steps approach
- ✅ Floating-point comparison uses `assert_in_delta`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * DuckDB scalar functions now support DOUBLE return types, enabling floating-point results in addition to the existing INTEGER and BIGINT types.

* **Tests**
  * Added test coverage for DOUBLE return type functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->