### PR TITLE
Refactor: move IDs and infinite_* helpers from result.c to conveter.c (step 1 of #1204)

### DIFF
--- a/ext/duckdb/converter.h
+++ b/ext/duckdb/converter.h
@@ -1,6 +1,26 @@
 #ifndef RUBY_DUCKDB_CONVERTER_H
 #define RUBY_DUCKDB_CONVERTER_H
 
+extern ID id__to_date;
+extern ID id__to_time;
+extern ID id__to_time_from_duckdb_time;
+extern ID id__to_interval_from_vector;
+extern ID id__to_hugeint_from_vector;
+extern ID id__to_decimal_from_hugeint;
+extern ID id__to_uuid_from_vector;
+extern ID id__to_time_from_duckdb_timestamp_s;
+extern ID id__to_time_from_duckdb_timestamp_ms;
+extern ID id__to_time_from_duckdb_timestamp_ns;
+extern ID id__to_time_from_duckdb_time_tz;
+extern ID id__to_time_from_duckdb_timestamp_tz;
+extern ID id__to_infinity;
+
+VALUE infinite_date_value(duckdb_date date);
+VALUE infinite_timestamp_value(duckdb_timestamp timestamp);
+VALUE infinite_timestamp_s_value(duckdb_timestamp_s timestamp_s);
+VALUE infinite_timestamp_ms_value(duckdb_timestamp_ms timestamp_ms);
+VALUE infinite_timestamp_ns_value(duckdb_timestamp_ns timestamp_ns);
+
 void rbduckdb_init_duckdb_converter(void);
 
 #endif

--- a/ext/duckdb/conveter.c
+++ b/ext/duckdb/conveter.c
@@ -2,6 +2,79 @@
 
 VALUE mDuckDBConverter;
 
+ID id__to_date;
+ID id__to_time;
+ID id__to_time_from_duckdb_time;
+ID id__to_interval_from_vector;
+ID id__to_hugeint_from_vector;
+ID id__to_decimal_from_hugeint;
+ID id__to_uuid_from_vector;
+ID id__to_time_from_duckdb_timestamp_s;
+ID id__to_time_from_duckdb_timestamp_ms;
+ID id__to_time_from_duckdb_timestamp_ns;
+ID id__to_time_from_duckdb_time_tz;
+ID id__to_time_from_duckdb_timestamp_tz;
+ID id__to_infinity;
+
+VALUE infinite_date_value(duckdb_date date) {
+    if (duckdb_is_finite_date(date) == false) {
+        return rb_funcall(mDuckDBConverter, id__to_infinity, 1,
+                          INT2NUM(date.days)
+                         );
+    }
+    return Qnil;
+}
+
+VALUE infinite_timestamp_value(duckdb_timestamp timestamp) {
+    if (duckdb_is_finite_timestamp(timestamp) == false) {
+        return rb_funcall(mDuckDBConverter, id__to_infinity, 1,
+                          LL2NUM(timestamp.micros)
+                         );
+    }
+    return Qnil;
+}
+
+VALUE infinite_timestamp_s_value(duckdb_timestamp_s timestamp_s) {
+    if (duckdb_is_finite_timestamp_s(timestamp_s) == false) {
+        return rb_funcall(mDuckDBConverter, id__to_infinity, 1,
+                          LL2NUM(timestamp_s.seconds)
+                         );
+    }
+    return Qnil;
+}
+
+VALUE infinite_timestamp_ms_value(duckdb_timestamp_ms timestamp_ms) {
+    if (duckdb_is_finite_timestamp_ms(timestamp_ms) == false) {
+        return rb_funcall(mDuckDBConverter, id__to_infinity, 1,
+                          LL2NUM(timestamp_ms.millis)
+                         );
+    }
+    return Qnil;
+}
+
+VALUE infinite_timestamp_ns_value(duckdb_timestamp_ns timestamp_ns) {
+    if (duckdb_is_finite_timestamp_ns(timestamp_ns) == false) {
+        return rb_funcall(mDuckDBConverter, id__to_infinity, 1,
+                          LL2NUM(timestamp_ns.nanos)
+                         );
+    }
+    return Qnil;
+}
+
 void rbduckdb_init_duckdb_converter(void) {
     mDuckDBConverter = rb_define_module_under(mDuckDB, "Converter");
+
+    id__to_date = rb_intern("_to_date");
+    id__to_time = rb_intern("_to_time");
+    id__to_time_from_duckdb_time = rb_intern("_to_time_from_duckdb_time");
+    id__to_interval_from_vector = rb_intern("_to_interval_from_vector");
+    id__to_hugeint_from_vector = rb_intern("_to_hugeint_from_vector");
+    id__to_decimal_from_hugeint = rb_intern("_to_decimal_from_hugeint");
+    id__to_uuid_from_vector = rb_intern("_to_uuid_from_vector");
+    id__to_time_from_duckdb_timestamp_s = rb_intern("_to_time_from_duckdb_timestamp_s");
+    id__to_time_from_duckdb_timestamp_ms = rb_intern("_to_time_from_duckdb_timestamp_ms");
+    id__to_time_from_duckdb_timestamp_ns = rb_intern("_to_time_from_duckdb_timestamp_ns");
+    id__to_time_from_duckdb_time_tz = rb_intern("_to_time_from_duckdb_time_tz");
+    id__to_time_from_duckdb_timestamp_tz = rb_intern("_to_time_from_duckdb_timestamp_tz");
+    id__to_infinity = rb_intern("_to_infinity");
 }

--- a/ext/duckdb/result.c
+++ b/ext/duckdb/result.c
@@ -6,19 +6,6 @@ struct chunk_arg {
 };
 
 static VALUE cDuckDBResult;
-static ID id__to_date;
-static ID id__to_time;
-static ID id__to_time_from_duckdb_time;
-static ID id__to_interval_from_vector;
-static ID id__to_hugeint_from_vector;
-static ID id__to_decimal_from_hugeint;
-static ID id__to_uuid_from_vector;
-static ID id__to_time_from_duckdb_timestamp_s;
-static ID id__to_time_from_duckdb_timestamp_ms;
-static ID id__to_time_from_duckdb_timestamp_ns;
-static ID id__to_time_from_duckdb_time_tz;
-static ID id__to_time_from_duckdb_timestamp_tz;
-static ID id__to_infinity;
 
 static void deallocate(void *ctx);
 static VALUE allocate(VALUE klass);
@@ -37,7 +24,6 @@ static VALUE duckdb_result__enum_internal_type(VALUE oDuckDBResult, VALUE col_id
 static VALUE duckdb_result__enum_dictionary_size(VALUE oDuckDBResult, VALUE col_idx);
 static VALUE duckdb_result__enum_dictionary_value(VALUE oDuckDBResult, VALUE col_idx, VALUE idx);
 
-static VALUE infinite_date_value(duckdb_date date);
 static VALUE vector_date(void *vector_data, idx_t row_idx);
 static VALUE vector_timestamp(void* vector_data, idx_t row_idx);
 static VALUE vector_time(void* vector_data, idx_t row_idx);
@@ -47,10 +33,6 @@ static VALUE vector_varchar(void* vector_data, idx_t row_idx);
 static VALUE vector_hugeint(void* vector_data, idx_t row_idx);
 static VALUE vector_uhugeint(void* vector_data, idx_t row_idx);
 static VALUE vector_decimal(duckdb_logical_type ty, void* vector_data, idx_t row_idx);
-static VALUE infinite_timestamp_value(duckdb_timestamp timestamp);
-static VALUE infinite_timestamp_s_value(duckdb_timestamp_s timestamp_s);
-static VALUE infinite_timestamp_ms_value(duckdb_timestamp_ms timestamp_ms);
-static VALUE infinite_timestamp_ns_value(duckdb_timestamp_ns timestamp_ns);
 
 static VALUE vector_timestamp_s(void* vector_data, idx_t row_idx);
 static VALUE vector_timestamp_ms(void* vector_data, idx_t row_idx);
@@ -290,14 +272,6 @@ VALUE rbduckdb_create_result(void) {
     return allocate(cDuckDBResult);
 }
 
-static VALUE infinite_date_value(duckdb_date date) {
-    if (duckdb_is_finite_date(date) == false) {
-        return rb_funcall(mDuckDBConverter, id__to_infinity, 1,
-                          INT2NUM(date.days)
-                         );
-    }
-    return Qnil;
-}
 
 static VALUE vector_date(void *vector_data, idx_t row_idx) {
     duckdb_date date = ((duckdb_date *) vector_data)[row_idx];
@@ -425,23 +399,7 @@ static VALUE vector_decimal(duckdb_logical_type ty, void* vector_data, idx_t row
                       );
 }
 
-static VALUE infinite_timestamp_value(duckdb_timestamp timestamp) {
-    if (duckdb_is_finite_timestamp(timestamp) == false) {
-        return rb_funcall(mDuckDBConverter, id__to_infinity, 1,
-                          LL2NUM(timestamp.micros)
-                         );
-    }
-    return Qnil;
-}
 
-static VALUE infinite_timestamp_s_value(duckdb_timestamp_s timestamp_s) {
-    if (duckdb_is_finite_timestamp_s(timestamp_s) == false) {
-        return rb_funcall(mDuckDBConverter, id__to_infinity, 1,
-                          LL2NUM(timestamp_s.seconds)
-                         );
-    }
-    return Qnil;
-}
 
 static VALUE vector_timestamp_s(void* vector_data, idx_t row_idx) {
     duckdb_timestamp_s data = ((duckdb_timestamp_s *)vector_data)[row_idx];
@@ -454,14 +412,6 @@ static VALUE vector_timestamp_s(void* vector_data, idx_t row_idx) {
                       );
 }
 
-static VALUE infinite_timestamp_ms_value(duckdb_timestamp_ms timestamp_ms) {
-    if (duckdb_is_finite_timestamp_ms(timestamp_ms) == false) {
-        return rb_funcall(mDuckDBConverter, id__to_infinity, 1,
-                          LL2NUM(timestamp_ms.millis)
-                         );
-    }
-    return Qnil;
-}
 
 static VALUE vector_timestamp_ms(void* vector_data, idx_t row_idx) {
     duckdb_timestamp_ms data = ((duckdb_timestamp_ms *)vector_data)[row_idx];
@@ -474,14 +424,6 @@ static VALUE vector_timestamp_ms(void* vector_data, idx_t row_idx) {
                       );
 }
 
-static VALUE infinite_timestamp_ns_value(duckdb_timestamp_ns timestamp_ns) {
-    if (duckdb_is_finite_timestamp_ns(timestamp_ns) == false) {
-        return rb_funcall(mDuckDBConverter, id__to_infinity, 1,
-                          LL2NUM(timestamp_ns.nanos)
-                         );
-    }
-    return Qnil;
-}
 
 static VALUE vector_timestamp_ns(void* vector_data, idx_t row_idx) {
     duckdb_timestamp_ns data = ((duckdb_timestamp_ns *)vector_data)[row_idx];
@@ -840,19 +782,6 @@ void rbduckdb_init_duckdb_result(void) {
     VALUE mDuckDB = rb_define_module("DuckDB");
 #endif
     cDuckDBResult = rb_define_class_under(mDuckDB, "Result", rb_cObject);
-    id__to_date = rb_intern("_to_date");
-    id__to_time = rb_intern("_to_time");
-    id__to_time_from_duckdb_time = rb_intern("_to_time_from_duckdb_time");
-    id__to_interval_from_vector = rb_intern("_to_interval_from_vector");
-    id__to_hugeint_from_vector = rb_intern("_to_hugeint_from_vector");
-    id__to_decimal_from_hugeint = rb_intern("_to_decimal_from_hugeint");
-    id__to_uuid_from_vector = rb_intern("_to_uuid_from_vector");
-    id__to_time_from_duckdb_timestamp_s = rb_intern("_to_time_from_duckdb_timestamp_s");
-    id__to_time_from_duckdb_timestamp_ms = rb_intern("_to_time_from_duckdb_timestamp_ms");
-    id__to_time_from_duckdb_timestamp_ns = rb_intern("_to_time_from_duckdb_timestamp_ns");
-    id__to_time_from_duckdb_time_tz = rb_intern("_to_time_from_duckdb_time_tz");
-    id__to_time_from_duckdb_timestamp_tz = rb_intern("_to_time_from_duckdb_timestamp_tz");
-    id__to_infinity = rb_intern("_to_infinity");
 
     rb_define_alloc_func(cDuckDBResult, allocate);
 


### PR DESCRIPTION
## Summary

Step 1 of the refactoring described in issue #1204.

Moves the 13 Ruby method IDs (`id__to_date`, `id__to_time`, etc.) and the 5 `infinite_*_value` helper functions out of `result.c` and into `conveter.c`, which already owns `mDuckDBConverter`.

## Changes

- **`ext/duckdb/conveter.c`**: IDs added as module-level globals; `infinite_*_value` functions added; `rb_intern()` calls moved here from `result.c` into `rbduckdb_init_duckdb_converter()`
- **`ext/duckdb/converter.h`**: `extern` declarations added for all IDs and `infinite_*_value` functions, so `result.c` continues to compile without changes to its logic
- **`ext/duckdb/result.c`**: `static ID` declarations removed; `infinite_*_value` functions removed; `rb_intern()` calls removed from `rbduckdb_init_duckdb_result()`

## Why

This positions `conveter.c` as the future home for shared struct-to-Ruby converter functions (step 2), where both `rbduckdb_vector_value_at` and `rbduckdb_duckdb_value_to_ruby` can call them. No behaviour changes in this step.

Closes part of #1204.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Reorganized internal date and timestamp conversion logic to improve handling of edge cases, including infinite values across multiple timestamp formats and timezone-aware variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->