### PR TITLE
feat: add `DuckDB::LogicalType.create_array` to create an array logical type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 # Unreleased
 - `DuckDB::DataChunk#set_value` accepts date.
+- add `DuckDB::LogicalType.create_array` to create an array logical type
 - add `DuckDB::LogicalType.create_list` to create a list logical type.
 - `DuckDB::BindInfo#add_result_column` accepts symbols as column, column type argument.
 - add `DuckDB::LogicalType.resolve`.

--- a/ext/duckdb/logical_type.c
+++ b/ext/duckdb/logical_type.c
@@ -23,6 +23,7 @@ static VALUE duckdb_logical_type_dictionary_size(VALUE self);
 static VALUE duckdb_logical_type_dictionary_value_at(VALUE self, VALUE didx);
 static VALUE duckdb_logical_type__get_alias(VALUE self);
 static VALUE duckdb_logical_type__set_alias(VALUE self, VALUE aname);
+static VALUE duckdb_logical_type_s_create_array_type(VALUE klass, VALUE child, VALUE array_size);
 static VALUE duckdb_logical_type_s_create_list_type(VALUE klass, VALUE child);
 static VALUE initialize(VALUE self, VALUE type_id_arg);
 
@@ -437,6 +438,24 @@ static VALUE duckdb_logical_type__set_alias(VALUE self, VALUE aname) {
 
 /*
  *  call-seq:
+ *    DuckDB::LogicalType._create_array_type(logical_type, size) -> DuckDB::LogicalType
+ *
+ *  Return an array logical type from the given child logical type and size.
+ */
+ static VALUE duckdb_logical_type_s_create_array_type(VALUE klass, VALUE child, VALUE array_size) {
+    rubyDuckDBLogicalType *child_ctx = get_struct_logical_type(child);
+    idx_t size = NUM2ULL(array_size);
+    duckdb_logical_type new_type = duckdb_create_array_type(child_ctx->logical_type, size);
+
+    if (!new_type) {
+        rb_raise(eDuckDBError, "Failed to create array type");
+    }
+
+    return rbduckdb_create_logical_type(new_type);
+}
+
+/*
+ *  call-seq:
  *    DuckDB::LogicalType._create_list_type(logical_type) -> DuckDB::LogicalType
  *
  *  Return a list logical type from the given child logical type.
@@ -490,6 +509,8 @@ void rbduckdb_init_duckdb_logical_type(void) {
     rb_define_method(cDuckDBLogicalType, "get_alias", duckdb_logical_type__get_alias, 0);
     rb_define_method(cDuckDBLogicalType, "set_alias", duckdb_logical_type__set_alias, 1);
 
+    rb_define_private_method(rb_singleton_class(cDuckDBLogicalType), "_create_array_type",
+                             duckdb_logical_type_s_create_array_type, 2);
     rb_define_private_method(rb_singleton_class(cDuckDBLogicalType), "_create_list_type",
                              duckdb_logical_type_s_create_list_type, 1);
 

--- a/lib/duckdb/logical_type.rb
+++ b/lib/duckdb/logical_type.rb
@@ -63,6 +63,21 @@ module DuckDB
         raise ArgumentError, "Unknown logical type symbol: #{symbol}"
       end
 
+      # Creates an array logical type with the given child type and size.
+      #
+      # The +type+ argument can be a symbol or a DuckDB::LogicalType instance.
+      # The +size+ argument specifies the fixed size of the array.
+      #
+      #   require 'duckdb'
+      #
+      #   array_type = DuckDB::LogicalType.create_array(:integer, 3)
+      #   array_type.type #=> :array
+      #   array_type.child_type.type #=> :integer
+      #   array_type.size #=> 3
+      def create_array(type, size)
+        _create_array_type(LogicalType.resolve(type), size)
+      end
+
       # Creates a list logical type with the given child type.
       #
       # The +type+ argument can be a symbol or a DuckDB::LogicalType instance.

--- a/test/duckdb_test/logical_type_test.rb
+++ b/test/duckdb_test/logical_type_test.rb
@@ -352,6 +352,43 @@ module DuckDBTest
       assert_raises(ArgumentError) { DuckDB::LogicalType.new(24) }
     end
 
+    def test_s_create_array_with_logical_type
+      array_type = DuckDB::LogicalType.create_array(DuckDB::LogicalType::INTEGER, 3)
+
+      assert_equal(:array, array_type.type)
+      assert_equal(:integer, array_type.child_type.type)
+      assert_equal(3, array_type.size)
+    end
+
+    def test_s_create_array_with_symbol
+      array_type = DuckDB::LogicalType.create_array(:varchar, 5)
+
+      assert_equal(:array, array_type.type)
+      assert_equal(:varchar, array_type.child_type.type)
+      assert_equal(5, array_type.size)
+    end
+
+    def test_s_create_array_with_nested_array
+      child_array_type = DuckDB::LogicalType.create_array(:integer, 3)
+      parent_array_type = DuckDB::LogicalType.create_array(child_array_type, 2)
+
+      assert_equal(:array, parent_array_type.type)
+      assert_equal(:array, parent_array_type.child_type.type)
+      assert_equal(:integer, parent_array_type.child_type.child_type.type)
+    end
+
+    def test_s_create_array_with_nested_array_size
+      child_array_type = DuckDB::LogicalType.create_array(:integer, 3)
+      parent_array_type = DuckDB::LogicalType.create_array(child_array_type, 2)
+
+      assert_equal(2, parent_array_type.size)
+      assert_equal(3, parent_array_type.child_type.size)
+    end
+
+    def test_s_create_array_with_invalid_arg
+      assert_raises(ArgumentError) { DuckDB::LogicalType.create_array(:nonexistent, 1) }
+    end
+
     def test_s_create_list_with_logical_type
       list_type = DuckDB::LogicalType.create_list(DuckDB::LogicalType::INTEGER)
 


### PR DESCRIPTION
refs: GH-940

In this PR, we add `DuckDB::LogicalType.create_array` to create an array logical type by wrapping the following C API:

- [duckdb_logical_type duckdb_create_array_type(duckdb_logical_type type, idx_t array_size)](https://duckdb.org/docs/stable/clients/c/api#duckdb_create_array_type)

The method accepts either a symbol (e.g., `:integer`) or a `DuckDB::LogicalType` instance, along with a fixed array size, and supports nested array types.

This is one of the steps for supporting the duckdb_create_xxxx_type C APIs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added array logical type creation capability with fixed sizes, supporting primitive types, symbol-based types, and nested array structures for flexible data type definitions.

* **Tests**
  * Comprehensive test coverage added for array logical type creation, including validation of nested arrays, various input type formats, and error handling for invalid type specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->