### PR TITLE
remove `PreparedStatement deprecate pending_prepared_stream`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 # Unreleased
 - bump duckdb to 1.5.0 on CI.
 
+## Breaking changes
+- remove `DuckDB::PrepareadStatement#pending_prepared_stream` method. Use `DuckDB::PreparedStatement#pending_prepared` instead.
+
 # 1.4.4.0 - 2026-03-07
 - `DuckDB::DataChunk#set_value` accepts date.
 - add `DuckDB::LogicalType.create_array` to create an array logical type

--- a/lib/duckdb/prepared_statement.rb
+++ b/lib/duckdb/prepared_statement.rb
@@ -51,11 +51,6 @@ module DuckDB
       PendingResult.new(self)
     end
 
-    def pending_prepared_stream
-      warn("`#{self.class}##{__method__}` will be deprecated. use `#{self.class}#pending_prepared` instead")
-      pending_prepared
-    end
-
     # returns statement type. The return value is one of the following symbols:
     #  :invalid, :select, :insert, :update, :explain, :delete, :prepare, :create,
     #  :execute, :alter, :transaction, :copy, :analyze, :variable_set, :create_func,


### PR DESCRIPTION
refs #914

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Breaking Changes**
  * Removed `pending_prepared_stream` method; migrate to `pending_prepared` instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->