### PR TITLE
make short time for timeout in windows test

### DIFF
--- a/.github/workflows/test_on_windows.yml
+++ b/.github/workflows/test_on_windows.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   test:
     runs-on: windows-latest
-    timeout-minutes: 12
+    timeout-minutes: 8
     strategy:
       matrix:
         ruby: ['3.2.9', '3.3.10', '3.4.8', '4.0.1', 'ucrt', 'mingw', 'mswin', 'head']
@@ -59,7 +59,7 @@ jobs:
     - name: rake test
       uses: nick-fields/retry@v3
       with:
-        timeout_minutes: 3
+        timeout_minutes: 1
         max_attempts: 3
         command: bundle exec rake test TESTOPTS="--verbose"
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized Windows CI/CD workflow test execution with adjusted timeout configurations for improved efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->