### PR TITLE
Add TINYINT support to scalar functions

### DIFF
--- a/test/duckdb_test/scalar_function_test.rb
+++ b/test/duckdb_test/scalar_function_test.rb
@@ -315,6 +315,27 @@ module DuckDBTest
       assert_equal 59, rows[1][0].min
     end
 
+    def test_scalar_function_tinyint_return_type # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Minitest/MultipleAssertions
+      @con.execute('SET threads=1')
+      @con.execute('CREATE TABLE test_table (value TINYINT)')
+      @con.execute('INSERT INTO test_table VALUES (100), (-50), (0)')
+
+      sf = DuckDB::ScalarFunction.new
+      sf.name = 'double_value'
+      sf.add_parameter(DuckDB::LogicalType.new(2)) # TINYINT (type ID 2)
+      sf.return_type = DuckDB::LogicalType.new(2) # TINYINT
+      sf.set_function { |v| v * 2 }
+
+      @con.register_scalar_function(sf)
+      result = @con.execute('SELECT double_value(value) FROM test_table ORDER BY value')
+      rows = result.to_a
+
+      assert_equal 3, rows.size
+      assert_equal(-100, rows[0][0]) # -50 * 2
+      assert_equal 0, rows[1][0]     # 0 * 2
+      assert_equal(-56, rows[2][0])  # 100 * 2 = 200, overflows to -56
+    end
+
     def test_scalar_function_utinyint_return_type # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Minitest/MultipleAssertions
       @con.execute('SET threads=1')
       @con.execute('CREATE TABLE test_table (value UTINYINT)')


### PR DESCRIPTION
Adds support for TINYINT (int8_t, type ID 2) return type in scalar functions.

Part of Phase 2: Additional Integer Types

**Changes:**
- Added TINYINT case to `vector_set_value_at()` in `ext/duckdb/scalar_function.c`
- Updated type validation in `lib/duckdb/scalar_function.rb` to allow TINYINT
- Added comprehensive test with overflow behavior

**Test coverage:**
- 21 tests, 42 assertions
- Tests basic arithmetic with TINYINT values
- Verifies overflow behavior (200 wraps to -56 for int8)

Range: -128 to 127

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added TINYINT (8-bit integer) type support to scalar functions. Users can now define scalar functions that accept and return TINYINT values with proper type validation and handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->