### PR TITLE
Rename rbduckdb_init_duckdb_bind_info to rbduckdb_init_duckdb_table_function_bind_info

### DIFF
--- a/ext/duckdb/duckdb.c
+++ b/ext/duckdb/duckdb.c
@@ -62,6 +62,6 @@ Init_duckdb_native(void) {
     rbduckdb_init_duckdb_data_chunk();
     rbduckdb_init_memory_helper();
     rbduckdb_init_duckdb_table_function();
-    rbduckdb_init_duckdb_bind_info();
+    rbduckdb_init_duckdb_table_function_bind_info();
     rbduckdb_init_duckdb_table_function_init_info();
 }

--- a/ext/duckdb/table_function_bind_info.c
+++ b/ext/duckdb/table_function_bind_info.c
@@ -226,7 +226,7 @@ static VALUE rbduckdb_bind_info_set_error(VALUE self, VALUE error) {
     return self;
 }
 
-void rbduckdb_init_duckdb_bind_info(void) {
+void rbduckdb_init_duckdb_table_function_bind_info(void) {
 #if 0
     VALUE mDuckDB = rb_define_module("DuckDB");
 #endif

--- a/ext/duckdb/table_function_bind_info.h
+++ b/ext/duckdb/table_function_bind_info.h
@@ -9,6 +9,6 @@ typedef struct _rubyDuckDBBindInfo rubyDuckDBBindInfo;
 
 extern VALUE cDuckDBTableFunctionBindInfo;
 rubyDuckDBBindInfo *get_struct_bind_info(VALUE obj);
-void rbduckdb_init_duckdb_bind_info(void);
+void rbduckdb_init_duckdb_table_function_bind_info(void);
 
 #endif


### PR DESCRIPTION
## Summary

Rename the C init function to match the convention established in #1180 for `rbduckdb_init_duckdb_table_function_init_info`.

## Changes

- `table_function_bind_info.c`: rename function definition
- `table_function_bind_info.h`: rename function declaration
- `duckdb.c`: update call site

## Related

Part of #1122