### PR TITLE
Refactor: share time-to-Ruby conversion between vector and value paths (step 2 of #1204)

### DIFF
--- a/ext/duckdb/converter.h
+++ b/ext/duckdb/converter.h
@@ -15,6 +15,7 @@ extern ID id__to_time_from_duckdb_time_tz;
 extern ID id__to_time_from_duckdb_timestamp_tz;
 extern ID id__to_infinity;
 
+VALUE rbduckdb_time_to_ruby(duckdb_time t);
 VALUE rbduckdb_date_to_ruby(duckdb_date date);
 VALUE rbduckdb_timestamp_to_ruby(duckdb_timestamp ts);
 

--- a/ext/duckdb/conveter.c
+++ b/ext/duckdb/conveter.c
@@ -61,6 +61,16 @@ VALUE infinite_timestamp_ns_value(duckdb_timestamp_ns timestamp_ns) {
     return Qnil;
 }
 
+VALUE rbduckdb_time_to_ruby(duckdb_time t) {
+    duckdb_time_struct data = duckdb_from_time(t);
+    return rb_funcall(mDuckDBConverter, id__to_time_from_duckdb_time, 4,
+                      INT2FIX(data.hour),
+                      INT2FIX(data.min),
+                      INT2FIX(data.sec),
+                      INT2NUM(data.micros)
+                      );
+}
+
 VALUE rbduckdb_date_to_ruby(duckdb_date date) {
     VALUE obj = infinite_date_value(date);
 

--- a/ext/duckdb/result.c
+++ b/ext/duckdb/result.c
@@ -282,13 +282,7 @@ static VALUE vector_timestamp(void* vector_data, idx_t row_idx) {
 }
 
 static VALUE vector_time(void* vector_data, idx_t row_idx) {
-    duckdb_time_struct data = duckdb_from_time(((duckdb_time *)vector_data)[row_idx]);
-    return rb_funcall(mDuckDBConverter, id__to_time_from_duckdb_time, 4,
-                      INT2FIX(data.hour),
-                      INT2FIX(data.min),
-                      INT2FIX(data.sec),
-                      INT2NUM(data.micros)
-                      );
+    return rbduckdb_time_to_ruby(((duckdb_time *)vector_data)[row_idx]);
 }
 
 

--- a/ext/duckdb/value_impl.c
+++ b/ext/duckdb/value_impl.c
@@ -85,6 +85,9 @@ VALUE rbduckdb_duckdb_value_to_ruby(duckdb_value val) {
         case DUCKDB_TYPE_DATE:
             result = rbduckdb_date_to_ruby(duckdb_get_date(val));
             break;
+        case DUCKDB_TYPE_TIME:
+            result = rbduckdb_time_to_ruby(duckdb_get_time(val));
+            break;
         case DUCKDB_TYPE_VARCHAR:
             str = duckdb_get_varchar(val);
             result = rb_str_new_cstr(str);

--- a/test/duckdb_test/expression_test.rb
+++ b/test/duckdb_test/expression_test.rb
@@ -130,6 +130,21 @@ module DuckDBTest
       assert_equal 30,   value.day
     end
 
+    def test_fold_returns_time_for_time_literal # rubocop:disable Minitest/MultipleAssertions
+      expr, client_context = bind_argument_of(
+        'test_fold_time', :time,
+        "SELECT test_fold_time('12:34:56.123456'::TIME)"
+      )
+
+      value = expr.fold(client_context)
+
+      assert_instance_of Time, value
+      assert_equal 12,      value.hour
+      assert_equal 34,      value.min
+      assert_equal 56,      value.sec
+      assert_equal 123_456, value.usec
+    end
+
     private
 
     # Registers a pass-through scalar function, executes sql, and returns


### PR DESCRIPTION
## Summary

Same approach as PR #1206 (timestamp) and PR #1208 (date), applied to `DUCKDB_TYPE_TIME`.

## Changes

### `ext/duckdb/conveter.c` + `ext/duckdb/converter.h`
Add `rbduckdb_time_to_ruby(duckdb_time t)` — conversion logic extracted from `vector_time`.

### `ext/duckdb/result.c`
`vector_time` becomes a one-liner:
```c
static VALUE vector_time(void* vector_data, idx_t row_idx) {
    return rbduckdb_time_to_ruby(((duckdb_time *)vector_data)[row_idx]);
}
```

### `ext/duckdb/value_impl.c`
`rbduckdb_duckdb_value_to_ruby` gains a new case (previously fell through to `Qnil`):
```c
case DUCKDB_TYPE_TIME:
    result = rbduckdb_time_to_ruby(duckdb_get_time(val));
    break;
```

### `test/duckdb_test/expression_test.rb`
Add `test_fold_returns_time_for_time_literal` covering the new `DUCKDB_TYPE_TIME` case in `rbduckdb_duckdb_value_to_ruby`, including microsecond precision.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * DuckDB TIME type values are now properly converted to Ruby Time objects with accurate hour, minute, second, and microsecond components
  * Improved consistency in time data handling across the conversion pipeline

* **Tests**
  * Added test coverage for time literal folding and conversion

<!-- end of auto-generated comment: release notes by coderabbit.ai -->