### PR TITLE
ci: reduce Windows job timeout-minutes from 15 to 12

### DIFF
--- a/.github/workflows/test_on_windows.yml
+++ b/.github/workflows/test_on_windows.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   test:
     runs-on: windows-latest
-    timeout-minutes: 15
+    timeout-minutes: 12
     strategy:
       matrix:
         ruby: ['3.2.9', '3.3.10', '3.4.8', '4.0.1', 'ucrt', 'mingw', 'mswin', 'head']


### PR DESCRIPTION
DuckDB binary is now cached via `actions/cache@v4` (merged in #1170), so the download step is skipped on cache hits, making 15 minutes unnecessarily long. Reduce to 12 minutes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized test job execution parameters for Windows test runner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->