### PR TITLE
Refactor ScalarFunction to use SUPPORTED_RETURN_TYPES constant

### DIFF
--- a/lib/duckdb/scalar_function.rb
+++ b/lib/duckdb/scalar_function.rb
@@ -3,6 +3,28 @@
 module DuckDB
   # DuckDB::ScalarFunction encapsulates DuckDB's scalar function
   class ScalarFunction
+    # Supported return types for scalar functions
+    SUPPORTED_RETURN_TYPES = %i[
+      bigint
+      blob
+      boolean
+      date
+      double
+      float
+      integer
+      smallint
+      time
+      timestamp
+      tinyint
+      ubigint
+      uinteger
+      usmallint
+      utinyint
+      varchar
+    ].freeze
+
+    private_constant :SUPPORTED_RETURN_TYPES
+
     # Sets the return type for the scalar function.
     # Currently supports BIGINT, BLOB, BOOLEAN, DATE, DOUBLE, FLOAT, INTEGER, SMALLINT, TIME, TIMESTAMP, TINYINT,
     # UBIGINT, UINTEGER, USMALLINT, UTINYINT, and VARCHAR types.
@@ -13,13 +35,10 @@ module DuckDB
     def return_type=(logical_type)
       raise DuckDB::Error, 'logical_type must be a DuckDB::LogicalType' unless logical_type.is_a?(DuckDB::LogicalType)
 
-      # Check if the type is supported
-      supported_types = %i[bigint blob boolean date double float integer smallint time timestamp tinyint ubigint
-                           uinteger usmallint utinyint varchar]
-      unless supported_types.include?(logical_type.type)
+      unless SUPPORTED_RETURN_TYPES.include?(logical_type.type)
+        type_list = SUPPORTED_RETURN_TYPES.map(&:upcase).join(', ')
         raise DuckDB::Error,
-              'Only BIGINT, BLOB, BOOLEAN, DATE, DOUBLE, FLOAT, INTEGER, SMALLINT, TIME, TIMESTAMP, TINYINT, ' \
-              'UBIGINT, UINTEGER, USMALLINT, UTINYINT, and VARCHAR return types are currently supported'
+              "Only #{type_list} return types are currently supported"
       end
 
       _set_return_type(logical_type)


### PR DESCRIPTION
## Motivation

The current implementation has the list of supported types hardcoded in two places:
1. As a local variable in the method
2. As a hardcoded error message string

This makes it harder to maintain - when adding new types, you need to update both the array and the error message manually.

## Changes

### Extract constant
```ruby
SUPPORTED_RETURN_TYPES = %i[
  bigint blob boolean date double float
  integer smallint time timestamp tinyint
  ubigint uinteger usmallint utinyint varchar
].freeze

private_constant :SUPPORTED_RETURN_TYPES
```

### Generate error message dynamically
```ruby
type_list = SUPPORTED_RETURN_TYPES.map(&:upcase).join(', ')
raise DuckDB::Error, "Only #{type_list} return types are currently supported"
```

## Benefits

1. **Single source of truth**: Types are defined in one place
2. **Maintainability**: Adding a new type only requires updating the constant
3. **Accuracy**: Error message automatically stays in sync
4. **Readability**: Constant is formatted for clarity (one type per line)

## Testing

- ✅ All 611 tests pass (1172 assertions)
- ✅ Error message test passes (uses regex, works with new format)
- ✅ Error message includes all expected types
- ✅ RuboCop clean

## Example

Before:
```
Only BIGINT, BLOB, BOOLEAN, DATE, DOUBLE, FLOAT, INTEGER, SMALLINT, TIME, TIMESTAMP, TINYINT, UBIGINT, UINTEGER, USMALLINT, UTINYINT, and VARCHAR return types are currently supported
```

After (same message, but generated):
```
Only BIGINT, BLOB, BOOLEAN, DATE, DOUBLE, FLOAT, INTEGER, SMALLINT, TIME, TIMESTAMP, TINYINT, UBIGINT, UINTEGER, USMALLINT, UTINYINT, VARCHAR return types are currently supported
```

## Future

When adding a new type (e.g., DECIMAL), now you only need to:
1. Add to constant: `decimal`
2. Add C implementation
3. Add test

The error message updates automatically!