### PR TITLE
Re-enable table function tests on Windows

### DIFF
--- a/test/duckdb_test/table_function_test.rb
+++ b/test/duckdb_test/table_function_test.rb
@@ -14,8 +14,6 @@ module DuckDBTest
     # Test: Create function with set_value (high-level API)
     # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Minitest/MultipleAssertions
     def test_create_with_set_value
-      skip if Gem.win_platform?
-
       db = DuckDB::Database.open
       conn = db.connect
       conn.query('SET threads=1')
@@ -91,7 +89,6 @@ module DuckDBTest
     # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Minitest/MultipleAssertions
     def test_gc_compaction_safety
       skip 'GC.compact not available' unless GC.respond_to?(:compact)
-      skip 'GC.compact hangs on Windows in parallel test execution' if Gem.win_platform?
 
       db = DuckDB::Database.open
       conn = db.connect
@@ -159,8 +156,6 @@ module DuckDBTest
 
     # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     def test_symbol_columns
-      skip if Gem.win_platform?
-
       db = DuckDB::Database.open
       conn = db.connect
       conn.query('SET threads=1')


### PR DESCRIPTION
## Summary

Remove 3 Windows skips from `table_function_test.rb`. The retry mechanism (#1161) should handle intermittent hangs.

Refs #1158

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests
* Expanded Windows platform test coverage for table functions to improve compatibility and reliability across Windows environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->