### PR TITLE
Retry rake test on Windows up to 3 times with 5-minute timeout

### DIFF
--- a/.github/workflows/test_on_windows.yml
+++ b/.github/workflows/test_on_windows.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   test:
     runs-on: windows-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
     strategy:
       matrix:
         ruby: ['3.2.9', '3.3.10', '3.4.8', '4.0.1', 'ucrt', 'mingw', 'mswin', 'head']


### PR DESCRIPTION
## Summary

The `rake test` step intermittently hangs on Windows due to DuckDB Ruby callbacks deadlocking in certain Ruby/DuckDB version combinations (observed with Ruby 3.2.x, 3.3.x, 3.4.x).

## Change

Replace the single `rake test` step with `nick-fields/retry@v3`:
- **max_attempts**: 3
- **timeout_minutes**: 5 per attempt (vs the previous single 10-minute run)

If a run hangs and times out after 5 minutes, it will be retried automatically up to 2 more times.

Refs #1158

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Windows test workflow with automatic retry logic to improve test reliability and reduce transient failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->