### PR TITLE
Re-enable scalar function tests on Windows

### DIFF
--- a/test/duckdb_test/scalar_function_test.rb
+++ b/test/duckdb_test/scalar_function_test.rb
@@ -55,8 +55,6 @@ module DuckDBTest
     end
 
     def test_register_scalar_function
-      skip 'Scalar functions with Ruby test' if Gem.win_platform?
-
       sf = DuckDB::ScalarFunction.new
       sf.name = 'foo'
       sf.return_type = DuckDB::LogicalType::INTEGER
@@ -100,9 +98,7 @@ module DuckDBTest
       assert_match(/Unknown logical type/i, error.message)
     end
 
-    def test_scalar_function_with_one_parameter # rubocop:disable Metrics/MethodLength
-      skip 'Scalar functions with Ruby test' if Gem.win_platform?
-
+    def test_scalar_function_with_one_parameter
       @con.execute('CREATE TABLE test_table (value INTEGER)')
       @con.execute('INSERT INTO test_table VALUES (5), (10), (15)')
 
@@ -119,8 +115,6 @@ module DuckDBTest
     end
 
     def test_scalar_function_with_two_parameters # rubocop:disable Metrics/MethodLength
-      skip 'Scalar functions with Ruby test' if Gem.win_platform?
-
       @con.execute('CREATE TABLE test_table (a INTEGER, b INTEGER)')
       @con.execute('INSERT INTO test_table VALUES (5, 3), (10, 2), (15, 4)')
 
@@ -137,9 +131,7 @@ module DuckDBTest
       assert_equal [[8], [12], [19]], result.to_a
     end
 
-    def test_scalar_function_with_null_input # rubocop:disable Metrics/MethodLength
-      skip 'Scalar functions with Ruby test' if Gem.win_platform?
-
+    def test_scalar_function_with_null_input
       @con.execute('CREATE TABLE test_table (value INTEGER)')
       @con.execute('INSERT INTO test_table VALUES (5), (NULL), (15)')
 
@@ -155,9 +147,7 @@ module DuckDBTest
       assert_equal [[10], [30], [nil]], result.to_a
     end
 
-    def test_scalar_function_bigint_return_type # rubocop:disable Metrics/MethodLength
-      skip 'Scalar functions with Ruby test' if Gem.win_platform?
-
+    def test_scalar_function_bigint_return_type
       @con.execute('CREATE TABLE test_table (value BIGINT)')
       @con.execute('INSERT INTO test_table VALUES (9223372036854775807)') # Max int64
 
@@ -173,9 +163,7 @@ module DuckDBTest
       assert_equal 9_223_372_036_854_775_806, result.first.first
     end
 
-    def test_scalar_function_double_return_type # rubocop:disable Metrics/MethodLength
-      skip 'Scalar functions with Ruby test' if Gem.win_platform?
-
+    def test_scalar_function_double_return_type
       @con.execute('CREATE TABLE test_table (value DOUBLE)')
       @con.execute('INSERT INTO test_table VALUES (3.14159)')
 
@@ -191,9 +179,7 @@ module DuckDBTest
       assert_in_delta 6.28318, result.first.first, 0.00001
     end
 
-    def test_scalar_function_boolean_return_type # rubocop:disable Metrics/MethodLength
-      skip 'Scalar functions with Ruby test' if Gem.win_platform?
-
+    def test_scalar_function_boolean_return_type
       @con.execute('CREATE TABLE test_table (value INTEGER)')
       @con.execute('INSERT INTO test_table VALUES (5), (10), (15)')
 
@@ -209,9 +195,7 @@ module DuckDBTest
       assert_equal [[false], [false], [true]], result.to_a
     end
 
-    def test_scalar_function_float_return_type # rubocop:disable Metrics/MethodLength
-      skip 'Scalar functions with Ruby test' if Gem.win_platform?
-
+    def test_scalar_function_float_return_type
       @con.execute('CREATE TABLE test_table (value FLOAT)')
       @con.execute('INSERT INTO test_table VALUES (2.5)')
 
@@ -227,9 +211,7 @@ module DuckDBTest
       assert_in_delta 3.0, result.first.first, 0.0001
     end
 
-    def test_scalar_function_varchar_return_type # rubocop:disable Metrics/MethodLength
-      skip 'Scalar functions with Ruby test' if Gem.win_platform?
-
+    def test_scalar_function_varchar_return_type
       @con.execute('CREATE TABLE test_table (name VARCHAR)')
       @con.execute("INSERT INTO test_table VALUES ('Alice'), ('Bob')")
 
@@ -246,8 +228,6 @@ module DuckDBTest
     end
 
     def test_scalar_function_blob_return_type # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
-      skip 'Scalar functions with Ruby test' if Gem.win_platform?
-
       @con.execute('CREATE TABLE test_table (data BLOB)')
       @con.execute("INSERT INTO test_table VALUES ('\\x00\\x01\\x02\\x03'::BLOB), ('\\x00\\xAA\\xBB\\xCC'::BLOB)")
 
@@ -267,8 +247,6 @@ module DuckDBTest
     end
 
     def test_scalar_function_timestamp_return_type # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
-      skip 'Scalar functions with Ruby test' if Gem.win_platform?
-
       @con.execute('CREATE TABLE test_table (ts TIMESTAMP)')
       @con.execute("INSERT INTO test_table VALUES ('2024-01-15 10:30:00'), ('2024-12-25 23:59:59')")
 
@@ -288,8 +266,6 @@ module DuckDBTest
     end
 
     def test_scalar_function_date_return_type # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
-      skip 'Scalar functions with Ruby test' if Gem.win_platform?
-
       @con.execute('CREATE TABLE test_table (d DATE)')
       @con.execute("INSERT INTO test_table VALUES ('2024-01-15'), ('2024-12-25')")
 
@@ -309,8 +285,6 @@ module DuckDBTest
     end
 
     def test_scalar_function_time_return_type # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Minitest/MultipleAssertions
-      skip 'Scalar functions with Ruby test' if Gem.win_platform?
-
       @con.execute('CREATE TABLE test_table (t TIME)')
       @con.execute("INSERT INTO test_table VALUES ('10:30:00'), ('23:59:59')")
 
@@ -334,8 +308,6 @@ module DuckDBTest
     end
 
     def test_scalar_function_smallint_return_type # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Minitest/MultipleAssertions
-      skip 'Scalar functions with Ruby test' if Gem.win_platform?
-
       @con.execute('CREATE TABLE test_table (value SMALLINT)')
       @con.execute('INSERT INTO test_table VALUES (32767), (-32768), (1000)')
 
@@ -356,8 +328,6 @@ module DuckDBTest
     end
 
     def test_scalar_function_tinyint_return_type # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Minitest/MultipleAssertions
-      skip 'Scalar functions with Ruby test' if Gem.win_platform?
-
       @con.execute('CREATE TABLE test_table (value TINYINT)')
       @con.execute('INSERT INTO test_table VALUES (100), (-50), (0)')
 
@@ -378,8 +348,6 @@ module DuckDBTest
     end
 
     def test_scalar_function_utinyint_return_type # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Minitest/MultipleAssertions
-      skip 'Scalar functions with Ruby test' if Gem.win_platform?
-
       @con.execute('CREATE TABLE test_table (value UTINYINT)')
       @con.execute('INSERT INTO test_table VALUES (255), (0), (100)')
 
@@ -401,8 +369,6 @@ module DuckDBTest
     end
 
     def test_scalar_function_usmallint_return_type # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Minitest/MultipleAssertions
-      skip 'Scalar functions with Ruby test' if Gem.win_platform?
-
       @con.execute('CREATE TABLE test_table (value USMALLINT)')
       @con.execute('INSERT INTO test_table VALUES (65535), (0), (1000)')
 
@@ -423,8 +389,6 @@ module DuckDBTest
     end
 
     def test_scalar_function_uinteger_return_type # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Minitest/MultipleAssertions
-      skip 'Scalar functions with Ruby test' if Gem.win_platform?
-
       @con.execute('CREATE TABLE test_table (value UINTEGER)')
       @con.execute('INSERT INTO test_table VALUES (4294967200), (0), (1000000)')
 
@@ -445,8 +409,6 @@ module DuckDBTest
     end
 
     def test_scalar_function_ubigint_return_type # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Minitest/MultipleAssertions
-      skip 'Scalar functions with Ruby test' if Gem.win_platform?
-
       @con.execute('CREATE TABLE test_table (value UBIGINT)')
       @con.execute('INSERT INTO test_table VALUES (9223372036854775807), (0), (1000000000)')
 
@@ -467,8 +429,6 @@ module DuckDBTest
     end
 
     def test_scalar_function_gc_safety # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
-      skip 'Scalar functions with Ruby test' if Gem.win_platform?
-
       # Register function and immediately lose reference
       @con.register_scalar_function(DuckDB::ScalarFunction.new.tap do |sf|
         sf.name = 'test_func'
@@ -496,7 +456,6 @@ module DuckDBTest
 
     def test_gc_compaction_safety # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
       skip 'GC.compact not available' unless GC.respond_to?(:compact)
-      skip 'GC.compact hangs on Windows in parallel test execution' if Gem.win_platform?
 
       # Register scalar function with callback that captures local variable
       multiplier = 10
@@ -526,7 +485,6 @@ module DuckDBTest
 
     def test_gc_compaction_with_table_scan # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
       skip 'GC.compact not available' unless GC.respond_to?(:compact)
-      skip 'GC.compact hangs on Windows in parallel test execution' if Gem.win_platform?
 
       @con.execute('CREATE TABLE test_table (value INTEGER)')
       @con.execute('INSERT INTO test_table VALUES (1), (2), (3), (4), (5)')
@@ -555,8 +513,6 @@ module DuckDBTest
     # Tests for ScalarFunction.create class method
 
     def test_create_with_single_parameter # rubocop:disable Metrics/MethodLength
-      skip 'Scalar functions with Ruby test' if Gem.win_platform?
-
       sf = DuckDB::ScalarFunction.create(
         name: :triple,
         return_type: DuckDB::LogicalType::INTEGER,
@@ -574,8 +530,6 @@ module DuckDBTest
     end
 
     def test_create_with_multiple_parameters # rubocop:disable Metrics/MethodLength
-      skip 'Scalar functions with Ruby test' if Gem.win_platform?
-
       sf = DuckDB::ScalarFunction.create(
         name: :add_numbers,
         return_type: DuckDB::LogicalType::INTEGER,
@@ -592,9 +546,7 @@ module DuckDBTest
       assert_equal 30, rows[0][0]
     end
 
-    def test_create_with_no_parameters # rubocop:disable Metrics/MethodLength
-      skip 'Scalar functions with Ruby test' if Gem.win_platform?
-
+    def test_create_with_no_parameters
       sf = DuckDB::ScalarFunction.create(
         name: :constant_value,
         return_type: DuckDB::LogicalType::INTEGER
@@ -635,8 +587,6 @@ module DuckDBTest
     end
 
     def test_create_accepts_symbol_for_name
-      skip 'Scalar functions with Ruby test' if Gem.win_platform?
-
       sf = DuckDB::ScalarFunction.create(
         name: :symbol_name,
         return_type: DuckDB::LogicalType::INTEGER
@@ -650,8 +600,6 @@ module DuckDBTest
     end
 
     def test_create_accepts_string_for_name
-      skip 'Scalar functions with Ruby test' if Gem.win_platform?
-
       sf = DuckDB::ScalarFunction.create(
         name: 'string_name',
         return_type: DuckDB::LogicalType::INTEGER
@@ -665,8 +613,6 @@ module DuckDBTest
     end
 
     def test_create_with_different_types # rubocop:disable Metrics/MethodLength
-      skip 'Scalar functions with Ruby test' if Gem.win_platform?
-
       sf = DuckDB::ScalarFunction.create(
         name: :concat_with_separator,
         return_type: DuckDB::LogicalType::VARCHAR,
@@ -684,9 +630,7 @@ module DuckDBTest
       assert_equal 'Hello - World', rows[0][0]
     end
 
-    def test_scalar_function_with_multithread # rubocop:disable Metrics/MethodLength
-      skip 'Scalar functions with Ruby test' if Gem.win_platform?
-
+    def test_scalar_function_with_multithread
       @con.execute('SET threads=4')
       @con.execute('CREATE TABLE large_test AS SELECT range::INTEGER AS value FROM range(10000)')
 
@@ -704,8 +648,6 @@ module DuckDBTest
     end
 
     def test_scalar_function_with_symbol_return_type_and_params
-      skip 'Scalar functions with Ruby test' if Gem.win_platform?
-
       @con.execute('CREATE TABLE large_test AS SELECT range::INTEGER AS value FROM range(10000)')
 
       sf = DuckDB::ScalarFunction.new


### PR DESCRIPTION
## Summary

Remove 35 Windows skips from `scalar_function_test.rb` added in earlier PRs. The retry mechanism (#1161) should handle intermittent hangs.

Refs #1158

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Scalar function registration, execution, and parameterization tests now run on Windows instead of being skipped.
  * GC compaction tests enabled on Windows, expanding test coverage for the platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->