### PR TITLE
ci: use precompiled DuckDB library on Ubuntu

### DIFF
--- a/.github/workflows/test_on_ubuntu.yml
+++ b/.github/workflows/test_on_ubuntu.yml
@@ -56,6 +56,12 @@ jobs:
         DUCKDB_VERSION: ${{ matrix.duckdb }}
       run: |
         curl -OL https://github.com/duckdb/duckdb/releases/download/v${DUCKDB_VERSION}/libduckdb-linux-amd64.zip
+        case "${DUCKDB_VERSION}" in
+          "1.5.0") EXPECTED_SHA256="e9b2adb9dc5348da57eee9562782e0e7f543e74ff26d634bc7c208a5b6c59a1c" ;;
+          "1.4.4") EXPECTED_SHA256="09cc288295964d897b47665d1898e16e8ef176cae9ea615797fc136eae15bd5d" ;;
+          *) echo "No known SHA256 for DuckDB v${DUCKDB_VERSION}"; exit 1 ;;
+        esac
+        echo "${EXPECTED_SHA256}  libduckdb-linux-amd64.zip" | sha256sum -c
         mkdir libduckdb-linux-amd64
         unzip libduckdb-linux-amd64.zip -d libduckdb-linux-amd64
 
@@ -78,8 +84,15 @@ jobs:
         bundle exec rake build -- --with-duckdb-include=${GITHUB_WORKSPACE}/libduckdb-linux-amd64 --with-duckdb-lib=${GITHUB_WORKSPACE}/libduckdb-linux-amd64
 
     - name: confirm duckdb library version
+      env:
+        EXPECTED_DUCKDB_VERSION: ${{ matrix.duckdb }}
       run: |
-        ruby -Ilib -rduckdb -e 'puts "duckdb library #{DuckDB.library_version}"'
+        ruby -Ilib -rduckdb -e '
+          actual = DuckDB::LIBRARY_VERSION
+          expected = ENV.fetch("EXPECTED_DUCKDB_VERSION")
+          abort("Expected DuckDB #{expected}, got #{actual}") if actual != expected
+          puts "duckdb library #{actual}"
+        '
 
     - name: test with Ruby ${{ matrix.ruby }}
       env:


### PR DESCRIPTION
Replace building DuckDB from source with downloading the precompiled `libduckdb-linux-amd64.zip` from GitHub releases, mirroring the approach used in `test_on_windows.yml`.

## Changes
- Download `libduckdb-linux-amd64.zip` from GitHub releases (cache miss only)
- Cache the extracted `libduckdb-linux-amd64/` directory via `actions/cache@v4`
- Copy `libduckdb.so` to `/usr/local/lib/` and run `ldconfig` (replacing the need to build from source)
- Simplify `--with-duckdb-include` / `--with-duckdb-lib` paths (headers and lib now in the same directory)
- Remove `DUCKDB_VERSION` env vars from steps where it was only used for path construction

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Optimized CI workflow by switching to prebuilt native libraries to speed builds and reduce compile time.
  * Improved caching behavior and simplified build environment configuration to make runs more reliable.
  * Added a pipeline step that logs the native library version during CI to aid diagnostics and reproducibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->