### PR TITLE
ci: add duckdb cache for Windows workflow

### DIFF
--- a/.github/workflows/test_on_windows.yml
+++ b/.github/workflows/test_on_windows.yml
@@ -31,24 +31,30 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby }}
 
+    - name: duckdb cache
+      id: duckdb-cache
+      uses: actions/cache@v4
+      with:
+        path: libduckdb-windows-amd64
+        key: ${{ runner.os }}-duckdb-v${{ matrix.duckdb }}
+
     - name: download duckdb binary for windows 64bit
+      if: steps.duckdb-cache.outputs.cache-hit != 'true'
       env:
         DUCKDB_VERSION: ${{ matrix.duckdb }}
       run: |
         curl -OL https://github.com/duckdb/duckdb/releases/download/v${env:DUCKDB_VERSION}/libduckdb-windows-amd64.zip
-
-    - name: extract zip file
-      run: |
-        unzip libduckdb-windows-amd64.zip
+        mkdir libduckdb-windows-amd64
+        unzip libduckdb-windows-amd64.zip -d libduckdb-windows-amd64
 
     - name: setup duckdb.dll
       run: |
-        cp duckdb.dll C:/Windows/System32/
+        cp libduckdb-windows-amd64/duckdb.dll C:/Windows/System32/
 
     - name: Build with Rake with Ruby ${{ matrix.ruby }}
       run: |
         bundle install
-        bundle exec rake build -- --with-duckdb-include=../../../.. --with-duckdb-lib=../../../..
+        bundle exec rake build -- --with-duckdb-include=../../../../libduckdb-windows-amd64 --with-duckdb-lib=../../../../libduckdb-windows-amd64
 
     - name: rake test
       uses: nick-fields/retry@v3


### PR DESCRIPTION
Use `actions/cache@v4` to cache the downloaded DuckDB binary (extracted into `libduckdb-windows-amd64/`), avoiding re-downloading from GitHub releases on every test run.

## Changes
- Add `duckdb cache` step using `actions/cache@v4` with key `${{ runner.os }}-duckdb-v${{ matrix.duckdb }}`
- Download and extract zip only on cache miss
- Update include/lib paths to point to the cached `libduckdb-windows-amd64/` directory

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Chores**
- Enhanced Windows CI pipeline with automated caching of build dependencies, reducing build times and improving efficiency across test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->