### PR TITLE
ci: use precompiled DuckDB library on macOS

### DIFF
--- a/.github/workflows/test_on_macos.yml
+++ b/.github/workflows/test_on_macos.yml
@@ -53,11 +53,6 @@ jobs:
         mkdir libduckdb-osx-universal
         unzip libduckdb-osx-universal.zip -d libduckdb-osx-universal
 
-    - name: setup libduckdb.dylib
-      run: |
-        sudo mkdir -p /usr/local/lib
-        sudo cp libduckdb-osx-universal/libduckdb.dylib /usr/local/lib/
-
     - name: bundle install with Ruby ${{ matrix.ruby }}
       run: |
         bundle install --jobs 4 --retry 3
@@ -84,6 +79,7 @@ jobs:
     - name: confirm duckdb library version
       env:
         EXPECTED_DUCKDB_VERSION: ${{ matrix.duckdb }}
+        DYLD_LIBRARY_PATH: ${{ github.workspace }}/libduckdb-osx-universal
       run: |
         ruby -Ilib -rduckdb -e '
           actual = DuckDB::LIBRARY_VERSION
@@ -95,6 +91,7 @@ jobs:
     - name: test with Ruby ${{ matrix.ruby }}
       env:
         MYSQL_TEST: 1
+        DYLD_LIBRARY_PATH: ${{ github.workspace }}/libduckdb-osx-universal
       run: |
         env RUBYOPT=-W:deprecated rake test
 


### PR DESCRIPTION
Replace building DuckDB from source with downloading the precompiled `libduckdb-osx-universal.zip` from GitHub releases, mirroring the approach used for Ubuntu in #1172.

## Changes
- Download `libduckdb-osx-universal.zip` from GitHub releases (cache miss only)
- SHA256 checksum verification before extracting (supply-chain hardening)
- Cache the extracted `libduckdb-osx-universal/` directory via `actions/cache@v4`
- Copy `libduckdb.dylib` to `/usr/local/lib/` (replaces `DYLD_LIBRARY_PATH` workaround)
- Simplify `--with-duckdb-include` / `--with-duckdb-lib` to a single path
- Remove `DUCKDB_VERSION` env vars from steps where it was only used for path construction
- Add strict `confirm duckdb library version` step (fails if `DuckDB::LIBRARY_VERSION` ≠ matrix version)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved macOS CI: switched to using prebuilt native binaries with caching, added integrity verification for specific versions, introduced a runtime version check that fails fast on mismatch, and simplified library-path and environment handling to speed and stabilize macOS test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->