### PR TITLE
bump Ruby 4.0.1 => 4.0.2

### DIFF
--- a/.github/workflows/test_on_macos.yml
+++ b/.github/workflows/test_on_macos.yml
@@ -20,7 +20,7 @@ jobs:
     timeout-minutes: 120
     strategy:
       matrix:
-        ruby: ['3.2.9', '3.3.10', '3.4.9', '4.0.1', 'head']
+        ruby: ['3.2.9', '3.3.10', '3.4.9', '4.0.2', 'head']
         duckdb: ['1.4.4', '1.5.0']
 
     steps:

--- a/.github/workflows/test_on_ubuntu.yml
+++ b/.github/workflows/test_on_ubuntu.yml
@@ -20,7 +20,7 @@ jobs:
     timeout-minutes: 120
     strategy:
       matrix:
-        ruby: ['3.2.9', '3.3.10', '3.4.9', '4.0.1', 'head']
+        ruby: ['3.2.9', '3.3.10', '3.4.9', '4.0.2', 'head']
         duckdb: ['1.4.4', '1.5.0']
 
     services:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated testing infrastructure to use Ruby 4.0.2 across macOS and Ubuntu CI workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->