### PR TITLE
Skip scalar function tests on Windows to avoid CI timeout

### DIFF
--- a/test/duckdb_test/connection_test.rb
+++ b/test/duckdb_test/connection_test.rb
@@ -322,6 +322,8 @@ module DuckDBTest
     # Tests for register_scalar_function
 
     def test_register_scalar_function_inline_with_single_parameter
+      skip 'Scalar functions with Ruby callbacks hang on Windows' if Gem.win_platform?
+
       @con.register_scalar_function(
         name: :inline_triple,
         return_type: DuckDB::LogicalType::INTEGER,
@@ -336,6 +338,8 @@ module DuckDBTest
     end
 
     def test_register_scalar_function_inline_with_multiple_parameters
+      skip 'Scalar functions with Ruby callbacks hang on Windows' if Gem.win_platform?
+
       @con.register_scalar_function(
         name: :inline_add,
         return_type: DuckDB::LogicalType::INTEGER,
@@ -350,6 +354,8 @@ module DuckDBTest
     end
 
     def test_register_scalar_function_inline_with_no_parameters
+      skip 'Scalar functions with Ruby callbacks hang on Windows' if Gem.win_platform?
+
       @con.register_scalar_function(
         name: :inline_constant,
         return_type: DuckDB::LogicalType::INTEGER
@@ -363,6 +369,8 @@ module DuckDBTest
     end
 
     def test_register_scalar_function_inline_with_varchar
+      skip 'Scalar functions with Ruby callbacks hang on Windows' if Gem.win_platform?
+
       @con.register_scalar_function(
         name: :inline_reverse,
         return_type: DuckDB::LogicalType::VARCHAR,
@@ -406,6 +414,8 @@ module DuckDBTest
     end
 
     def test_register_scalar_function_object_style_still_works
+      skip 'Scalar functions with Ruby callbacks hang on Windows' if Gem.win_platform?
+
       sf = DuckDB::ScalarFunction.create(
         name: :object_style,
         return_type: DuckDB::LogicalType::INTEGER


### PR DESCRIPTION
## Summary

Tests that invoke Ruby callbacks via scalar functions hang on Windows, causing random CI timeouts. Skip them temporarily until the root cause is identified and fixed.

## Changes

- Skip 5 scalar function tests on Windows platform using `Gem.win_platform?`

## Motivation

The scalar function tests that use Ruby block callbacks (via `register_scalar_function`) intermittently hang on Windows CI, making builds unreliable.

refs #1158

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test suite configuration to skip specific scalar function registration tests on Windows platform to ensure compatibility across operating systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->