### PR TITLE
add DuckDB::LogicalType.resolve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 All notable changes to this project will be documented in this file.
 
 # Unreleased
-- add `DuckDB.cast` method.
+- add `DuckDB::LogicalType.resolve`.
+- add `DuckDB.cast`.
 - support TIMESTAMP_TZ column writing Ruby Time object in `DuckDB::DataChunk#set_value`.
 - add `DuckDB::MemoryHelper.write_timestamp_tz` method to write a Ruby Time object as a DuckDB TIMESTAMP_TZ (microseconds since Unix epoch UTC) to raw memory.
 - support TIMESTAMP column writing Ruby Time object in `DuckDB::DataChunk#set_value`.

--- a/lib/duckdb/logical_type.rb
+++ b/lib/duckdb/logical_type.rb
@@ -54,6 +54,14 @@ module DuckDB
       const_set(method_name.upcase, send(method_name))
     end
 
+    class << self
+      def resolve(symbol)
+        DuckDB::LogicalType.const_get(symbol.upcase)
+      rescue NameError
+        raise ArgumentError, "Unknown logical type symbol: #{symbol}"
+      end
+    end
+
     # returns logical type's type symbol
     # `:unknown` means that the logical type's type is unknown/unsupported by ruby-duckdb.
     # `:invalid` means that the logical type's type is invalid in duckdb.

--- a/test/duckdb_test/logical_type_test.rb
+++ b/test/duckdb_test/logical_type_test.rb
@@ -154,6 +154,21 @@ module DuckDBTest
       end
     end
 
+    def test_s_resolve
+      SINGLETON_METHOD_NAMES.each do |method_name|
+        logical_type = DuckDB::LogicalType.resolve(method_name)
+
+        assert_instance_of(DuckDB::LogicalType, logical_type)
+        assert_equal(method_name, logical_type.type)
+      end
+    end
+
+    def test_s_resolve_with_invalid_symbol
+      assert_raises(ArgumentError) do
+        DuckDB::LogicalType.resolve(:invalid_type)
+      end
+    end
+
     def test_type
       logical_types = @columns.map(&:logical_type)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a resolver method for DuckDB::LogicalType that dynamically resolves type symbols to their corresponding instances with clear error messaging for unsupported types.

* **Tests**
  * Added comprehensive test coverage for the LogicalType resolver method, validating successful type resolution and error handling for invalid inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->