### PR TITLE
refactor: Standardize object allocation to rb_class_new_instance

### DIFF
--- a/ext/duckdb/table_function.c
+++ b/ext/duckdb/table_function.c
@@ -268,7 +268,7 @@ static void table_function_init_callback(duckdb_init_info info) {
     TypedData_Get_Struct(self, rubyDuckDBTableFunction, &table_function_data_type, ctx);
 
     // Create InitInfo wrapper
-    init_info_obj = rb_funcall(cDuckDBInitInfo, rb_intern("allocate"), 0);
+    init_info_obj = rb_class_new_instance(0, NULL, cDuckDBInitInfo);
     init_info_ctx = get_struct_init_info(init_info_obj);
     init_info_ctx->info = info;
 
@@ -330,12 +330,12 @@ static void table_function_execute_callback(duckdb_function_info info, duckdb_da
     TypedData_Get_Struct(self, rubyDuckDBTableFunction, &table_function_data_type, ctx);
 
     // Create FunctionInfo wrapper
-    func_info_obj = rb_funcall(cDuckDBFunctionInfo, rb_intern("allocate"), 0);
+    func_info_obj = rb_class_new_instance(0, NULL, cDuckDBFunctionInfo);
     func_info_ctx = get_struct_function_info(func_info_obj);
     func_info_ctx->info = info;
 
     // Create DataChunk wrapper
-    data_chunk_obj = rb_funcall(cDuckDBDataChunk, rb_intern("allocate"), 0);
+    data_chunk_obj = rb_class_new_instance(0, NULL, cDuckDBDataChunk);
     data_chunk_ctx = get_struct_data_chunk(data_chunk_obj);
     data_chunk_ctx->data_chunk = output;
 


### PR DESCRIPTION
## Summary

Standardizes wrapper object allocation across all TableFunction callbacks to use `rb_class_new_instance` instead of mixing it with `rb_funcall(..., "allocate", 0)`.

## Problem

Inconsistent object allocation patterns:
- `bind_callback`: Used `rb_class_new_instance` ✅
- `init_callback`: Used `rb_funcall(..., "allocate")` ❌
- `execute_callback`: Used `rb_funcall(..., "allocate")` ❌
- `data_chunk.get_vector`: Used `rb_class_new_instance` ✅

## Changes

Replaced `rb_funcall(cDuckDBInitInfo, rb_intern("allocate"), 0)` with `rb_class_new_instance(0, NULL, cDuckDBInitInfo)` in:
- `table_function_init_callback` (InitInfo)
- `table_function_execute_callback` (FunctionInfo and DataChunk)

## Benefits

1. **More efficient**: No method lookup overhead
2. **Consistent**: All callbacks now use the same pattern
3. **Standard practice**: `rb_class_new_instance` is the idiomatic Ruby C API way

## Test Coverage

- ✅ All 650 tests passing
- ✅ 0 build warnings
- ✅ No behavioral changes

## Related

- Addresses CodeRabbit review: https://github.com/suketa/ruby-duckdb/pull/1103#pullrequestreview-3801192112
- Related to PR #1103 (Phase 5: InitInfo)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal object instantiation efficiency in DuckDB table function handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->