### PR TITLE
DuckDB.cast accept DuckDB::LogicalType.

### DIFF
--- a/lib/duckdb/casting.rb
+++ b/lib/duckdb/casting.rb
@@ -3,6 +3,7 @@
 module DuckDB
   module Casting
     def cast(value, type) # rubocop:disable Metrics/MethodLength
+      type = type.type if type.is_a?(DuckDB::LogicalType)
       case type
       when :integer, :bigint, :hugeint
         Integer(value)

--- a/test/duckdb_test/casting_test.rb
+++ b/test/duckdb_test/casting_test.rb
@@ -10,6 +10,10 @@ module DuckDBTest
       assert_equal(2_147_483_647, DuckDB.cast(2_147_483_647, :integer))
     end
 
+    def test_cast_logical_type_integer
+      assert_equal(2_147_483_647, DuckDB.cast('2147483647', DuckDB::LogicalType::INTEGER))
+    end
+
     def test_cast_integer_invalid
       assert_raises(ArgumentError) { DuckDB.cast('abc', :integer) }
     end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed type casting to properly handle logical type objects, resolving issues with integer value casting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->