### PR TITLE
Reduce Windows CI retry timeout from 5 to 3 minutes

### DIFF
--- a/.github/workflows/test_on_windows.yml
+++ b/.github/workflows/test_on_windows.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   test:
     runs-on: windows-latest
-    timeout-minutes: 20
+    timeout-minutes: 15
     strategy:
       matrix:
         ruby: ['3.2.9', '3.3.10', '3.4.8', '4.0.1', 'ucrt', 'mingw', 'mswin', 'head']
@@ -53,7 +53,7 @@ jobs:
     - name: rake test
       uses: nick-fields/retry@v3
       with:
-        timeout_minutes: 5
+        timeout_minutes: 3
         max_attempts: 3
         command: bundle exec rake test TESTOPTS="--verbose"
 


### PR DESCRIPTION
Tests consistently complete well within 3 minutes when not hanging, so reduce the per-attempt timeout from 5 to 3 minutes. Also reduce the job-level timeout from 20 to 15 minutes accordingly.\n\nRefs #1158

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized Windows CI workflow timeouts for improved test execution efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->