### PR TITLE
Refactor: share timestamp_ms-to-Ruby conversion between vector and value paths

### DIFF
--- a/ext/duckdb/converter.h
+++ b/ext/duckdb/converter.h
@@ -16,6 +16,7 @@ extern ID id__to_time_from_duckdb_timestamp_tz;
 extern ID id__to_infinity;
 
 VALUE rbduckdb_timestamp_s_to_ruby(duckdb_timestamp_s ts);
+VALUE rbduckdb_timestamp_ms_to_ruby(duckdb_timestamp_ms ts);
 VALUE rbduckdb_time_to_ruby(duckdb_time t);
 VALUE rbduckdb_date_to_ruby(duckdb_date date);
 VALUE rbduckdb_timestamp_to_ruby(duckdb_timestamp ts);

--- a/ext/duckdb/conveter.c
+++ b/ext/duckdb/conveter.c
@@ -71,6 +71,16 @@ VALUE rbduckdb_timestamp_s_to_ruby(duckdb_timestamp_s ts) {
                       );
 }
 
+VALUE rbduckdb_timestamp_ms_to_ruby(duckdb_timestamp_ms ts) {
+    VALUE obj = infinite_timestamp_ms_value(ts);
+    if (obj != Qnil) {
+        return obj;
+    }
+    return rb_funcall(mDuckDBConverter, id__to_time_from_duckdb_timestamp_ms, 1,
+                      LL2NUM(ts.millis)
+                      );
+}
+
 VALUE rbduckdb_time_to_ruby(duckdb_time t) {
     duckdb_time_struct data = duckdb_from_time(t);
     return rb_funcall(mDuckDBConverter, id__to_time_from_duckdb_time, 4,

--- a/ext/duckdb/result.c
+++ b/ext/duckdb/result.c
@@ -375,14 +375,7 @@ static VALUE vector_timestamp_s(void* vector_data, idx_t row_idx) {
 
 
 static VALUE vector_timestamp_ms(void* vector_data, idx_t row_idx) {
-    duckdb_timestamp_ms data = ((duckdb_timestamp_ms *)vector_data)[row_idx];
-    VALUE obj = infinite_timestamp_ms_value(data);
-    if (obj != Qnil) {
-        return obj;
-    }
-    return rb_funcall(mDuckDBConverter, id__to_time_from_duckdb_timestamp_ms, 1,
-                      LL2NUM(data.millis)
-                      );
+    return rbduckdb_timestamp_ms_to_ruby(((duckdb_timestamp_ms *)vector_data)[row_idx]);
 }
 
 

--- a/ext/duckdb/value_impl.c
+++ b/ext/duckdb/value_impl.c
@@ -91,6 +91,9 @@ VALUE rbduckdb_duckdb_value_to_ruby(duckdb_value val) {
         case DUCKDB_TYPE_TIMESTAMP_S:
             result = rbduckdb_timestamp_s_to_ruby(duckdb_get_timestamp_s(val));
             break;
+        case DUCKDB_TYPE_TIMESTAMP_MS:
+            result = rbduckdb_timestamp_ms_to_ruby(duckdb_get_timestamp_ms(val));
+            break;
         case DUCKDB_TYPE_VARCHAR:
             str = duckdb_get_varchar(val);
             result = rb_str_new_cstr(str);

--- a/lib/duckdb/scalar_function.rb
+++ b/lib/duckdb/scalar_function.rb
@@ -100,6 +100,7 @@ module DuckDB
       time
       timestamp
       timestamp_s
+      timestamp_ms
       tinyint
       ubigint
       uinteger
@@ -112,7 +113,7 @@ module DuckDB
 
     # Adds a parameter to the scalar function.
     # Currently supports BIGINT, BLOB, BOOLEAN, DATE, DOUBLE, FLOAT, INTEGER, SMALLINT, TIME, TIMESTAMP,
-    # TIMESTAMP_S, TINYINT, UBIGINT, UINTEGER, USMALLINT, UTINYINT, and VARCHAR types.
+    # TIMESTAMP_S, TIMESTAMP_MS, TINYINT, UBIGINT, UINTEGER, USMALLINT, UTINYINT, and VARCHAR types.
     #
     # @param logical_type [DuckDB::LogicalType | :logical_type_symbol] the parameter type
     # @return [DuckDB::ScalarFunction] self
@@ -125,7 +126,7 @@ module DuckDB
 
     # Sets the return type for the scalar function.
     # Currently supports BIGINT, BLOB, BOOLEAN, DATE, DOUBLE, FLOAT, INTEGER, SMALLINT, TIME, TIMESTAMP,
-    # TIMESTAMP_S, TINYINT, UBIGINT, UINTEGER, USMALLINT, UTINYINT, and VARCHAR types.
+    # TIMESTAMP_S, TIMESTAMP_MS, TINYINT, UBIGINT, UINTEGER, USMALLINT, UTINYINT, and VARCHAR types.
     #
     # @param logical_type [DuckDB::LogicalType | :logical_type_symbol] the return type
     # @return [DuckDB::ScalarFunction] self
@@ -156,7 +157,7 @@ module DuckDB
     # (e.g. a separator followed by a variable list of values).
     # The block receives fixed parameters positionally, then varargs as a splat (|fixed, *rest|).
     # Currently supports BIGINT, BLOB, BOOLEAN, DATE, DOUBLE, FLOAT, INTEGER, SMALLINT, TIME, TIMESTAMP,
-    # TIMESTAMP_S, TINYINT, UBIGINT, UINTEGER, USMALLINT, UTINYINT, and VARCHAR types.
+    # TIMESTAMP_S, TIMESTAMP_MS, TINYINT, UBIGINT, UINTEGER, USMALLINT, UTINYINT, and VARCHAR types.
     #
     # @param logical_type [DuckDB::LogicalType | :logical_type_symbol] the varargs element type
     # @return [DuckDB::ScalarFunction] self

--- a/test/duckdb_test/expression_test.rb
+++ b/test/duckdb_test/expression_test.rb
@@ -164,6 +164,25 @@ module DuckDBTest
       assert_equal 45,   value.sec
     end
 
+    def test_fold_returns_time_for_timestamp_ms_literal # rubocop:disable Minitest/MultipleAssertions, Metrics/MethodLength
+      expr, client_context = bind_argument_of(
+        'test_fold_ts_ms', :timestamp_ms,
+        "SELECT test_fold_ts_ms('2025-06-20 14:22:33'::TIMESTAMP_MS)",
+        return_type: :bigint,
+        function: ->(_v) { 0 }
+      )
+
+      value = expr.fold(client_context)
+
+      assert_instance_of Time, value
+      assert_equal 2025, value.year
+      assert_equal 6,    value.month
+      assert_equal 20,   value.day
+      assert_equal 14,   value.hour
+      assert_equal 22,   value.min
+      assert_equal 33,   value.sec
+    end
+
     private
 
     # Registers a scalar function, executes sql, and returns


### PR DESCRIPTION
## Summary

Extract `rbduckdb_timestamp_ms_to_ruby(duckdb_timestamp_ms)` into `conveter.c`, following the same pattern as the TIMESTAMP_S converter in #1210.

## Changes

- **`ext/duckdb/conveter.c`**: Add `rbduckdb_timestamp_ms_to_ruby(duckdb_timestamp_ms ts)`
- **`ext/duckdb/converter.h`**: Declare the new shared helper
- **`ext/duckdb/result.c`**: Simplify `vector_timestamp_ms()` to a one-liner
- **`ext/duckdb/value_impl.c`**: Add `DUCKDB_TYPE_TIMESTAMP_MS` case using `duckdb_get_timestamp_ms(val)`
- **`lib/duckdb/scalar_function.rb`**: Add `:timestamp_ms` to `SUPPORTED_TYPES`
- **`test/duckdb_test/expression_test.rb`**: Add `test_fold_returns_time_for_timestamp_ms_literal`

Part of #1204.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for DuckDB's `TIMESTAMP_MS` (millisecond-precision timestamp) data type in scalar function definitions and value conversions.
  * Timestamp millisecond values are now properly converted and evaluated during query planning.

* **Tests**
  * Added test for expression folding with millisecond-precision timestamp literals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->