### PR TITLE
Add FLOAT support to ScalarFunction return type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 # Unreleased
+- add FLOAT support to DuckDB::ScalarFunction return type.
 - add BOOLEAN support to DuckDB::ScalarFunction return type.
 - add DOUBLE support to DuckDB::ScalarFunction return type.
 - add BIGINT support to DuckDB::ScalarFunction return type.

--- a/ext/duckdb/scalar_function.c
+++ b/ext/duckdb/scalar_function.c
@@ -237,6 +237,9 @@ static void vector_set_value_at(duckdb_vector vector, duckdb_logical_type elemen
         case DUCKDB_TYPE_BIGINT:
             ((int64_t *)vector_data)[index] = NUM2LL(value);
             break;
+        case DUCKDB_TYPE_FLOAT:
+            ((float *)vector_data)[index] = (float)NUM2DBL(value);
+            break;
         case DUCKDB_TYPE_DOUBLE:
             ((double *)vector_data)[index] = NUM2DBL(value);
             break;

--- a/lib/duckdb/scalar_function.rb
+++ b/lib/duckdb/scalar_function.rb
@@ -4,7 +4,7 @@ module DuckDB
   # DuckDB::ScalarFunction encapsulates DuckDB's scalar function
   class ScalarFunction
     # Sets the return type for the scalar function.
-    # Currently supports INTEGER, BIGINT, DOUBLE, and BOOLEAN types.
+    # Currently supports BOOLEAN, INTEGER, BIGINT, FLOAT, and DOUBLE types.
     #
     # @param logical_type [DuckDB::LogicalType] the return type
     # @return [DuckDB::ScalarFunction] self
@@ -13,8 +13,8 @@ module DuckDB
       raise DuckDB::Error, 'logical_type must be a DuckDB::LogicalType' unless logical_type.is_a?(DuckDB::LogicalType)
 
       # Check if the type is supported
-      unless %i[boolean integer bigint double].include?(logical_type.type)
-        raise DuckDB::Error, 'Only BOOLEAN, INTEGER, BIGINT, and DOUBLE return types are currently supported'
+      unless %i[boolean integer bigint float double].include?(logical_type.type)
+        raise DuckDB::Error, 'Only BOOLEAN, INTEGER, BIGINT, FLOAT, and DOUBLE return types are currently supported'
       end
 
       _set_return_type(logical_type)


### PR DESCRIPTION
Completes Phase 1 - all simple numeric types now supported!