### PR TITLE
Add experimental warning to TableFunction documentation

### DIFF
--- a/lib/duckdb/table_function.rb
+++ b/lib/duckdb/table_function.rb
@@ -4,6 +4,8 @@ module DuckDB
   #
   # The DuckDB::TableFunction encapsulates a DuckDB table function.
   #
+  # NOTE: DuckDB::TableFunction is experimental now.
+  #
   #   require 'duckdb'
   #
   #   db = DuckDB::Database.new


### PR DESCRIPTION
Adds a note to the TableFunction class documentation indicating that it is experimental.