### PR TITLE
Refactor: share timestamp_ns-to-Ruby conversion between vector and value paths

### DIFF
--- a/ext/duckdb/converter.h
+++ b/ext/duckdb/converter.h
@@ -17,6 +17,7 @@ extern ID id__to_infinity;
 
 VALUE rbduckdb_timestamp_s_to_ruby(duckdb_timestamp_s ts);
 VALUE rbduckdb_timestamp_ms_to_ruby(duckdb_timestamp_ms ts);
+VALUE rbduckdb_timestamp_ns_to_ruby(duckdb_timestamp_ns ts);
 VALUE rbduckdb_time_to_ruby(duckdb_time t);
 VALUE rbduckdb_date_to_ruby(duckdb_date date);
 VALUE rbduckdb_timestamp_to_ruby(duckdb_timestamp ts);

--- a/ext/duckdb/conveter.c
+++ b/ext/duckdb/conveter.c
@@ -81,6 +81,16 @@ VALUE rbduckdb_timestamp_ms_to_ruby(duckdb_timestamp_ms ts) {
                       );
 }
 
+VALUE rbduckdb_timestamp_ns_to_ruby(duckdb_timestamp_ns ts) {
+    VALUE obj = infinite_timestamp_ns_value(ts);
+    if (obj != Qnil) {
+        return obj;
+    }
+    return rb_funcall(mDuckDBConverter, id__to_time_from_duckdb_timestamp_ns, 1,
+                      LL2NUM(ts.nanos)
+                      );
+}
+
 VALUE rbduckdb_time_to_ruby(duckdb_time t) {
     duckdb_time_struct data = duckdb_from_time(t);
     return rb_funcall(mDuckDBConverter, id__to_time_from_duckdb_time, 4,

--- a/ext/duckdb/result.c
+++ b/ext/duckdb/result.c
@@ -380,14 +380,7 @@ static VALUE vector_timestamp_ms(void* vector_data, idx_t row_idx) {
 
 
 static VALUE vector_timestamp_ns(void* vector_data, idx_t row_idx) {
-    duckdb_timestamp_ns data = ((duckdb_timestamp_ns *)vector_data)[row_idx];
-    VALUE obj = infinite_timestamp_ns_value(data);
-    if (obj != Qnil) {
-        return obj;
-    }
-    return rb_funcall(mDuckDBConverter, id__to_time_from_duckdb_timestamp_ns, 1,
-                      LL2NUM(data.nanos)
-                      );
+    return rbduckdb_timestamp_ns_to_ruby(((duckdb_timestamp_ns *)vector_data)[row_idx]);
 }
 
 static VALUE vector_enum(duckdb_logical_type ty, void* vector_data, idx_t row_idx) {

--- a/ext/duckdb/value_impl.c
+++ b/ext/duckdb/value_impl.c
@@ -94,6 +94,9 @@ VALUE rbduckdb_duckdb_value_to_ruby(duckdb_value val) {
         case DUCKDB_TYPE_TIMESTAMP_MS:
             result = rbduckdb_timestamp_ms_to_ruby(duckdb_get_timestamp_ms(val));
             break;
+        case DUCKDB_TYPE_TIMESTAMP_NS:
+            result = rbduckdb_timestamp_ns_to_ruby(duckdb_get_timestamp_ns(val));
+            break;
         case DUCKDB_TYPE_VARCHAR:
             str = duckdb_get_varchar(val);
             result = rb_str_new_cstr(str);

--- a/lib/duckdb/scalar_function.rb
+++ b/lib/duckdb/scalar_function.rb
@@ -101,6 +101,7 @@ module DuckDB
       timestamp
       timestamp_s
       timestamp_ms
+      timestamp_ns
       tinyint
       ubigint
       uinteger
@@ -113,7 +114,7 @@ module DuckDB
 
     # Adds a parameter to the scalar function.
     # Currently supports BIGINT, BLOB, BOOLEAN, DATE, DOUBLE, FLOAT, INTEGER, SMALLINT, TIME, TIMESTAMP,
-    # TIMESTAMP_S, TIMESTAMP_MS, TINYINT, UBIGINT, UINTEGER, USMALLINT, UTINYINT, and VARCHAR types.
+    # TIMESTAMP_S, TIMESTAMP_MS, TIMESTAMP_NS, TINYINT, UBIGINT, UINTEGER, USMALLINT, UTINYINT, and VARCHAR types.
     #
     # @param logical_type [DuckDB::LogicalType | :logical_type_symbol] the parameter type
     # @return [DuckDB::ScalarFunction] self
@@ -126,7 +127,7 @@ module DuckDB
 
     # Sets the return type for the scalar function.
     # Currently supports BIGINT, BLOB, BOOLEAN, DATE, DOUBLE, FLOAT, INTEGER, SMALLINT, TIME, TIMESTAMP,
-    # TIMESTAMP_S, TIMESTAMP_MS, TINYINT, UBIGINT, UINTEGER, USMALLINT, UTINYINT, and VARCHAR types.
+    # TIMESTAMP_S, TIMESTAMP_MS, TIMESTAMP_NS, TINYINT, UBIGINT, UINTEGER, USMALLINT, UTINYINT, and VARCHAR types.
     #
     # @param logical_type [DuckDB::LogicalType | :logical_type_symbol] the return type
     # @return [DuckDB::ScalarFunction] self
@@ -157,7 +158,7 @@ module DuckDB
     # (e.g. a separator followed by a variable list of values).
     # The block receives fixed parameters positionally, then varargs as a splat (|fixed, *rest|).
     # Currently supports BIGINT, BLOB, BOOLEAN, DATE, DOUBLE, FLOAT, INTEGER, SMALLINT, TIME, TIMESTAMP,
-    # TIMESTAMP_S, TIMESTAMP_MS, TINYINT, UBIGINT, UINTEGER, USMALLINT, UTINYINT, and VARCHAR types.
+    # TIMESTAMP_S, TIMESTAMP_MS, TIMESTAMP_NS, TINYINT, UBIGINT, UINTEGER, USMALLINT, UTINYINT, and VARCHAR types.
     #
     # @param logical_type [DuckDB::LogicalType | :logical_type_symbol] the varargs element type
     # @return [DuckDB::ScalarFunction] self

--- a/test/duckdb_test/expression_test.rb
+++ b/test/duckdb_test/expression_test.rb
@@ -183,6 +183,25 @@ module DuckDBTest
       assert_equal 33,   value.sec
     end
 
+    def test_fold_returns_time_for_timestamp_ns_literal # rubocop:disable Minitest/MultipleAssertions, Metrics/MethodLength
+      expr, client_context = bind_argument_of(
+        'test_fold_ts_ns', :timestamp_ns,
+        "SELECT test_fold_ts_ns('2025-09-10 20:11:59'::TIMESTAMP_NS)",
+        return_type: :bigint,
+        function: ->(_v) { 0 }
+      )
+
+      value = expr.fold(client_context)
+
+      assert_instance_of Time, value
+      assert_equal 2025, value.year
+      assert_equal 9,    value.month
+      assert_equal 10,   value.day
+      assert_equal 20,   value.hour
+      assert_equal 11,   value.min
+      assert_equal 59,   value.sec
+    end
+
     private
 
     # Registers a scalar function, executes sql, and returns


### PR DESCRIPTION
## Summary

Extract `rbduckdb_timestamp_ns_to_ruby(duckdb_timestamp_ns)` into `conveter.c`, following the same pattern as the TIMESTAMP_MS converter in #1211.

## Changes

- **`ext/duckdb/conveter.c`**: Add `rbduckdb_timestamp_ns_to_ruby(duckdb_timestamp_ns ts)`
- **`ext/duckdb/converter.h`**: Declare the new shared helper
- **`ext/duckdb/result.c`**: Simplify `vector_timestamp_ns()` to a one-liner
- **`ext/duckdb/value_impl.c`**: Add `DUCKDB_TYPE_TIMESTAMP_NS` case using `duckdb_get_timestamp_ns(val)`
- **`lib/duckdb/scalar_function.rb`**: Add `:timestamp_ns` to `SUPPORTED_TYPES`
- **`test/duckdb_test/expression_test.rb`**: Add `test_fold_returns_time_for_timestamp_ns_literal`

Part of #1204.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Introduced nanosecond-precision timestamp support, enabling accurate handling of TIMESTAMP_NS values in DuckDB conversions and expressions.
  - Nanosecond timestamps are now fully supported in scalar functions and properly convert to Ruby time objects.

* **Tests**
  - Added test coverage for nanosecond timestamp literal expressions and conversions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->