### PR TITLE
feat: implement ScalarFunction#set_special_handling and null_handling: keyword

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project will be documented in this file.
 
 - add `DuckDB::ScalarFunction#varargs_type=` to register a scalar function that accepts a variable number of arguments of a given type (wraps `duckdb_scalar_function_set_varargs`).
 - `DuckDB::ScalarFunction.create` accepts `varargs_type:` keyword argument (mutually exclusive with `parameter_type:`/`parameter_types:`).
+- add `DuckDB::ScalarFunction#set_special_handling` to make the block receive `nil` for NULL inputs instead of DuckDB short-circuiting (wraps `duckdb_scalar_function_set_special_handling`).
+- `DuckDB::ScalarFunction.create` accepts `null_handling: true` keyword to enable special NULL handling.
+- add `34 => :any` to `Converter::IntToSym::HASH_TYPES` and `:any` to `ScalarFunction::SUPPORTED_TYPES` so `DuckDB::LogicalType::ANY` can be used with `varargs_type=`.
 
 # 1.5.0.2 - 2026-03-22
 

--- a/ext/duckdb/scalar_function.c
+++ b/ext/duckdb/scalar_function.c
@@ -33,6 +33,7 @@ static VALUE rbduckdb_scalar_function_set_name(VALUE self, VALUE name);
 static VALUE rbduckdb_scalar_function__set_return_type(VALUE self, VALUE logical_type);
 static VALUE rbduckdb_scalar_function__set_varargs(VALUE self, VALUE logical_type);
 static VALUE rbduckdb_scalar_function_add_parameter(VALUE self, VALUE logical_type);
+static VALUE rbduckdb_scalar_function__set_special_handling(VALUE self);
 static VALUE rbduckdb_scalar_function_set_function(VALUE self);
 static void scalar_function_callback(duckdb_function_info info, duckdb_data_chunk input, duckdb_vector output);
 static void vector_set_value_at(duckdb_vector vector, duckdb_logical_type element_type, idx_t index, VALUE value);
@@ -390,6 +391,15 @@ static VALUE rbduckdb_scalar_function__set_varargs(VALUE self, VALUE logical_typ
     return self;
 }
 
+static VALUE rbduckdb_scalar_function__set_special_handling(VALUE self) {
+    rubyDuckDBScalarFunction *p;
+
+    TypedData_Get_Struct(self, rubyDuckDBScalarFunction, &scalar_function_data_type, p);
+    duckdb_scalar_function_set_special_handling(p->scalar_function);
+
+    return self;
+}
+
 static VALUE rbduckdb_scalar_function_add_parameter(VALUE self, VALUE logical_type) {
     rubyDuckDBScalarFunction *p;
     rubyDuckDBLogicalType *lt;
@@ -693,6 +703,7 @@ void rbduckdb_init_duckdb_scalar_function(void) {
     rb_define_method(cDuckDBScalarFunction, "name=", rbduckdb_scalar_function_set_name, 1);
     rb_define_private_method(cDuckDBScalarFunction, "_set_return_type", rbduckdb_scalar_function__set_return_type, 1);
     rb_define_private_method(cDuckDBScalarFunction, "_set_varargs", rbduckdb_scalar_function__set_varargs, 1);
+    rb_define_private_method(cDuckDBScalarFunction, "_set_special_handling", rbduckdb_scalar_function__set_special_handling, 0);
     rb_define_private_method(cDuckDBScalarFunction, "_add_parameter", rbduckdb_scalar_function_add_parameter, 1);
     rb_define_method(cDuckDBScalarFunction, "set_function", rbduckdb_scalar_function_set_function, 0);
 }

--- a/lib/duckdb/converter/int_to_sym.rb
+++ b/lib/duckdb/converter/int_to_sym.rb
@@ -69,6 +69,7 @@ module DuckDB
         29 => :bit,
         30 => :time_tz,
         31 => :timestamp_tz,
+        34 => :any,
         35 => :bignum,
         36 => :sqlnull,
         37 => :string_literal,

--- a/lib/duckdb/scalar_function.rb
+++ b/lib/duckdb/scalar_function.rb
@@ -76,6 +76,7 @@ module DuckDB
 
     # Supported types for scalar function parameters and return values
     SUPPORTED_TYPES = %i[
+      any
       bigint
       blob
       boolean
@@ -120,6 +121,20 @@ module DuckDB
       logical_type = check_supported_type!(logical_type)
 
       _set_return_type(logical_type)
+    end
+
+    # Sets special NULL handling for the scalar function.
+    # By default DuckDB skips the callback and returns NULL when any input row
+    # contains a NULL argument. Calling this method disables that behaviour so
+    # the block is invoked even when inputs are NULL, receiving +nil+ for each
+    # NULL argument. This lets the function implement its own NULL semantics
+    # (e.g. treating NULL as 0, or counting NULLs).
+    #
+    # Wraps +duckdb_scalar_function_set_special_handling+.
+    #
+    # @return [DuckDB::ScalarFunction] self
+    def set_special_handling
+      _set_special_handling
     end
 
     # Sets the varargs type for the scalar function.

--- a/lib/duckdb/scalar_function.rb
+++ b/lib/duckdb/scalar_function.rb
@@ -13,6 +13,9 @@ module DuckDB
     # @param parameter_types [Array<DuckDB::LogicalType|:logical_type_symbol>, nil] multiple fixed parameter types
     # @param varargs_type [DuckDB::LogicalType|:logical_type_symbol, nil] trailing varargs element type;
     #   can be combined with parameter_type/parameter_types to add fixed leading parameters
+    # @param null_handling [Boolean] when +true+, calls +set_special_handling+ so the block
+    #   receives +nil+ for NULL inputs instead of DuckDB short-circuiting and returning NULL.
+    #   Default is +false+ (standard SQL NULL propagation).
     # @yield [fixed_args..., *varargs] the function implementation
     # @return [DuckDB::ScalarFunction] configured scalar function ready to register
     # @raise [ArgumentError] if block is not provided, or both parameter_type and parameter_types are specified
@@ -51,8 +54,16 @@ module DuckDB
     #     name: :random_num,
     #     return_type: :integer
     #   ) { rand(100) }
-    def self.create( # rubocop:disable Metrics/MethodLength,Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity
-      name:, return_type:, parameter_type: nil, parameter_types: nil, varargs_type: nil, &
+    #
+    # @example NULL-aware function (block receives nil for NULL inputs)
+    #   sf = DuckDB::ScalarFunction.create(
+    #     name: :null_as_zero,
+    #     return_type: :integer,
+    #     parameter_type: :integer,
+    #     null_handling: true
+    #   ) { |v| v.nil? ? 0 : v }
+    def self.create( # rubocop:disable Metrics/MethodLength,Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity,Metrics/ParameterLists
+      name:, return_type:, parameter_type: nil, parameter_types: nil, varargs_type: nil, null_handling: false, &
     )
       raise ArgumentError, 'Block required' unless block_given?
       raise ArgumentError, 'Cannot specify both parameter_type and parameter_types' if parameter_type && parameter_types
@@ -70,6 +81,7 @@ module DuckDB
       sf.return_type = return_type
       params.each { |type| sf.add_parameter(type) }
       sf.varargs_type = varargs_type if varargs_type
+      sf.set_special_handling if null_handling
       sf.set_function(&)
       sf
     end

--- a/test/duckdb_test/scalar_function_test.rb
+++ b/test/duckdb_test/scalar_function_test.rb
@@ -938,5 +938,190 @@ module DuckDBTest
 
       assert_equal 'a-b-c', result.first.first
     end
+
+    # =========================================================================
+    # Tests for set_special_handling
+    #
+    # `duckdb_scalar_function_set_special_handling` marks a scalar function to
+    # receive NULL inputs directly, bypassing DuckDB's standard SQL NULL
+    # propagation (which normally short-circuits the callback and returns NULL
+    # whenever any argument is NULL).
+    #
+    # With special handling enabled the Ruby block IS called even when one or
+    # more arguments are NULL (nil in Ruby), giving the function the chance to
+    # decide its own NULL semantics — e.g. treating NULL as 0, or returning a
+    # default value.
+    #
+    # Reference: duckdb_scalar_function_set_special_handling (duckdb.h:3719)
+    # Issue: https://github.com/suketa/ruby-duckdb/issues/1122
+    # =========================================================================
+
+    def test_set_special_handling_returns_self
+      # set_special_handling should return the ScalarFunction itself so it can
+      # be chained fluently with other configuration calls.
+      skip 'set_special_handling is not yet implemented (issue #1122)'
+
+      sf = DuckDB::ScalarFunction.new
+      result = sf.set_special_handling
+
+      assert_instance_of DuckDB::ScalarFunction, result
+      assert_equal sf.__id__, result.__id__
+    end
+
+    def test_set_special_handling_block_receives_null_arg
+      # By default DuckDB skips the callback and returns NULL when any input is
+      # NULL.  After set_special_handling the block IS called with nil, so the
+      # function can return something other than NULL.
+      #
+      # Here we implement COALESCE-like behaviour: treat a NULL INTEGER as 0.
+      skip 'set_special_handling is not yet implemented (issue #1122)'
+
+      sf = DuckDB::ScalarFunction.new
+      sf.name = 'null_as_zero'
+      sf.add_parameter(DuckDB::LogicalType::INTEGER)
+      sf.return_type = DuckDB::LogicalType::INTEGER
+      sf.set_special_handling
+      sf.set_function { |val| val.nil? ? 0 : val }
+
+      @con.register_scalar_function(sf)
+
+      # Without special handling, NULL input → NULL output.
+      # With special handling, NULL input → block is called → 0.
+      assert_equal 0,  @con.execute('SELECT null_as_zero(NULL)').first.first
+      assert_equal 42, @con.execute('SELECT null_as_zero(42)').first.first
+    end
+
+    def test_set_special_handling_with_two_parameters_any_null
+      # Both parameters arrive as-is (nil or value) when special handling is
+      # set.  The block should handle every combination of nil / non-nil.
+      skip 'set_special_handling is not yet implemented (issue #1122)'
+
+      sf = DuckDB::ScalarFunction.new
+      sf.name = 'add_nullable'
+      sf.add_parameter(DuckDB::LogicalType::INTEGER)
+      sf.add_parameter(DuckDB::LogicalType::INTEGER)
+      sf.return_type = DuckDB::LogicalType::INTEGER
+      sf.set_special_handling
+      # Treat NULL as 0 for addition
+      sf.set_function { |a, b| (a || 0) + (b || 0) }
+
+      @con.register_scalar_function(sf)
+
+      assert_equal 5, @con.execute('SELECT add_nullable(2, 3)').first.first
+      assert_equal 3, @con.execute('SELECT add_nullable(NULL, 3)').first.first
+      assert_equal 2, @con.execute('SELECT add_nullable(2, NULL)').first.first
+      assert_equal 0, @con.execute('SELECT add_nullable(NULL, NULL)').first.first
+    end
+
+    def test_set_special_handling_with_varargs_null_coalesce
+      # Varargs + special handling: even if individual args are NULL the block
+      # is invoked and may inspect/replace each nil in the splat.
+      skip 'set_special_handling is not yet implemented (issue #1122)'
+
+      sf = DuckDB::ScalarFunction.new
+      sf.name = 'sum_coalesce'
+      sf.varargs_type = DuckDB::LogicalType::INTEGER
+      sf.return_type = DuckDB::LogicalType::INTEGER
+      sf.set_special_handling
+      sf.set_function { |*args| args.map { |v| v || 0 }.sum }
+
+      @con.register_scalar_function(sf)
+
+      # Without special_handling this would return NULL; with it we get the sum
+      # of non-NULL values (NULLs coerced to 0).
+      assert_equal 4, @con.execute('SELECT sum_coalesce(1, NULL, 3)').first.first
+      assert_equal 0, @con.execute('SELECT sum_coalesce(NULL, NULL)').first.first
+    end
+
+    def test_set_special_handling_without_null_returns_normally
+      # Enabling special handling must not change behaviour when all inputs are
+      # non-NULL — the block should still be called and return correctly.
+      skip 'set_special_handling is not yet implemented (issue #1122)'
+
+      sf = DuckDB::ScalarFunction.new
+      sf.name = 'double_special'
+      sf.add_parameter(DuckDB::LogicalType::INTEGER)
+      sf.return_type = DuckDB::LogicalType::INTEGER
+      sf.set_special_handling
+      sf.set_function { |val| val * 2 }
+
+      @con.register_scalar_function(sf)
+
+      assert_equal 10, @con.execute('SELECT double_special(5)').first.first
+    end
+
+    def test_set_special_handling_can_return_null_explicitly
+      # Even with special handling the block may choose to return nil (NULL) —
+      # the method must not force a non-NULL result.
+      skip 'set_special_handling is not yet implemented (issue #1122)'
+
+      sf = DuckDB::ScalarFunction.new
+      sf.name = 'passthrough_null'
+      sf.add_parameter(DuckDB::LogicalType::INTEGER)
+      sf.return_type = DuckDB::LogicalType::INTEGER
+      sf.set_special_handling
+      sf.set_function { |val| val } # echo input — nil stays nil
+
+      @con.register_scalar_function(sf)
+
+      assert_nil @con.execute('SELECT passthrough_null(NULL)').first.first
+      assert_equal 7, @con.execute('SELECT passthrough_null(7)').first.first
+    end
+
+    def test_set_special_handling_null_count_varargs_integer
+      # Mirrors the canonical DuckDB C API test (capi_scalar_functions.cpp,
+      # "Test Scalar Functions - variadic number of ANY parameters") but uses
+      # INTEGER varargs instead of ANY, because DuckDB::LogicalType::ANY is not
+      # yet exposed (issue #1122).
+      #
+      # The function counts how many of its INTEGER arguments are NULL.
+      # With default NULL propagation the block would never be called when any
+      # arg is NULL; set_special_handling lets us actually count them.
+      #
+      # Expected behaviour (directly from the DuckDB C API test):
+      #   my_null_count(40, 1, 3)        → 0   (no NULLs)
+      #   my_null_count(1, 42, NULL)     → 1   (one NULL)
+      #   my_null_count(NULL, NULL, NULL)→ 3   (three NULLs)
+      #   my_null_count()                → 0   (no args, no NULLs)
+      skip 'set_special_handling is not yet implemented (issue #1122)'
+
+      sf = DuckDB::ScalarFunction.new
+      sf.name = 'my_null_count'
+      sf.varargs_type = DuckDB::LogicalType::INTEGER
+      sf.return_type = DuckDB::LogicalType::INTEGER
+      sf.set_special_handling
+      sf.set_function { |*args| args.count(&:nil?) }
+
+      @con.register_scalar_function(sf)
+
+      assert_equal 0, @con.execute('SELECT my_null_count(40, 1, 3)').first.first
+      assert_equal 1, @con.execute('SELECT my_null_count(1, 42, NULL)').first.first
+      assert_equal 3, @con.execute('SELECT my_null_count(NULL, NULL, NULL)').first.first
+      assert_equal 0, @con.execute('SELECT my_null_count()').first.first
+    end
+
+    def test_set_special_handling_null_count_any_varargs
+      # Same null_count function as above but using DuckDB::LogicalType::ANY,
+      # which allows arguments of mixed types (matching the DuckDB C API test
+      # exactly: my_null_count(40, [1], 'hello', 3) → 0).
+      #
+      # Skipped additionally until DuckDB::LogicalType::ANY is added
+      # (DUCKDB_TYPE_ANY = 34, see issue #1122).
+      skip 'set_special_handling with ANY varargs requires DuckDB::LogicalType::ANY (issue #1122)'
+
+      sf = DuckDB::ScalarFunction.new
+      sf.name = 'my_null_count_any'
+      sf.varargs_type = DuckDB::LogicalType::ANY
+      sf.return_type = DuckDB::LogicalType::INTEGER
+      sf.set_special_handling
+      sf.set_function { |*args| args.count(&:nil?) }
+
+      @con.register_scalar_function(sf)
+
+      assert_equal 0, @con.execute("SELECT my_null_count_any(40, 'hello', 3)").first.first
+      assert_equal 1, @con.execute("SELECT my_null_count_any(1, 42, NULL)").first.first
+      assert_equal 3, @con.execute('SELECT my_null_count_any(NULL, NULL, NULL)').first.first
+      assert_equal 0, @con.execute('SELECT my_null_count_any()').first.first
+    end
   end
 end

--- a/test/duckdb_test/scalar_function_test.rb
+++ b/test/duckdb_test/scalar_function_test.rb
@@ -939,7 +939,55 @@ module DuckDBTest
       assert_equal 'a-b-c', result.first.first
     end
 
-    # =========================================================================
+    def test_scalar_function_create_null_handling_false_by_default
+      # null_handling: defaults to false — DuckDB short-circuits on NULL input
+      # and returns NULL without calling the block.
+      sf = DuckDB::ScalarFunction.create(
+        name: :default_null,
+        return_type: :integer,
+        parameter_type: :integer
+      ) { |v| v.nil? ? 0 : v }
+
+      @con.register_scalar_function(sf)
+
+      assert_nil @con.execute('SELECT default_null(NULL)').first.first
+      assert_equal 42, @con.execute('SELECT default_null(42)').first.first
+    end
+
+    def test_scalar_function_create_with_null_handling_true
+      # null_handling: true calls set_special_handling so the block receives
+      # nil for NULL inputs and can return a non-NULL value.
+      sf = DuckDB::ScalarFunction.create(
+        name: :null_as_zero,
+        return_type: :integer,
+        parameter_type: :integer,
+        null_handling: true
+      ) { |v| v.nil? ? 0 : v }
+
+      @con.register_scalar_function(sf)
+
+      assert_equal 0,  @con.execute('SELECT null_as_zero(NULL)').first.first
+      assert_equal 42, @con.execute('SELECT null_as_zero(42)').first.first
+    end
+
+    def test_scalar_function_create_null_handling_with_varargs
+      # null_handling: true also works with varargs — NULLs arrive as nil
+      # in the splat and the block can count or replace them.
+      sf = DuckDB::ScalarFunction.create(
+        name: :count_nulls,
+        return_type: :integer,
+        varargs_type: :integer,
+        null_handling: true
+      ) { |*args| args.count(&:nil?) }
+
+      @con.register_scalar_function(sf)
+
+      assert_equal 0, @con.execute('SELECT count_nulls(1, 2, 3)').first.first
+      assert_equal 1, @con.execute('SELECT count_nulls(1, NULL, 3)').first.first
+      assert_equal 3, @con.execute('SELECT count_nulls(NULL, NULL, NULL)').first.first
+    end
+
+
     # Tests for set_special_handling
     #
     # `duckdb_scalar_function_set_special_handling` marks a scalar function to

--- a/test/duckdb_test/scalar_function_test.rb
+++ b/test/duckdb_test/scalar_function_test.rb
@@ -959,7 +959,6 @@ module DuckDBTest
     def test_set_special_handling_returns_self
       # set_special_handling should return the ScalarFunction itself so it can
       # be chained fluently with other configuration calls.
-      skip 'set_special_handling is not yet implemented (issue #1122)'
 
       sf = DuckDB::ScalarFunction.new
       result = sf.set_special_handling
@@ -974,7 +973,6 @@ module DuckDBTest
       # function can return something other than NULL.
       #
       # Here we implement COALESCE-like behaviour: treat a NULL INTEGER as 0.
-      skip 'set_special_handling is not yet implemented (issue #1122)'
 
       sf = DuckDB::ScalarFunction.new
       sf.name = 'null_as_zero'
@@ -994,7 +992,6 @@ module DuckDBTest
     def test_set_special_handling_with_two_parameters_any_null
       # Both parameters arrive as-is (nil or value) when special handling is
       # set.  The block should handle every combination of nil / non-nil.
-      skip 'set_special_handling is not yet implemented (issue #1122)'
 
       sf = DuckDB::ScalarFunction.new
       sf.name = 'add_nullable'
@@ -1016,7 +1013,6 @@ module DuckDBTest
     def test_set_special_handling_with_varargs_null_coalesce
       # Varargs + special handling: even if individual args are NULL the block
       # is invoked and may inspect/replace each nil in the splat.
-      skip 'set_special_handling is not yet implemented (issue #1122)'
 
       sf = DuckDB::ScalarFunction.new
       sf.name = 'sum_coalesce'
@@ -1036,7 +1032,6 @@ module DuckDBTest
     def test_set_special_handling_without_null_returns_normally
       # Enabling special handling must not change behaviour when all inputs are
       # non-NULL — the block should still be called and return correctly.
-      skip 'set_special_handling is not yet implemented (issue #1122)'
 
       sf = DuckDB::ScalarFunction.new
       sf.name = 'double_special'
@@ -1053,7 +1048,6 @@ module DuckDBTest
     def test_set_special_handling_can_return_null_explicitly
       # Even with special handling the block may choose to return nil (NULL) —
       # the method must not force a non-NULL result.
-      skip 'set_special_handling is not yet implemented (issue #1122)'
 
       sf = DuckDB::ScalarFunction.new
       sf.name = 'passthrough_null'
@@ -1083,7 +1077,6 @@ module DuckDBTest
       #   my_null_count(1, 42, NULL)     → 1   (one NULL)
       #   my_null_count(NULL, NULL, NULL)→ 3   (three NULLs)
       #   my_null_count()                → 0   (no args, no NULLs)
-      skip 'set_special_handling is not yet implemented (issue #1122)'
 
       sf = DuckDB::ScalarFunction.new
       sf.name = 'my_null_count'
@@ -1107,7 +1100,6 @@ module DuckDBTest
       #
       # Skipped additionally until DuckDB::LogicalType::ANY is added
       # (DUCKDB_TYPE_ANY = 34, see issue #1122).
-      skip 'set_special_handling with ANY varargs requires DuckDB::LogicalType::ANY (issue #1122)'
 
       sf = DuckDB::ScalarFunction.new
       sf.name = 'my_null_count_any'

--- a/test/duckdb_test/scalar_function_test.rb
+++ b/test/duckdb_test/scalar_function_test.rb
@@ -854,15 +854,22 @@ module DuckDBTest
       end
     end
 
-    def test_scalar_function_with_varargs_any_type
+    def test_scalar_function_with_varargs_any_type # rubocop:disable Metrics/AbcSize
       # varargs_type= with DuckDB::LogicalType::ANY allows the function to
       # accept arguments of any type — each arg may differ.  The DuckDB C API
       # test uses DUCKDB_TYPE_ANY for this (capi_scalar_functions.cpp,
       # "variadic number of ANY parameters").
-      #
-      # Skipped until DuckDB::LogicalType::ANY is added to ruby-duckdb
-      # (DUCKDB_TYPE_ANY = 34 is in the public C API header).
-      skip 'varargs_type= with ANY type requires DuckDB::LogicalType::ANY to be exposed first'
+      sf = DuckDB::ScalarFunction.new
+      sf.name = 'count_args'
+      sf.varargs_type = DuckDB::LogicalType::ANY
+      sf.return_type = DuckDB::LogicalType::INTEGER
+      sf.set_function { |*args| args.size }
+
+      @con.register_scalar_function(sf)
+
+      assert_equal 0, @con.execute('SELECT count_args()').first.first
+      assert_equal 2, @con.execute('SELECT count_args(42, 99)').first.first
+      assert_equal 3, @con.execute("SELECT count_args(1, 'hello', true)").first.first
     end
 
     def test_scalar_function_create_with_varargs_type

--- a/test/duckdb_test/scalar_function_test.rb
+++ b/test/duckdb_test/scalar_function_test.rb
@@ -987,7 +987,6 @@ module DuckDBTest
       assert_equal 3, @con.execute('SELECT count_nulls(NULL, NULL, NULL)').first.first
     end
 
-
     # Tests for set_special_handling
     #
     # `duckdb_scalar_function_set_special_handling` marks a scalar function to
@@ -1037,7 +1036,7 @@ module DuckDBTest
       assert_equal 42, @con.execute('SELECT null_as_zero(42)').first.first
     end
 
-    def test_set_special_handling_with_two_parameters_any_null
+    def test_set_special_handling_with_two_parameters_any_null # rubocop:disable Metrics/AbcSize,Metrics/MethodLength,Minitest/MultipleAssertions
       # Both parameters arrive as-is (nil or value) when special handling is
       # set.  The block should handle every combination of nil / non-nil.
 
@@ -1058,7 +1057,7 @@ module DuckDBTest
       assert_equal 0, @con.execute('SELECT add_nullable(NULL, NULL)').first.first
     end
 
-    def test_set_special_handling_with_varargs_null_coalesce
+    def test_set_special_handling_with_varargs_null_coalesce # rubocop:disable Metrics/AbcSize
       # Varargs + special handling: even if individual args are NULL the block
       # is invoked and may inspect/replace each nil in the splat.
 
@@ -1110,7 +1109,7 @@ module DuckDBTest
       assert_equal 7, @con.execute('SELECT passthrough_null(7)').first.first
     end
 
-    def test_set_special_handling_null_count_varargs_integer
+    def test_set_special_handling_null_count_varargs_integer # rubocop:disable Metrics/AbcSize,Metrics/MethodLength,Minitest/MultipleAssertions
       # Mirrors the canonical DuckDB C API test (capi_scalar_functions.cpp,
       # "Test Scalar Functions - variadic number of ANY parameters") but uses
       # INTEGER varargs instead of ANY, because DuckDB::LogicalType::ANY is not
@@ -1141,7 +1140,7 @@ module DuckDBTest
       assert_equal 0, @con.execute('SELECT my_null_count()').first.first
     end
 
-    def test_set_special_handling_null_count_any_varargs
+    def test_set_special_handling_null_count_any_varargs # rubocop:disable Metrics/AbcSize,Metrics/MethodLength,Minitest/MultipleAssertions
       # Same null_count function as above but using DuckDB::LogicalType::ANY,
       # which allows arguments of mixed types (matching the DuckDB C API test
       # exactly: my_null_count(40, [1], 'hello', 3) → 0).
@@ -1159,7 +1158,7 @@ module DuckDBTest
       @con.register_scalar_function(sf)
 
       assert_equal 0, @con.execute("SELECT my_null_count_any(40, 'hello', 3)").first.first
-      assert_equal 1, @con.execute("SELECT my_null_count_any(1, 42, NULL)").first.first
+      assert_equal 1, @con.execute('SELECT my_null_count_any(1, 42, NULL)').first.first
       assert_equal 3, @con.execute('SELECT my_null_count_any(NULL, NULL, NULL)').first.first
       assert_equal 0, @con.execute('SELECT my_null_count_any()').first.first
     end


### PR DESCRIPTION
## Summary

Closes #1176 (sub-issue of #1122).

Wraps `duckdb_scalar_function_set_special_handling` so Ruby scalar functions can receive `nil` for NULL inputs instead of DuckDB short-circuiting and returning NULL.

## Changes

### `ext/duckdb/scalar_function.c`
- Add thin C wrapper `_set_special_handling` (private, 0-arg) — same pattern as `_set_varargs`

### `lib/duckdb/scalar_function.rb`
- Add public `set_special_handling` method (calls C wrapper, returns `self` for chaining)
- Add `null_handling: false` keyword to `ScalarFunction.create` — when `true`, calls `set_special_handling` automatically
- Add `:any` to `SUPPORTED_TYPES` so `varargs_type= DuckDB::LogicalType::ANY` is accepted

### `lib/duckdb/converter/int_to_sym.rb`
- Add `34 => :any` to `HASH_TYPES` (was simply missing, caused `Unknown type: 34` errors)

### `CHANGELOG.md`
- Document all three additions under `# Unreleased`

## Usage

```ruby
# Using the method directly
sf = DuckDB::ScalarFunction.new
sf.name = 'null_as_zero'
sf.add_parameter(DuckDB::LogicalType::INTEGER)
sf.return_type = DuckDB::LogicalType::INTEGER
sf.set_special_handling
sf.set_function { |v| v.nil? ? 0 : v }

# Using ScalarFunction.create
sf = DuckDB::ScalarFunction.create(
  name: :null_as_zero,
  return_type: :integer,
  parameter_type: :integer,
  null_handling: true
) { |v| v.nil? ? 0 : v }
```

## Behaviour

| | Without `set_special_handling` | With `set_special_handling` |
|---|---|---|
| Non-NULL input | block called, receives value | block called, receives value |
| NULL input | block **not** called, returns `NULL` | block called, receives `nil` |

## Tests

8 tests added covering:
- Returns `self` for fluent chaining
- Block receives `nil` for NULL inputs (single param, two params, varargs)
- Non-NULL inputs still work normally
- Block can explicitly return `nil` even with special handling
- Canonical DuckDB C API null-count pattern with INTEGER varargs
- Canonical DuckDB C API null-count pattern with `ANY` varargs
- `ScalarFunction.create` with `null_handling: false` (default)
- `ScalarFunction.create` with `null_handling: true`
- `ScalarFunction.create` with `null_handling: true` + varargs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Scalar functions can opt into null-handling via a new null_handling option so registered blocks receive nil for NULL inputs.
  * Added a public method to enable special NULL input behavior (returns self for chaining).
  * varargs support extended to the ANY logical type.

* **Tests**
  * Added coverage for ANY varargs, mixed-type varargs, and null-handling behaviors (default short-circuit vs. opt-in invocation).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->