### PR TITLE
Refactor: share date-to-Ruby conversion between vector and value paths (step 2 of #1204)

### DIFF
--- a/ext/duckdb/converter.h
+++ b/ext/duckdb/converter.h
@@ -15,6 +15,7 @@ extern ID id__to_time_from_duckdb_time_tz;
 extern ID id__to_time_from_duckdb_timestamp_tz;
 extern ID id__to_infinity;
 
+VALUE rbduckdb_date_to_ruby(duckdb_date date);
 VALUE rbduckdb_timestamp_to_ruby(duckdb_timestamp ts);
 
 VALUE infinite_date_value(duckdb_date date);

--- a/ext/duckdb/conveter.c
+++ b/ext/duckdb/conveter.c
@@ -61,6 +61,20 @@ VALUE infinite_timestamp_ns_value(duckdb_timestamp_ns timestamp_ns) {
     return Qnil;
 }
 
+VALUE rbduckdb_date_to_ruby(duckdb_date date) {
+    VALUE obj = infinite_date_value(date);
+
+    if (obj == Qnil) {
+        duckdb_date_struct date_st = duckdb_from_date(date);
+        obj = rb_funcall(mDuckDBConverter, id__to_date, 3,
+                         INT2FIX(date_st.year),
+                         INT2FIX(date_st.month),
+                         INT2FIX(date_st.day)
+                         );
+    }
+    return obj;
+}
+
 VALUE rbduckdb_timestamp_to_ruby(duckdb_timestamp ts) {
     VALUE obj = infinite_timestamp_value(ts);
 

--- a/ext/duckdb/result.c
+++ b/ext/duckdb/result.c
@@ -274,18 +274,7 @@ VALUE rbduckdb_create_result(void) {
 
 
 static VALUE vector_date(void *vector_data, idx_t row_idx) {
-    duckdb_date date = ((duckdb_date *) vector_data)[row_idx];
-    VALUE obj = infinite_date_value(date);
-
-    if (obj == Qnil) {
-        duckdb_date_struct date_st = duckdb_from_date(date);
-        obj = rb_funcall(mDuckDBConverter, id__to_date, 3,
-                         INT2FIX(date_st.year),
-                         INT2FIX(date_st.month),
-                         INT2FIX(date_st.day)
-                         );
-    }
-    return obj;
+    return rbduckdb_date_to_ruby(((duckdb_date *)vector_data)[row_idx]);
 }
 
 static VALUE vector_timestamp(void* vector_data, idx_t row_idx) {

--- a/ext/duckdb/value_impl.c
+++ b/ext/duckdb/value_impl.c
@@ -82,6 +82,9 @@ VALUE rbduckdb_duckdb_value_to_ruby(duckdb_value val) {
         case DUCKDB_TYPE_TIMESTAMP:
             result = rbduckdb_timestamp_to_ruby(duckdb_get_timestamp(val));
             break;
+        case DUCKDB_TYPE_DATE:
+            result = rbduckdb_date_to_ruby(duckdb_get_date(val));
+            break;
         case DUCKDB_TYPE_VARCHAR:
             str = duckdb_get_varchar(val);
             result = rb_str_new_cstr(str);

--- a/test/duckdb_test/expression_test.rb
+++ b/test/duckdb_test/expression_test.rb
@@ -116,6 +116,20 @@ module DuckDBTest
       assert_equal 123_456, value.usec
     end
 
+    def test_fold_returns_date_for_date_literal # rubocop:disable Minitest/MultipleAssertions
+      expr, client_context = bind_argument_of(
+        'test_fold_date', :date,
+        "SELECT test_fold_date('2025-06-30'::DATE)"
+      )
+
+      value = expr.fold(client_context)
+
+      assert_instance_of Date, value
+      assert_equal 2025, value.year
+      assert_equal 6,    value.month
+      assert_equal 30,   value.day
+    end
+
     private
 
     # Registers a pass-through scalar function, executes sql, and returns


### PR DESCRIPTION
## Summary

Same approach as PR #1206 (timestamp), applied to `DUCKDB_TYPE_DATE`.

## Changes

### `ext/duckdb/conveter.c` + `ext/duckdb/converter.h`
Add `rbduckdb_date_to_ruby(duckdb_date date)` — conversion logic extracted from `vector_date`.

### `ext/duckdb/result.c`
`vector_date` becomes a one-liner:
```c
static VALUE vector_date(void *vector_data, idx_t row_idx) {
    return rbduckdb_date_to_ruby(((duckdb_date *)vector_data)[row_idx]);
}
```

### `ext/duckdb/value_impl.c`
`rbduckdb_duckdb_value_to_ruby` gains a new case (previously fell through to `Qnil`):
```c
case DUCKDB_TYPE_DATE:
    result = rbduckdb_date_to_ruby(duckdb_get_date(val));
    break;
```

### `test/duckdb_test/expression_test.rb`
Add `test_fold_returns_date_for_date_literal` covering the new `DUCKDB_TYPE_DATE` case in `rbduckdb_duckdb_value_to_ruby`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for converting DuckDB date values to Ruby Date objects with proper handling of infinite date values

* **Refactor**
  * Centralized date conversion logic across the codebase

* **Tests**
  * Added test coverage for date value conversion and expression folding operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->