### PR TITLE
Re-enable table function integration tests on Windows

### DIFF
--- a/test/duckdb_test/table_function_integration_test.rb
+++ b/test/duckdb_test/table_function_integration_test.rb
@@ -18,8 +18,6 @@ module DuckDBTest
     # Test 1: Simple table function returning data
     # rubocop:disable Minitest/MultipleAssertions
     def test_simple_table_function
-      skip if Gem.win_platform?
-
       table_function = create_simple_function
 
       @connection.register_table_function(table_function)
@@ -37,8 +35,6 @@ module DuckDBTest
     # Test 2: Table function with parameters
     # rubocop:disable Minitest/MultipleAssertions
     def test_table_function_with_parameters
-      skip 'test_simple_table_function' if Gem.win_platform?
-
       table_function = create_parameterized_function
 
       @connection.register_table_function(table_function)


### PR DESCRIPTION
Remove 2 Windows skips from `table_function_integration_test.rb`. The retry mechanism (#1161) should handle intermittent hangs.\n\nRefs #1158

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed platform-specific skip conditions, enabling table function tests to execute on Windows systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->