### PR TITLE
refactoring

### DIFF
--- a/lib/duckdb/appender.rb
+++ b/lib/duckdb/appender.rb
@@ -24,7 +24,7 @@ module DuckDB
     # :startdoc:
 
     class << self
-      alias from_query create_query if DuckDB::Appender.respond_to?(:create_query)
+      alias from_query create_query
     end
 
     # :call-seq:

--- a/test/duckdb_test/appender_test.rb
+++ b/test/duckdb_test/appender_test.rb
@@ -57,10 +57,6 @@ module DuckDBTest
     end
 
     def test_s_create_query
-      unless DuckDB::Appender.respond_to?(:create_query)
-        skip 'DuckDB::Appender.create_query is not supported in this DuckDB version'
-      end
-
       query = 'INSERT OR REPLACE INTO t SELECT i, val FROM my_appended_data'
       types = [DuckDB::LogicalType::INTEGER, DuckDB::LogicalType::VARCHAR]
       appender = DuckDB::Appender.create_query(@con, query, types, 'my_appended_data', %w[i val])
@@ -70,10 +66,6 @@ module DuckDBTest
 
     # test for alias of create_query
     def test_s_from_query
-      unless DuckDB::Appender.respond_to?(:create_from_query)
-        skip 'DuckDB::Appender.create_query is not supported in this DuckDB version'
-      end
-
       query = 'INSERT OR REPLACE INTO t SELECT i, val FROM my_appended_data'
       types = [DuckDB::LogicalType::INTEGER, DuckDB::LogicalType::VARCHAR]
       appender = DuckDB::Appender.from_query(@con, query, types, 'my_appended_data', %w[i val])
@@ -82,10 +74,6 @@ module DuckDBTest
     end
 
     def test_s_create_query_append_test
-      unless DuckDB::Appender.respond_to?(:create_query)
-        skip 'DuckDB::Appender.create_query is not supported in this DuckDB version'
-      end
-
       setup_table_with_initial_data
       appender = create_query_appender
 


### PR DESCRIPTION
skip checking create_query.
ruby-duckdb supports duckdb >= 1.4.0.
So we can remove create_query check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced reliability of the appender interface by ensuring the `from_query` method is consistently available in all scenarios.

* **Tests**
  * Improved test coverage by removing conditional skipping, ensuring comprehensive testing of appender functionality without version-based restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->