### PR TITLE
Add DATE support to scalar functions

### DIFF
--- a/ext/duckdb/scalar_function.c
+++ b/ext/duckdb/scalar_function.c
@@ -278,6 +278,22 @@ static void vector_set_value_at(duckdb_vector vector, duckdb_logical_type elemen
             ((duckdb_timestamp *)vector_data)[index] = ts;
             break;
         }
+        case DUCKDB_TYPE_DATE: {
+            // Convert Ruby Date to DuckDB date
+            // Ruby Date is defined in date library, check with Class name
+            VALUE date_class = rb_const_get(rb_cObject, rb_intern("Date"));
+            if (!rb_obj_is_kind_of(value, date_class)) {
+                rb_raise(rb_eTypeError, "Expected Date object for DATE");
+            }
+            
+            VALUE year = rb_funcall(value, rb_intern("year"), 0);
+            VALUE month = rb_funcall(value, rb_intern("month"), 0);
+            VALUE day = rb_funcall(value, rb_intern("day"), 0);
+            
+            duckdb_date date = rbduckdb_to_duckdb_date_from_value(year, month, day);
+            ((duckdb_date *)vector_data)[index] = date;
+            break;
+        }
         default:
             rb_raise(rb_eArgError, "Unsupported return type for scalar function");
             break;

--- a/lib/duckdb/scalar_function.rb
+++ b/lib/duckdb/scalar_function.rb
@@ -4,7 +4,7 @@ module DuckDB
   # DuckDB::ScalarFunction encapsulates DuckDB's scalar function
   class ScalarFunction
     # Sets the return type for the scalar function.
-    # Currently supports BIGINT, BLOB, BOOLEAN, DOUBLE, FLOAT, INTEGER, TIMESTAMP, and VARCHAR types.
+    # Currently supports BIGINT, BLOB, BOOLEAN, DATE, DOUBLE, FLOAT, INTEGER, TIMESTAMP, and VARCHAR types.
     #
     # @param logical_type [DuckDB::LogicalType] the return type
     # @return [DuckDB::ScalarFunction] self
@@ -13,9 +13,9 @@ module DuckDB
       raise DuckDB::Error, 'logical_type must be a DuckDB::LogicalType' unless logical_type.is_a?(DuckDB::LogicalType)
 
       # Check if the type is supported
-      unless %i[bigint blob boolean double float integer timestamp varchar].include?(logical_type.type)
+      unless %i[bigint blob boolean date double float integer timestamp varchar].include?(logical_type.type)
         raise DuckDB::Error,
-              'Only BIGINT, BLOB, BOOLEAN, DOUBLE, FLOAT, INTEGER, TIMESTAMP, and VARCHAR return types are ' \
+              'Only BIGINT, BLOB, BOOLEAN, DATE, DOUBLE, FLOAT, INTEGER, TIMESTAMP, and VARCHAR return types are ' \
               'currently supported'
       end
 


### PR DESCRIPTION
This PR adds DATE support to the `vector_set_value_at()` helper function, allowing scalar functions to return date values.

## Changes
- Added `DUCKDB_TYPE_DATE` case to `vector_set_value_at()`
- Converts Ruby Date to DuckDB date using existing `rbduckdb_to_duckdb_date_from_value()` helper
- Extracts year, month, day from Ruby Date object
- Updated type validation in `lib/duckdb/scalar_function.rb` to allow `:date`
- Added `test_scalar_function_date_return_type` test
- Updated error test to use TIME (now unsupported)

## Implementation Details
DATE conversion uses the existing utility function from `util.c`:
```c
VALUE year = rb_funcall(value, rb_intern("year"), 0);
VALUE month = rb_funcall(value, rb_intern("month"), 0);
VALUE day = rb_funcall(value, rb_intern("day"), 0);

duckdb_date date = rbduckdb_to_duckdb_date_from_value(year, month, day);
((duckdb_date *)vector_data)[index] = date;
```

## Testing
```ruby
sf.set_function { |date| date + 1 } # Add 1 day
```

All 19 tests passing with 33 assertions.

Part of Phase 4 (Date/Time types) in the type support plan.