### PR TITLE
bump duckdb to 1.5.0

### DIFF
--- a/.github/workflows/test_on_macos.yml
+++ b/.github/workflows/test_on_macos.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         ruby: ['3.2.9', '3.3.10', '3.4.8', '4.0.1', 'head']
-        duckdb: ['1.4.4', '1.3.2']
+        duckdb: ['1.4.4', '1.5.0']
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test_on_ubuntu.yml
+++ b/.github/workflows/test_on_ubuntu.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         ruby: ['3.2.9', '3.3.10', '3.4.8', '4.0.1', 'head']
-        duckdb: ['1.4.4', '1.3.2']
+        duckdb: ['1.4.4', '1.5.0']
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test_on_windows.yml
+++ b/.github/workflows/test_on_windows.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         ruby: ['3.2.9', '3.3.10', '3.4.8', '4.0.1', 'ucrt', 'mingw', 'mswin', 'head']
-        duckdb: ['1.4.4', '1.3.2']
+        duckdb: ['1.4.4', '1.5.0']
 
     steps:
     - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 # Unreleased
+- bump duckdb to 1.5.0 on CI.
 
 # 1.4.4.0 - 2026-03-07
 - `DuckDB::DataChunk#set_value` accepts date.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Updated testing workflows to use DuckDB version 1.5.0 across all platforms (macOS, Ubuntu, Windows).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->