### PR TITLE
Re-enable scalar function tests on Windows

### DIFF
--- a/test/duckdb_test/connection_test.rb
+++ b/test/duckdb_test/connection_test.rb
@@ -322,8 +322,6 @@ module DuckDBTest
     # Tests for register_scalar_function
 
     def test_register_scalar_function_inline_with_single_parameter
-      skip 'Scalar functions with Ruby callbacks hang on Windows' if Gem.win_platform?
-
       @con.register_scalar_function(
         name: :inline_triple,
         return_type: DuckDB::LogicalType::INTEGER,
@@ -338,8 +336,6 @@ module DuckDBTest
     end
 
     def test_register_scalar_function_inline_with_multiple_parameters
-      skip 'Scalar functions with Ruby callbacks hang on Windows' if Gem.win_platform?
-
       @con.register_scalar_function(
         name: :inline_add,
         return_type: DuckDB::LogicalType::INTEGER,
@@ -354,8 +350,6 @@ module DuckDBTest
     end
 
     def test_register_scalar_function_inline_with_no_parameters
-      skip 'Scalar functions with Ruby callbacks hang on Windows' if Gem.win_platform?
-
       @con.register_scalar_function(
         name: :inline_constant,
         return_type: DuckDB::LogicalType::INTEGER
@@ -369,8 +363,6 @@ module DuckDBTest
     end
 
     def test_register_scalar_function_inline_with_varchar
-      skip 'Scalar functions with Ruby callbacks hang on Windows' if Gem.win_platform?
-
       @con.register_scalar_function(
         name: :inline_reverse,
         return_type: DuckDB::LogicalType::VARCHAR,
@@ -414,8 +406,6 @@ module DuckDBTest
     end
 
     def test_register_scalar_function_object_style_still_works
-      skip 'Scalar functions with Ruby callbacks hang on Windows' if Gem.win_platform?
-
       sf = DuckDB::ScalarFunction.create(
         name: :object_style,
         return_type: DuckDB::LogicalType::INTEGER


### PR DESCRIPTION
## Summary

Remove the Windows skips added in #1159. Now that #1161 added automatic retry (3 attempts × 5 min timeout), the intermittent hang should be handled without permanently skipping tests.

## Changes

- Remove 5 `skip ... if Gem.win_platform?` lines from `connection_test.rb` (tests for `register_scalar_function`)

## Goal

Restore Windows test coverage and confirm whether these tests genuinely pass with retries, or if they need to be investigated further.

Refs #1158

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enabled scalar function registration tests to run on Windows platform, expanding compatibility testing coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->