### PR TITLE
DuckDB::BindInfo#add_result_column accepts symbol arguments.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 # Unreleased
+- DuckDB::BindInfo#add_result_column accepts symbols as column, column type argument.
 - add `DuckDB::LogicalType.resolve`.
 - add `DuckDB.cast`.
 - support TIMESTAMP_TZ column writing Ruby Time object in `DuckDB::DataChunk#set_value`.

--- a/ext/duckdb/bind_info.c
+++ b/ext/duckdb/bind_info.c
@@ -9,7 +9,7 @@ static VALUE convert_duckdb_value_to_ruby(duckdb_value param_value);
 static VALUE rbduckdb_bind_info_parameter_count(VALUE self);
 static VALUE rbduckdb_bind_info_get_parameter(VALUE self, VALUE index);
 static VALUE rbduckdb_bind_info_get_named_parameter(VALUE self, VALUE name);
-static VALUE rbduckdb_bind_info_add_result_column(VALUE self, VALUE column_name, VALUE logical_type);
+static VALUE rbduckdb_bind_info__add_result_column(VALUE self, VALUE column_name, VALUE logical_type);
 static VALUE rbduckdb_bind_info_set_cardinality(VALUE self, VALUE cardinality, VALUE is_exact);
 static VALUE rbduckdb_bind_info_set_error(VALUE self, VALUE error);
 
@@ -168,7 +168,7 @@ static VALUE rbduckdb_bind_info_get_named_parameter(VALUE self, VALUE name) {
  *   bind_info.add_result_column('id', DuckDB::LogicalType::BIGINT)
  *   bind_info.add_result_column('name', DuckDB::LogicalType::VARCHAR)
  */
-static VALUE rbduckdb_bind_info_add_result_column(VALUE self, VALUE column_name, VALUE logical_type) {
+static VALUE rbduckdb_bind_info__add_result_column(VALUE self, VALUE column_name, VALUE logical_type) {
     rubyDuckDBBindInfo *ctx;
     rubyDuckDBLogicalType *ctx_logical_type;
     const char *col_name;
@@ -236,7 +236,8 @@ void rbduckdb_init_duckdb_bind_info(void) {
     rb_define_method(cDuckDBBindInfo, "parameter_count", rbduckdb_bind_info_parameter_count, 0);
     rb_define_method(cDuckDBBindInfo, "get_parameter", rbduckdb_bind_info_get_parameter, 1);
     rb_define_method(cDuckDBBindInfo, "get_named_parameter", rbduckdb_bind_info_get_named_parameter, 1);
-    rb_define_method(cDuckDBBindInfo, "add_result_column", rbduckdb_bind_info_add_result_column, 2);
     rb_define_method(cDuckDBBindInfo, "set_cardinality", rbduckdb_bind_info_set_cardinality, 2);
     rb_define_method(cDuckDBBindInfo, "set_error", rbduckdb_bind_info_set_error, 1);
+
+    rb_define_private_method(cDuckDBBindInfo, "_add_result_column", rbduckdb_bind_info__add_result_column, 2);
 }

--- a/lib/duckdb/bind_info.rb
+++ b/lib/duckdb/bind_info.rb
@@ -24,9 +24,9 @@ module DuckDB
   #     bind_info.set_cardinality(limit, true)
   #   end
   #
-  # rubocop:disable Lint/EmptyClass
   class BindInfo
-    # All methods are defined in C extension (ext/duckdb/bind_info.c)
+    def add_result_column(name, type)
+      _add_result_column(name.to_s, DuckDB::LogicalType.resolve(type))
+    end
   end
-  # rubocop:enable Lint/EmptyClass
 end

--- a/lib/duckdb/logical_type.rb
+++ b/lib/duckdb/logical_type.rb
@@ -56,6 +56,8 @@ module DuckDB
 
     class << self
       def resolve(symbol)
+        return symbol if symbol.is_a?(DuckDB::LogicalType)
+
         DuckDB::LogicalType.const_get(symbol.upcase)
       rescue NameError
         raise ArgumentError, "Unknown logical type symbol: #{symbol}"

--- a/test/duckdb_test/bind_info_test.rb
+++ b/test/duckdb_test/bind_info_test.rb
@@ -14,7 +14,6 @@ module DuckDBTest
       @db.close
     end
 
-    # Test 1: Bind method accepts block and returns self
     def test_set_bind_callback
       table_function = DuckDB::TableFunction.new
       table_function.name = 'test_bind'
@@ -27,7 +26,6 @@ module DuckDBTest
       assert_equal table_function, result
     end
 
-    # Test 2: Add result column method works
     def test_bind_add_result_column
       table_function = DuckDB::TableFunction.new
       table_function.name = 'test_columns'
@@ -40,7 +38,19 @@ module DuckDBTest
       assert_equal table_function, result
     end
 
-    # Test 3: Parameter count method exists
+    def test_bind_add_result_column_with_symbol
+      table_function = DuckDB::TableFunction.new
+      table_function.name = 'test_bind'
+      table_function.add_parameter(DuckDB::LogicalType::BIGINT)
+
+      result = table_function.bind do |bind_info|
+        bind_info.add_result_column(:id, :bigint)
+        bind_info.add_result_column(:name, :varchar)
+      end
+
+      assert_equal table_function, result
+    end
+
     def test_bind_parameter_count
       table_function = DuckDB::TableFunction.new
       table_function.name = 'test_params'
@@ -55,7 +65,6 @@ module DuckDBTest
       assert_equal table_function, result
     end
 
-    # Test 4: Get parameter method accepts index
     def test_bind_get_parameter
       table_function = DuckDB::TableFunction.new
       table_function.name = 'test_get_param'
@@ -69,7 +78,6 @@ module DuckDBTest
       assert_equal table_function, result
     end
 
-    # Test 5: Get named parameter method accepts name
     def test_bind_get_named_parameter
       table_function = DuckDB::TableFunction.new
       table_function.name = 'test_named_param'
@@ -84,7 +92,6 @@ module DuckDBTest
       assert_equal table_function, result
     end
 
-    # Test 6: Set cardinality method works
     def test_bind_set_cardinality
       table_function = DuckDB::TableFunction.new
       table_function.name = 'test_cardinality'
@@ -97,7 +104,6 @@ module DuckDBTest
       assert_equal table_function, result
     end
 
-    # Test 7: Set error method works
     def test_bind_set_error
       table_function = DuckDB::TableFunction.new
       table_function.name = 'test_error'
@@ -109,7 +115,6 @@ module DuckDBTest
       assert_equal table_function, result
     end
 
-    # Test 8: Bind without block raises ArgumentError
     def test_bind_without_block_raises_error
       table_function = DuckDB::TableFunction.new
 
@@ -118,7 +123,6 @@ module DuckDBTest
       end
     end
 
-    # Test 9: Exception in bind block is caught safely
     def test_bind_exception_handling
       table_function = DuckDB::TableFunction.new
       table_function.name = 'test_exception'

--- a/test/duckdb_test/table_function_csv_test.rb
+++ b/test/duckdb_test/table_function_csv_test.rb
@@ -29,7 +29,7 @@ module DuckDBTest
       def columns(csv)
         headers = csv.first.headers
         csv.rewind
-        headers.to_h { |header| [header, DuckDB::LogicalType::VARCHAR] }
+        headers.to_h { |header| [header, :varchar] }
       end
 
       # read a line from the csv and write to output, return number of rows written

--- a/test/duckdb_test/table_function_test.rb
+++ b/test/duckdb_test/table_function_test.rb
@@ -316,6 +316,58 @@ module DuckDBTest
     end
     # rubocop:enable Metrics/AbcSize, Metrics/MethodLength, Minitest/MultipleAssertions
 
+    # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+    def test_symbol_columns
+      db = DuckDB::Database.open
+      conn = db.connect
+      conn.query('SET threads=1')
+
+      # Capture local variable in callbacks
+      row_multiplier = 2
+      done = false
+
+      tf = DuckDB::TableFunction.new
+      tf.name = 'test_symbol_columns'
+
+      # Bind callback
+      tf.bind do |bind_info|
+        bind_info.add_result_column(:id, :bigint)
+        bind_info.add_result_column(:value, :bigint)
+      end
+
+      # Init callback
+      tf.init do |_init_info|
+        done = false # Reset state
+      end
+
+      # Execute callback that captures local variable
+      tf.execute do |_func_info, output|
+        if done
+          output.size = 0
+        else
+          output.set_value(0, 0, 1)
+          output.set_value(1, 0, 10 * row_multiplier)
+          output.set_value(0, 1, 2)
+          output.set_value(1, 1, 20 * row_multiplier)
+          output.size = 2
+          done = true
+        end
+      end
+
+      conn.register_table_function(tf)
+
+      result = conn.query('SELECT * FROM test_symbol_columns()')
+      rows = result.each.to_a
+
+      assert_equal 2, rows.size
+      assert_equal 1, rows[0][0]
+      assert_equal 20, rows[0][1], 'Execute callback failed after GC compaction'
+
+      conn.disconnect
+      db.close
+    end
+    # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
+
     private
 
     def setup_incomplete_function


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for using symbols as column names when defining result columns in bind callbacks.
  * Enhanced type resolution to accept both type constants and symbols (e.g., `:varchar`, `:bigint`) for improved API flexibility.

* **Tests**
  * Updated test coverage to validate symbol-based column specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->