### PR TITLE
bump duckdb to 1.4.4.

### DIFF
--- a/.github/workflows/test_on_macos.yml
+++ b/.github/workflows/test_on_macos.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         ruby: ['3.2.9', '3.3.10', '3.4.8', '4.0.1', 'head']
-        duckdb: ['1.4.3', '1.3.2']
+        duckdb: ['1.4.4', '1.3.2']
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test_on_ubuntu.yml
+++ b/.github/workflows/test_on_ubuntu.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         ruby: ['3.2.9', '3.3.10', '3.4.8', '4.0.1', 'head']
-        duckdb: ['1.4.3', '1.3.2']
+        duckdb: ['1.4.4', '1.3.2']
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test_on_windows.yml
+++ b/.github/workflows/test_on_windows.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         ruby: ['3.2.9', '3.3.10', '3.4.8', 'ucrt', 'mingw', 'mswin', 'head']
-        duckdb: ['1.4.3', '1.3.2']
+        duckdb: ['1.4.4', '1.3.2']
 
     steps:
     - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 # Unreleased
+- bump duckdb to 1.4.4 on CI.
 - add inline style to DuckDB::Connection#register_scalar_function (accepts keyword arguments + block).
 - add DuckDB::ScalarFunction.create class method for declarative API.
 - add FLOAT support to DuckDB::ScalarFunction return type.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated DuckDB test matrix from version 1.4.3 to 1.4.4 across macOS, Ubuntu, and Windows CI workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->