### PR TITLE
Add TIME support to scalar functions

### DIFF
--- a/ext/duckdb/scalar_function.c
+++ b/ext/duckdb/scalar_function.c
@@ -294,6 +294,21 @@ static void vector_set_value_at(duckdb_vector vector, duckdb_logical_type elemen
             ((duckdb_date *)vector_data)[index] = date;
             break;
         }
+        case DUCKDB_TYPE_TIME: {
+            // Convert Ruby Time to DuckDB time (time-of-day only)
+            if (!rb_obj_is_kind_of(value, rb_cTime)) {
+                rb_raise(rb_eTypeError, "Expected Time object for TIME");
+            }
+            
+            VALUE hour = rb_funcall(value, rb_intern("hour"), 0);
+            VALUE min = rb_funcall(value, rb_intern("min"), 0);
+            VALUE sec = rb_funcall(value, rb_intern("sec"), 0);
+            VALUE usec = rb_funcall(value, rb_intern("usec"), 0);
+            
+            duckdb_time time = rbduckdb_to_duckdb_time_from_value(hour, min, sec, usec);
+            ((duckdb_time *)vector_data)[index] = time;
+            break;
+        }
         default:
             rb_raise(rb_eArgError, "Unsupported return type for scalar function");
             break;

--- a/lib/duckdb/scalar_function.rb
+++ b/lib/duckdb/scalar_function.rb
@@ -4,7 +4,7 @@ module DuckDB
   # DuckDB::ScalarFunction encapsulates DuckDB's scalar function
   class ScalarFunction
     # Sets the return type for the scalar function.
-    # Currently supports BIGINT, BLOB, BOOLEAN, DATE, DOUBLE, FLOAT, INTEGER, TIMESTAMP, and VARCHAR types.
+    # Currently supports BIGINT, BLOB, BOOLEAN, DATE, DOUBLE, FLOAT, INTEGER, TIME, TIMESTAMP, and VARCHAR types.
     #
     # @param logical_type [DuckDB::LogicalType] the return type
     # @return [DuckDB::ScalarFunction] self
@@ -13,10 +13,10 @@ module DuckDB
       raise DuckDB::Error, 'logical_type must be a DuckDB::LogicalType' unless logical_type.is_a?(DuckDB::LogicalType)
 
       # Check if the type is supported
-      unless %i[bigint blob boolean date double float integer timestamp varchar].include?(logical_type.type)
+      unless %i[bigint blob boolean date double float integer time timestamp varchar].include?(logical_type.type)
         raise DuckDB::Error,
-              'Only BIGINT, BLOB, BOOLEAN, DATE, DOUBLE, FLOAT, INTEGER, TIMESTAMP, and VARCHAR return types are ' \
-              'currently supported'
+              'Only BIGINT, BLOB, BOOLEAN, DATE, DOUBLE, FLOAT, INTEGER, TIME, TIMESTAMP, and VARCHAR return ' \
+              'types are currently supported'
       end
 
       _set_return_type(logical_type)


### PR DESCRIPTION
This PR adds TIME support to the `vector_set_value_at()` helper function, allowing scalar functions to return time values. **This completes Phase 4** - all date/time types are now supported! 🎉

## Changes
- Added `DUCKDB_TYPE_TIME` case to `vector_set_value_at()`
- Converts Ruby Time to DuckDB time using existing `rbduckdb_to_duckdb_time_from_value()` helper
- Extracts hour, min, sec, usec from Ruby Time object (time-of-day only)
- Updated type validation in `lib/duckdb/scalar_function.rb` to allow `:time`
- Added `test_scalar_function_time_return_type` test
- Updated error test to use INTERVAL (now unsupported)

## Implementation Details
TIME conversion uses the existing utility function from `util.c`:
```c
VALUE hour = rb_funcall(value, rb_intern("hour"), 0);
VALUE min = rb_funcall(value, rb_intern("min"), 0);
VALUE sec = rb_funcall(value, rb_intern("sec"), 0);
VALUE usec = rb_funcall(value, rb_intern("usec"), 0);

duckdb_time time = rbduckdb_to_duckdb_time_from_value(hour, min, sec, usec);
((duckdb_time *)vector_data)[index] = time;
```

## Testing
```ruby
sf.set_function { |time| time + 3600 } # Add 1 hour
```

All 20 tests passing with 38 assertions.

## Milestone
**Phase 4 Complete* 🎉 All date/time types are now supported:
- ✅ TIMESTAMP (PR #1076)
- ✅ DATE (PR #1077)
- ✅ TIME (this PR)

Currently supporting **10 types** in scalar functions:
BIGINT, BLOB, BOOLEAN, DATE, DOUBLE, FLOAT, INTEGER, TIME, TIMESTAMP, VARCHAR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Scalar functions now support TIME as a return type, enabling time-based computations and database queries.
* TIME return values are automatically converted to Ruby Time objects, preserving full precision including hours, minutes, seconds, and microseconds.
* Enhanced validation ensures proper error handling with descriptive messages for invalid TIME values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->