### PR TITLE
feat: add DuckDB::LogicalType.create_union to create a union logical type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 - add `DuckDB::ScalarFunction::BindInfo#get_argument(index)` to return the expression at the given argument index as a `DuckDB::Expression` object (wraps `duckdb_scalar_function_bind_get_argument`). Raises `ArgumentError` for out-of-range index.
 - add `DuckDB::Expression#foldable?` to check whether an expression can be folded to a constant at query planning time (wraps `duckdb_expression_is_foldable`). Returns `true` for literals and constant arithmetic, `false` for column references and non-deterministic functions.
 - add `DuckDB::LogicalType.create_map` to create a map logical type.
+- add `DuckDB::LogicalType.create_union` to create a union logical type.
 - bump duckdb to 1.5.1 on CI
 - add `DuckDB::ScalarFunction::BindInfo#client_context` to return the client context of the bind phase as a `DuckDB::ClientContext` object (wraps `duckdb_scalar_function_get_client_context`).
 - add `DuckDB::ClientContext#connection_id` to return the connection id of the client context (wraps `duckdb_client_context_get_connection_id`).

--- a/ext/duckdb/logical_type.c
+++ b/ext/duckdb/logical_type.c
@@ -26,6 +26,7 @@ static VALUE duckdb_logical_type__set_alias(VALUE self, VALUE aname);
 static VALUE duckdb_logical_type_s_create_array_type(VALUE klass, VALUE child, VALUE array_size);
 static VALUE duckdb_logical_type_s_create_list_type(VALUE klass, VALUE child);
 static VALUE duckdb_logical_type_s_create_map_type(VALUE klass, VALUE key, VALUE value);
+static VALUE duckdb_logical_type_s_create_union_type(VALUE klass, VALUE members);
 static VALUE initialize(VALUE self, VALUE type_id_arg);
 
 static const rb_data_type_t logical_type_data_type = {
@@ -490,6 +491,49 @@ static VALUE duckdb_logical_type_s_create_map_type(VALUE klass, VALUE key, VALUE
     return rbduckdb_create_logical_type(new_type);
 }
 
+/*
+ *  call-seq:
+ *    DuckDB::LogicalType._create_union_type(members) -> DuckDB::LogicalType
+ *
+ *  Return a union logical type from the given member hash.
+ */
+static VALUE duckdb_logical_type_s_create_union_type(VALUE klass, VALUE members) {
+    idx_t member_size = RHASH_SIZE(members);
+    duckdb_logical_type *member_types = NULL;
+    const char **member_names = NULL;
+    duckdb_logical_type new_type;
+    VALUE keys;
+
+    if (member_size == 0) {
+        rb_raise(rb_eArgError, "members hash must not be empty");
+    }
+
+    member_types = (duckdb_logical_type *)xcalloc(member_size, sizeof(duckdb_logical_type));
+    member_names = (const char **)xcalloc(member_size, sizeof(const char *));
+
+    keys = rb_funcall(members, rb_intern("keys"), 0);
+
+    for (idx_t i = 0; i < member_size; i++) {
+        VALUE key = rb_ary_entry(keys, (long)i);
+        VALUE val = rb_hash_aref(members, key);
+        rubyDuckDBLogicalType *type_ctx = get_struct_logical_type(val);
+
+        member_names[i] = rb_id2name(SYM2ID(key));
+        member_types[i] = type_ctx->logical_type;
+    }
+
+    new_type = duckdb_create_union_type(member_types, member_names, member_size);
+
+    xfree(member_types);
+    xfree(member_names);
+
+    if (!new_type) {
+        rb_raise(eDuckDBError, "Failed to create union type");
+    }
+
+    return rbduckdb_create_logical_type(new_type);
+}
+
 VALUE rbduckdb_create_logical_type(duckdb_logical_type logical_type) {
     VALUE obj;
     rubyDuckDBLogicalType *ctx;
@@ -534,6 +578,8 @@ void rbduckdb_init_duckdb_logical_type(void) {
                              duckdb_logical_type_s_create_list_type, 1);
     rb_define_private_method(rb_singleton_class(cDuckDBLogicalType), "_create_map_type",
                              duckdb_logical_type_s_create_map_type, 2);
+    rb_define_private_method(rb_singleton_class(cDuckDBLogicalType), "_create_union_type",
+                             duckdb_logical_type_s_create_union_type, 1);
 
     rb_define_method(cDuckDBLogicalType, "initialize", initialize, 1);
 }

--- a/lib/duckdb/logical_type.rb
+++ b/lib/duckdb/logical_type.rb
@@ -111,6 +111,23 @@ module DuckDB
         _create_map_type(LogicalType.resolve(key_type), LogicalType.resolve(value_type))
       end
 
+      # Creates a union logical type with the given member names and types.
+      #
+      # The keyword arguments map member names to types. Each type can be
+      # a symbol or a DuckDB::LogicalType instance.
+      #
+      #   require 'duckdb'
+      #
+      #   union_type = DuckDB::LogicalType.create_union(num: :integer, str: :varchar)
+      #   union_type.type #=> :union
+      #   union_type.member_count #=> 2
+      #   union_type.member_name_at(0) #=> "num"
+      #   union_type.member_type_at(0).type #=> :integer
+      def create_union(**members)
+        resolved = members.transform_values { |v| LogicalType.resolve(v) }
+        _create_union_type(resolved)
+      end
+
       private
 
       def raise_resolve_error(symbol)

--- a/test/duckdb_test/logical_type_test.rb
+++ b/test/duckdb_test/logical_type_test.rb
@@ -440,6 +440,38 @@ module DuckDBTest
       assert_raises(DuckDB::Error) { DuckDB::LogicalType.create_map(:integer, :nonexistent) }
     end
 
+    def test_s_create_union_with_logical_type
+      union_type = DuckDB::LogicalType.create_union(
+        num: DuckDB::LogicalType::INTEGER,
+        str: DuckDB::LogicalType::VARCHAR
+      )
+
+      assert_equal(:union, union_type.type)
+      assert_equal(2, union_type.member_count)
+    end
+
+    def test_s_create_union_member_names
+      union_type = DuckDB::LogicalType.create_union(num: :integer, str: :varchar)
+
+      assert_equal('num', union_type.member_name_at(0))
+      assert_equal('str', union_type.member_name_at(1))
+    end
+
+    def test_s_create_union_member_types
+      union_type = DuckDB::LogicalType.create_union(num: :integer, str: :varchar)
+
+      assert_equal(:integer, union_type.member_type_at(0).type)
+      assert_equal(:varchar, union_type.member_type_at(1).type)
+    end
+
+    def test_s_create_union_with_invalid_arg
+      assert_raises(DuckDB::Error) { DuckDB::LogicalType.create_union(bad: :nonexistent) }
+    end
+
+    def test_s_create_union_with_no_members
+      assert_raises(ArgumentError) { DuckDB::LogicalType.create_union }
+    end
+
     def test_new_with_primitive_like_complex_type
       # DUCKDB_TYPE_BIT = 29
       bit_type = DuckDB::LogicalType.new(29)


### PR DESCRIPTION
refs: GH-940

In this PR, we add `DuckDB::LogicalType.create_union` to create a union logical type by wrapping the following C API:

- [duckdb_logical_type duckdb_create_union_type(duckdb_logical_type *member_types, const char **member_names, idx_t member_count);](https://duckdb.org/docs/stable/clients/c/api#duckdb_create_union_type)

The method accepts keyword arguments where keys are member names and values are either symbols (e.g., `:integer`, `:varchar`) or `DuckDB::LogicalType` instances.

This is one of the steps for supporting the duckdb_create_xxxx_type C APIs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a factory to create union logical types by specifying member names and their types.
* **Documentation**
  * Added a changelog entry documenting the new union logical type API.
* **Tests**
  * Added unit tests covering successful creation, member ordering/names/types, and error cases for invalid or missing members.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->