### PR TITLE
drop duckdb v1.3.x and check duckdb v1.5.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 ## Breaking changes
 - remove `DuckDB::PrepareadStatement#pending_prepared_stream` method. Use `DuckDB::PreparedStatement#pending_prepared` instead.
 - remove `DuckDB::Connection#async_query_stream` method. Use `DuckDB::Connection#async_query` instead.
+- drop duckdb v1.3.x.
 
 # 1.4.4.0 - 2026-03-07
 - `DuckDB::DataChunk#set_value` accepts date.

--- a/ext/duckdb/extconf.rb
+++ b/ext/duckdb/extconf.rb
@@ -2,7 +2,7 @@
 
 require 'mkmf'
 
-DUCKDB_REQUIRED_VERSION = '1.3.0'
+DUCKDB_REQUIRED_VERSION = '1.4.0'
 
 def check_duckdb_header(header, version)
   found = find_header(
@@ -56,13 +56,12 @@ end
 dir_config('duckdb')
 
 check_duckdb_header('duckdb.h', DUCKDB_REQUIRED_VERSION)
-check_duckdb_library('duckdb', 'duckdb_get_table_names', DUCKDB_REQUIRED_VERSION)
-
-# check duckdb >= 1.3.0
-have_func('duckdb_get_table_names', 'duckdb.h')
+check_duckdb_library('duckdb', 'duckdb_appender_create_query', DUCKDB_REQUIRED_VERSION)
 
 # check duckdb >= 1.4.0
 have_func('duckdb_appender_create_query', 'duckdb.h')
+
+have_func('duckdb_unsafe_vector_assign_string_element_len', 'duckdb.h')
 
 $CFLAGS << ' -DDUCKDB_API_NO_DEPRECATED' if ENV['DUCKDB_API_NO_DEPRECATED']
 

--- a/ext/duckdb/ruby-duckdb.h
+++ b/ext/duckdb/ruby-duckdb.h
@@ -12,6 +12,10 @@
 #define HAVE_DUCKDB_H_GE_V1_4_0 1
 #endif
 
+#ifdef HAVE_DUCKDB_UNSAFE_VECTOR_ASSIGN_STRING_ELEMENT_LEN
+#define HAVE_DUCKDB_H_GE_V1_5_0 1
+#endif
+
 #include "./error.h"
 #include "./database.h"
 #include "./connection.h"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Dropped support for DuckDB v1.3.x. Minimum required DuckDB version is now v1.4.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->