### PR TITLE
refactor: rewrite sample/issue922.rb to use table adapter pattern

### DIFF
--- a/sample/issue922.rb
+++ b/sample/issue922.rb
@@ -3,6 +3,38 @@
 require 'duckdb'
 require 'polars-df'
 
+class PolarsDataFrameTableAdapter
+  def call(data_frame, name, columns: nil)
+    columns ||= infer_columns(data_frame)
+    DuckDB::TableFunction.create(name:, columns:, &execute_block(data_frame))
+  end
+
+  private
+
+  def execute_block(data_frame)
+    counter = 0
+    height = data_frame.height
+    width = data_frame.width
+    proc do |_func_info, output|
+      next counter = 0 if counter >= height
+
+      write_row(data_frame, output, counter, width)
+      counter += 1
+      1
+    end
+  end
+
+  def write_row(data_frame, output, counter, width)
+    width.times { |index| output.set_value(index, 0, data_frame[counter, index]) }
+  end
+
+  def infer_columns(data_frame)
+    data_frame.columns.to_h { |header| [header, DuckDB::LogicalType::VARCHAR] }
+  end
+end
+
+DuckDB::TableFunction.add_table_adapter(Polars::DataFrame, PolarsDataFrameTableAdapter.new)
+
 df = Polars::DataFrame.new(
   {
     a: [1, 2, 3],
@@ -10,66 +42,10 @@ df = Polars::DataFrame.new(
   }
 )
 
-module DuckDB
-  class TableFunction
-    @table_adapters = {}
-    class << self
-      def add_table_adapter(klass, adapter)
-        @table_adapters[klass] = adapter
-      end
-
-      def table_adapter_for(klass)
-        @table_adapters[klass]
-      end
-    end
-  end
-
-  class Connection
-    def create_table_function(object, name)
-      adapter = TableFunction.table_adapter_for(object.class)
-      raise ArgumentError, "No table adapter registered for #{object.class}" if adapter.nil?
-
-      tf = adapter.call(object, name)
-      register_table_function(tf)
-    end
-  end
-
-  module Polars
-    module DataFrame
-      class TableAdapter
-        def call(df, name) # rubocop:disable Metrics/MethodLength, Naming/MethodParameterName
-          columns = df.columns.to_h { |header| [header, LogicalType::VARCHAR] }
-          counter = 0
-          height = df.height
-          width = df.columns.length
-
-          DuckDB::TableFunction.create(
-            name:,
-            columns:
-          ) do |_func_info, output|
-            if counter < height
-              width.times do |index|
-                output.set_value(index, 0, df[counter, index])
-              end
-              counter += 1
-              1
-            else
-              counter = 0
-              0
-            end
-          end
-        end
-      end
-    end
-  end
-  TableFunction.add_table_adapter(::Polars::DataFrame, DuckDB::Polars::DataFrame::TableAdapter.new)
-end
-
 db = DuckDB::Database.open
-
 con = db.connect
 con.query('SET threads=1')
-con.create_table_function(df, 'polars_df')
+con.expose_as_table(df, 'polars_df')
 result = con.query('SELECT * FROM polars_df()').to_a
 p result
 puts result.first.first == '1'


### PR DESCRIPTION
## Summary

Rewrites `sample/issue922.rb` to use the table adapter pattern, consistent with the approach in `sample/issue930.rb`.

## Changes

- Remove monkey-patches on `DuckDB::TableFunction`, `DuckDB::Connection`, and `DuckDB::Polars::DataFrame`
- Add `PolarsDataFrameTableAdapter` class following the same structure as `CSVTableAdapter`
- Register via `DuckDB::TableFunction.add_table_adapter(Polars::DataFrame, ...)`
- Use `con.expose_as_table` instead of `con.create_table_function`
- All RuboCop offenses resolved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored Polars DataFrame integration with DuckDB to optimize data streaming performance and row handling efficiency
  * Introduced dedicated adapter architecture to improve management of table function operations, registration, and data exposure
  * Enhanced code clarity and maintainability through improved structural organization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->