### PR TITLE
Add BOOLEAN support to ScalarFunction return type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 # Unreleased
+- add BOOLEAN support to DuckDB::ScalarFunction return type.
 - add DOUBLE support to DuckDB::ScalarFunction return type.
 - add BIGINT support to DuckDB::ScalarFunction return type.
 - refactor DuckDB::ScalarFunction to use vector_set_value_at helper.

--- a/ext/duckdb/scalar_function.c
+++ b/ext/duckdb/scalar_function.c
@@ -228,6 +228,9 @@ static void vector_set_value_at(duckdb_vector vector, duckdb_logical_type elemen
     vector_data = duckdb_vector_get_data(vector);
 
     switch(type_id) {
+        case DUCKDB_TYPE_BOOLEAN:
+            ((bool *)vector_data)[index] = RTEST(value);
+            break;
         case DUCKDB_TYPE_INTEGER:
             ((int32_t *)vector_data)[index] = NUM2INT(value);
             break;

--- a/lib/duckdb/scalar_function.rb
+++ b/lib/duckdb/scalar_function.rb
@@ -4,7 +4,7 @@ module DuckDB
   # DuckDB::ScalarFunction encapsulates DuckDB's scalar function
   class ScalarFunction
     # Sets the return type for the scalar function.
-    # Currently supports INTEGER, BIGINT, and DOUBLE types.
+    # Currently supports INTEGER, BIGINT, DOUBLE, and BOOLEAN types.
     #
     # @param logical_type [DuckDB::LogicalType] the return type
     # @return [DuckDB::ScalarFunction] self
@@ -13,8 +13,8 @@ module DuckDB
       raise DuckDB::Error, 'logical_type must be a DuckDB::LogicalType' unless logical_type.is_a?(DuckDB::LogicalType)
 
       # Check if the type is supported
-      unless %i[integer bigint double].include?(logical_type.type)
-        raise DuckDB::Error, 'Only INTEGER, BIGINT, and DOUBLE return types are currently supported'
+      unless %i[boolean integer bigint double].include?(logical_type.type)
+        raise DuckDB::Error, 'Only BOOLEAN, INTEGER, BIGINT, and DOUBLE return types are currently supported'
       end
 
       _set_return_type(logical_type)


### PR DESCRIPTION
## Summary
Extends `vector_set_value_at()` to support **BOOLEAN** (bool) return values for scalar functions.

Part of the plan to add multiple type support (Phase 1.3 - BOOLEAN).

## Changes

### C Extension (`ext/duckdb/scalar_function.c`)
Added BOOLEAN case to `vector_set_value_at()` switch statement:
```c
case DUCKDB_TYPE_BOOLEAN:
    ((bool *)vector_data)[index] = RTEST(value);
    break;
```

### Ruby Validation (`lib/duckdb/scalar_function.rb`)
- Updated type validation to allow `:boolean` 
- Changed to: `%i[boolean integer bigint double].include?(logical_type.type)`
- Updated documentation and error messages
- Ordered alphabetically for clarity

### Test Coverage (`test/duckdb_test/scalar_function_test.rb`)
Added `test_scalar_function_boolean_return_type`:
- Tests integer comparison: `value > 10`
- Input: `[5, 10, 15]` → Output: `[false, false, true]`
- Verifies scalar function can return BOOLEAN values correctly

## Type Conversion

| Direction | Macro | Type | Description |
|-----------|-------|------|-------------|
| Ruby → DuckDB | `RTEST` | `bool` | Tests Ruby value for truthiness (nil/false → false, everything else → true) |
| DuckDB → Ruby | `Qtrue`/`Qfalse` | Already supported | Converts bool to Ruby true/false |

## Type ID Reference

- BOOLEAN: **1** (bool) ← New
- INTEGER: 4 (int32_t)
- BIGINT: 5 (int64_t)
- DOUBLE: 11 (double)
- FLOAT: 7 (float) - Coming in Phase 1.4

## TDD Process ✅

1. **RED**: Added failing test → Error: "Only INTEGER, BIGINT, and DOUBLE return types are currently supported"
2. **GREEN**: Added BOOLEAN to C switch statement (using RTEST macro)
3. **GREEN**: Updated Ruby type validation  
4. **Verify**: All 14 tests pass (22 assertions)
5. **Commit**: Clean, focused commit

## Testing

```bash
bundle exec ruby -Ilib:test test/duckdb_test/scalar_function_test.rb
# 14 runs, 22 assertions, 0 failures, 0 errors, 0 skips
```

### Example Usage
```ruby
con.execute('SET threads=1')
con.execute('CREATE TABLE t (value INTEGER)')
con.execute('INSERT INTO t VALUES (5), (10), (15)')

sf = DuckDB::ScalarFunction.new
sf.name = 'is_greater_than_ten'
sf.add_parameter(DuckDB::LogicalType.new(4)) # INTEGER
sf.return_type = DuckDB::LogicalType.new(1)  # BOOLEAN ✨ NEW
sf.set_function { |v| v > 10 }

con.register_scalar_function(sf)
result = con.execute('SELECT is_greater_than_ten(value) FROM t ORDER BY value')
# => [[false], [false], [true]]
```

## Notes on RTEST

The `RTEST` macro is Ruby's standard way to convert any Ruby value to a C boolean:
- `nil` → `false`
- `false` → `false`
- Everything else (including 0, empty strings, etc.) → `true`

This matches Ruby's truthiness semantics perfectly.

## Related

- **Plan**: `~/mywork/ruby-duckdb-copilot/extend-vector-set-value-at-types.md` Phase 1.3
- **Next**: Phase 1.4 (FLOAT) - Last type in Phase 1!
- **Previous PRs**: #1071 (DOUBLE), #1070 (BIGINT), #1068 (vector_set_value_at refactor)

## Checklist

- ✅ Test added and passing
- ✅ All existing tests pass (14 tests, 22 assertions)
- ✅ RuboCop clean
- ✅ CHANGELOG.md updated
- ✅ Documentation updated
- ✅ Following TDD baby steps approach
- ✅ Proper Ruby truthiness handling with RTEST

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Scalar functions now support Boolean return types, enabling functions that return true/false values.

* **Tests**
  * Added test coverage for Boolean return type scalar functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->