### PR TITLE
Refactor: share timestamp-to-Ruby conversion between vector and value paths (step 2 of #1204)

### DIFF
--- a/ext/duckdb/converter.h
+++ b/ext/duckdb/converter.h
@@ -15,6 +15,8 @@ extern ID id__to_time_from_duckdb_time_tz;
 extern ID id__to_time_from_duckdb_timestamp_tz;
 extern ID id__to_infinity;
 
+VALUE rbduckdb_timestamp_to_ruby(duckdb_timestamp ts);
+
 VALUE infinite_date_value(duckdb_date date);
 VALUE infinite_timestamp_value(duckdb_timestamp timestamp);
 VALUE infinite_timestamp_s_value(duckdb_timestamp_s timestamp_s);

--- a/ext/duckdb/conveter.c
+++ b/ext/duckdb/conveter.c
@@ -61,6 +61,24 @@ VALUE infinite_timestamp_ns_value(duckdb_timestamp_ns timestamp_ns) {
     return Qnil;
 }
 
+VALUE rbduckdb_timestamp_to_ruby(duckdb_timestamp ts) {
+    VALUE obj = infinite_timestamp_value(ts);
+
+    if (obj == Qnil) {
+        duckdb_timestamp_struct data_st = duckdb_from_timestamp(ts);
+        obj = rb_funcall(mDuckDBConverter, id__to_time, 7,
+                         INT2FIX(data_st.date.year),
+                         INT2FIX(data_st.date.month),
+                         INT2FIX(data_st.date.day),
+                         INT2FIX(data_st.time.hour),
+                         INT2FIX(data_st.time.min),
+                         INT2FIX(data_st.time.sec),
+                         INT2NUM(data_st.time.micros)
+                         );
+    }
+    return obj;
+}
+
 void rbduckdb_init_duckdb_converter(void) {
     mDuckDBConverter = rb_define_module_under(mDuckDB, "Converter");
 

--- a/ext/duckdb/result.c
+++ b/ext/duckdb/result.c
@@ -289,22 +289,7 @@ static VALUE vector_date(void *vector_data, idx_t row_idx) {
 }
 
 static VALUE vector_timestamp(void* vector_data, idx_t row_idx) {
-    duckdb_timestamp data = ((duckdb_timestamp *)vector_data)[row_idx];
-    VALUE obj = infinite_timestamp_value(data);
-
-    if (obj == Qnil) {
-        duckdb_timestamp_struct data_st = duckdb_from_timestamp(data);
-        return rb_funcall(mDuckDBConverter, id__to_time, 7,
-                          INT2FIX(data_st.date.year),
-                          INT2FIX(data_st.date.month),
-                          INT2FIX(data_st.date.day),
-                          INT2FIX(data_st.time.hour),
-                          INT2FIX(data_st.time.min),
-                          INT2FIX(data_st.time.sec),
-                          INT2NUM(data_st.time.micros)
-                          );
-    }
-    return obj;
+    return rbduckdb_timestamp_to_ruby(((duckdb_timestamp *)vector_data)[row_idx]);
 }
 
 static VALUE vector_time(void* vector_data, idx_t row_idx) {

--- a/ext/duckdb/value_impl.c
+++ b/ext/duckdb/value_impl.c
@@ -79,6 +79,9 @@ VALUE rbduckdb_duckdb_value_to_ruby(duckdb_value val) {
         case DUCKDB_TYPE_DOUBLE:
             result = DBL2NUM(duckdb_get_double(val));
             break;
+        case DUCKDB_TYPE_TIMESTAMP:
+            result = rbduckdb_timestamp_to_ruby(duckdb_get_timestamp(val));
+            break;
         case DUCKDB_TYPE_VARCHAR:
             str = duckdb_get_varchar(val);
             result = rb_str_new_cstr(str);

--- a/test/duckdb_test/expression_test.rb
+++ b/test/duckdb_test/expression_test.rb
@@ -98,6 +98,24 @@ module DuckDBTest
       assert_raises(DuckDB::Error) { expr.fold(client_context) }
     end
 
+    def test_fold_returns_time_for_timestamp_literal # rubocop:disable Minitest/MultipleAssertions, Metrics/AbcSize, Metrics/MethodLength
+      expr, client_context = bind_argument_of(
+        'test_fold_ts', :timestamp,
+        "SELECT test_fold_ts('2025-01-15 12:34:56.123456'::TIMESTAMP)"
+      )
+
+      value = expr.fold(client_context)
+
+      assert_instance_of Time, value
+      assert_equal 2025,    value.year
+      assert_equal 1,       value.month
+      assert_equal 15,      value.day
+      assert_equal 12,      value.hour
+      assert_equal 34,      value.min
+      assert_equal 56,      value.sec
+      assert_equal 123_456, value.usec
+    end
+
     private
 
     # Registers a pass-through scalar function, executes sql, and returns


### PR DESCRIPTION
## Summary

Part of the refactoring described in issue #1204. Focuses on `DUCKDB_TYPE_TIMESTAMP` only.

## Changes

### `ext/duckdb/converter.c` + `ext/duckdb/converter.h`
Add `rbduckdb_timestamp_to_ruby(duckdb_timestamp ts)` — the shared conversion logic extracted from `vector_timestamp`.

### `ext/duckdb/result.c`
`vector_timestamp` becomes a one-liner:
```c
static VALUE vector_timestamp(void* vector_data, idx_t row_idx) {
    return rbduckdb_timestamp_to_ruby(((duckdb_timestamp *)vector_data)[row_idx]);
}
```

### `ext/duckdb/value_impl.c`
`rbduckdb_duckdb_value_to_ruby` gains a new case (previously fell through to `Qnil`):
```c
case DUCKDB_TYPE_TIMESTAMP:
    result = rbduckdb_timestamp_to_ruby(duckdb_get_timestamp(val));
    break;
```

### `test/duckdb_test/expression_test.rb`
Add `test_fold_returns_time_for_timestamp_literal` covering the new `DUCKDB_TYPE_TIMESTAMP` case in `rbduckdb_duckdb_value_to_ruby`, including microsecond precision.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved timestamp value conversion and handling throughout the database result processing pipeline
  * Timestamp constants in expressions now properly fold and convert to Ruby Time objects
  * Fixed handling of non-finite (infinite) timestamp values

* **Tests**
  * Added test coverage for timestamp constant folding in expressions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->