### PR TITLE
Refactor: share timestamp_tz-to-Ruby conversion between vector and value paths

### DIFF
--- a/ext/duckdb/converter.h
+++ b/ext/duckdb/converter.h
@@ -19,6 +19,7 @@ VALUE rbduckdb_timestamp_s_to_ruby(duckdb_timestamp_s ts);
 VALUE rbduckdb_timestamp_ms_to_ruby(duckdb_timestamp_ms ts);
 VALUE rbduckdb_timestamp_ns_to_ruby(duckdb_timestamp_ns ts);
 VALUE rbduckdb_time_tz_to_ruby(duckdb_time_tz tz);
+VALUE rbduckdb_timestamp_tz_to_ruby(duckdb_timestamp ts);
 VALUE rbduckdb_time_to_ruby(duckdb_time t);
 VALUE rbduckdb_date_to_ruby(duckdb_date date);
 VALUE rbduckdb_timestamp_to_ruby(duckdb_timestamp ts);

--- a/ext/duckdb/conveter.c
+++ b/ext/duckdb/conveter.c
@@ -102,6 +102,12 @@ VALUE rbduckdb_time_tz_to_ruby(duckdb_time_tz tz) {
                       );
 }
 
+VALUE rbduckdb_timestamp_tz_to_ruby(duckdb_timestamp ts) {
+    return rb_funcall(mDuckDBConverter, id__to_time_from_duckdb_timestamp_tz, 1,
+                      LL2NUM(ts.micros)
+                      );
+}
+
 VALUE rbduckdb_time_to_ruby(duckdb_time t) {
     duckdb_time_struct data = duckdb_from_time(t);
     return rb_funcall(mDuckDBConverter, id__to_time_from_duckdb_time, 4,

--- a/ext/duckdb/result.c
+++ b/ext/duckdb/result.c
@@ -691,10 +691,8 @@ static VALUE vector_time_tz(void* vector_data, idx_t row_idx) {
 }
 
 static VALUE vector_timestamp_tz(void* vector_data, idx_t row_idx) {
-    duckdb_time_tz data = ((duckdb_time_tz *)vector_data)[row_idx];
-    return rb_funcall(mDuckDBConverter, id__to_time_from_duckdb_timestamp_tz, 1,
-                      ULL2NUM(data.bits)
-                      );
+    duckdb_timestamp ts = {(int64_t)((duckdb_time_tz *)vector_data)[row_idx].bits};
+    return rbduckdb_timestamp_tz_to_ruby(ts);
 }
 
 static VALUE vector_uuid(void* vector_data, idx_t row_idx) {

--- a/ext/duckdb/value_impl.c
+++ b/ext/duckdb/value_impl.c
@@ -100,6 +100,9 @@ VALUE rbduckdb_duckdb_value_to_ruby(duckdb_value val) {
         case DUCKDB_TYPE_TIME_TZ:
             result = rbduckdb_time_tz_to_ruby(duckdb_get_time_tz(val));
             break;
+        case DUCKDB_TYPE_TIMESTAMP_TZ:
+            result = rbduckdb_timestamp_tz_to_ruby(duckdb_get_timestamp_tz(val));
+            break;
         case DUCKDB_TYPE_VARCHAR:
             str = duckdb_get_varchar(val);
             result = rb_str_new_cstr(str);

--- a/lib/duckdb/scalar_function.rb
+++ b/lib/duckdb/scalar_function.rb
@@ -103,6 +103,7 @@ module DuckDB
       timestamp_ms
       timestamp_ns
       time_tz
+      timestamp_tz
       tinyint
       ubigint
       uinteger
@@ -115,7 +116,7 @@ module DuckDB
 
     # Adds a parameter to the scalar function.
     # Currently supports BIGINT, BLOB, BOOLEAN, DATE, DOUBLE, FLOAT, INTEGER, SMALLINT, TIME, TIMESTAMP,
-    # TIMESTAMP_S, TIMESTAMP_MS, TIMESTAMP_NS, TIME_TZ, TINYINT, UBIGINT, UINTEGER, USMALLINT, UTINYINT,
+    # TIMESTAMP_S, TIMESTAMP_MS, TIMESTAMP_NS, TIME_TZ, TIMESTAMP_TZ, TINYINT, UBIGINT, UINTEGER, USMALLINT, UTINYINT,
     # and VARCHAR types.
     #
     # @param logical_type [DuckDB::LogicalType | :logical_type_symbol] the parameter type
@@ -129,7 +130,7 @@ module DuckDB
 
     # Sets the return type for the scalar function.
     # Currently supports BIGINT, BLOB, BOOLEAN, DATE, DOUBLE, FLOAT, INTEGER, SMALLINT, TIME, TIMESTAMP,
-    # TIMESTAMP_S, TIMESTAMP_MS, TIMESTAMP_NS, TIME_TZ, TINYINT, UBIGINT, UINTEGER, USMALLINT, UTINYINT,
+    # TIMESTAMP_S, TIMESTAMP_MS, TIMESTAMP_NS, TIME_TZ, TIMESTAMP_TZ, TINYINT, UBIGINT, UINTEGER, USMALLINT, UTINYINT,
     # and VARCHAR types.
     #
     # @param logical_type [DuckDB::LogicalType | :logical_type_symbol] the return type
@@ -161,7 +162,7 @@ module DuckDB
     # (e.g. a separator followed by a variable list of values).
     # The block receives fixed parameters positionally, then varargs as a splat (|fixed, *rest|).
     # Currently supports BIGINT, BLOB, BOOLEAN, DATE, DOUBLE, FLOAT, INTEGER, SMALLINT, TIME, TIMESTAMP,
-    # TIMESTAMP_S, TIMESTAMP_MS, TIMESTAMP_NS, TIME_TZ, TINYINT, UBIGINT, UINTEGER, USMALLINT, UTINYINT,
+    # TIMESTAMP_S, TIMESTAMP_MS, TIMESTAMP_NS, TIME_TZ, TIMESTAMP_TZ, TINYINT, UBIGINT, UINTEGER, USMALLINT, UTINYINT,
     # and VARCHAR types.
     #
     # @param logical_type [DuckDB::LogicalType | :logical_type_symbol] the varargs element type

--- a/test/duckdb_test/expression_test.rb
+++ b/test/duckdb_test/expression_test.rb
@@ -219,6 +219,26 @@ module DuckDBTest
       assert_equal 19_800, value.utc_offset
     end
 
+    def test_fold_returns_time_for_timestamp_tz_literal # rubocop:disable Minitest/MultipleAssertions, Metrics/AbcSize, Metrics/MethodLength
+      expr, client_context = bind_argument_of(
+        'test_fold_ts_tz', :timestamp_tz,
+        "SELECT test_fold_ts_tz('2025-06-15 10:30:45+00'::TIMESTAMPTZ)",
+        return_type: :bigint,
+        function: ->(_v) { 0 }
+      )
+
+      value = expr.fold(client_context)
+
+      assert_instance_of Time, value
+      assert_equal 2025, value.year
+      assert_equal 6,    value.month
+      assert_equal 15,   value.day
+      assert_equal 10,   value.hour
+      assert_equal 30,   value.min
+      assert_equal 45,   value.sec
+      assert_equal 0,    value.utc_offset
+    end
+
     private
 
     # Registers a scalar function, executes sql, and returns


### PR DESCRIPTION
## Summary

Extract `rbduckdb_timestamp_tz_to_ruby(duckdb_timestamp)` into `conveter.c`, following the same pattern as previous converters (PR #1213).

## Implementation note

TIMESTAMP_TZ data in vectors is stored as UTC microseconds accessed through `duckdb_time_tz.bits` (uint64_t). `duckdb_get_timestamp_tz()` returns the same value as `duckdb_timestamp.micros` (int64_t). The shared helper takes `duckdb_timestamp`; the vector side casts `bits` via `(int64_t)`.

## Changes

- **`ext/duckdb/conveter.c`**: Add `rbduckdb_timestamp_tz_to_ruby(duckdb_timestamp ts)`
- **`ext/duckdb/converter.h`**: Declare the new shared helper
- **`ext/duckdb/result.c`**: Simplify `vector_timestamp_tz()` to a one-liner
- **`ext/duckdb/value_impl.c`**: Add `DUCKDB_TYPE_TIMESTAMP_TZ` case using `duckdb_get_timestamp_tz(val)`
- **`lib/duckdb/scalar_function.rb`**: Add `:timestamp_tz` to `SUPPORTED_TYPES`
- **`test/duckdb_test/expression_test.rb`**: Add `test_fold_returns_time_for_timestamp_tz_literal` (asserts `utc_offset == 0` since TIMESTAMPTZ always normalises to UTC)

Part of #1204.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for timezone-aware timestamp data type with proper conversion and handling across scalar functions and result processing.

* **Tests**
  * Added test coverage for timezone-aware timestamp literal folding and conversion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->