### PR TITLE
Re-enable GC stress tests on Windows

### DIFF
--- a/test/duckdb_test/gc_stress_test.rb
+++ b/test/duckdb_test/gc_stress_test.rb
@@ -18,7 +18,6 @@ module DuckDBTest
 
     def test_multiple_scalar_functions_with_gc_compaction
       skip 'GC.compact not available' unless GC.respond_to?(:compact)
-      skip 'GC.compact hangs on Windows in parallel test execution' if Gem.win_platform?
 
       # Register multiple scalar functions
       5.times do |i|
@@ -47,7 +46,6 @@ module DuckDBTest
 
     def test_scalar_function_aggressive_gc_stress
       skip 'GC.compact not available' unless GC.respond_to?(:compact)
-      skip 'GC.compact hangs on Windows in parallel test execution' if Gem.win_platform?
 
       # Capture multiple local variables
       base = 100
@@ -81,7 +79,6 @@ module DuckDBTest
     # rubocop:disable Minitest/MultipleAssertions
     def test_table_function_with_gc_compaction
       skip 'GC.compact not available' unless GC.respond_to?(:compact)
-      skip 'GC.compact hangs on Windows in parallel test execution' if Gem.win_platform?
 
       @con.execute('SET threads=1') # Table functions still require single-threaded execution
 
@@ -134,7 +131,6 @@ module DuckDBTest
 
     def test_mixed_functions_gc_stress
       skip 'GC.compact not available' unless GC.respond_to?(:compact)
-      skip 'GC.compact hangs on Windows in parallel test execution' if Gem.win_platform?
 
       @con.execute('SET threads=1') # Table functions still require single-threaded execution
 


### PR DESCRIPTION
Remove 4 Windows skips from `gc_stress_test.rb`. The retry mechanism (#1161) should handle intermittent hangs.\n\nRefs #1158

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed platform-specific test skips to enable GC stress tests on Windows platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->