### PR TITLE
Refactor: share uhugeint-to-Ruby conversion between vector and value paths

### DIFF
--- a/ext/duckdb/converter.h
+++ b/ext/duckdb/converter.h
@@ -16,6 +16,7 @@ extern ID id__to_time_from_duckdb_timestamp_tz;
 extern ID id__to_infinity;
 
 VALUE rbduckdb_hugeint_to_ruby(duckdb_hugeint h);
+VALUE rbduckdb_uhugeint_to_ruby(duckdb_uhugeint h);
 VALUE rbduckdb_timestamp_s_to_ruby(duckdb_timestamp_s ts);
 VALUE rbduckdb_timestamp_ms_to_ruby(duckdb_timestamp_ms ts);
 VALUE rbduckdb_timestamp_ns_to_ruby(duckdb_timestamp_ns ts);

--- a/ext/duckdb/conveter.c
+++ b/ext/duckdb/conveter.c
@@ -68,6 +68,13 @@ VALUE rbduckdb_hugeint_to_ruby(duckdb_hugeint h) {
                       );
 }
 
+VALUE rbduckdb_uhugeint_to_ruby(duckdb_uhugeint h) {
+    return rb_funcall(mDuckDBConverter, id__to_hugeint_from_vector, 2,
+                      ULL2NUM(h.lower),
+                      ULL2NUM(h.upper)
+                      );
+}
+
 VALUE rbduckdb_timestamp_s_to_ruby(duckdb_timestamp_s ts) {
     VALUE obj = infinite_timestamp_s_value(ts);
     if (obj != Qnil) {

--- a/ext/duckdb/result.c
+++ b/ext/duckdb/result.c
@@ -318,11 +318,7 @@ static VALUE vector_hugeint(void* vector_data, idx_t row_idx) {
 }
 
 static VALUE vector_uhugeint(void* vector_data, idx_t row_idx) {
-    duckdb_uhugeint uhugeint = ((duckdb_uhugeint *)vector_data)[row_idx];
-    return rb_funcall(mDuckDBConverter, id__to_hugeint_from_vector, 2,
-                      ULL2NUM(uhugeint.lower),
-                      ULL2NUM(uhugeint.upper)
-                      );
+    return rbduckdb_uhugeint_to_ruby(((duckdb_uhugeint *)vector_data)[row_idx]);
 }
 
 static VALUE vector_decimal(duckdb_logical_type ty, void* vector_data, idx_t row_idx) {

--- a/ext/duckdb/value_impl.c
+++ b/ext/duckdb/value_impl.c
@@ -64,6 +64,9 @@ VALUE rbduckdb_duckdb_value_to_ruby(duckdb_value val) {
         case DUCKDB_TYPE_HUGEINT:
             result = rbduckdb_hugeint_to_ruby(duckdb_get_hugeint(val));
             break;
+        case DUCKDB_TYPE_UHUGEINT:
+            result = rbduckdb_uhugeint_to_ruby(duckdb_get_uhugeint(val));
+            break;
         case DUCKDB_TYPE_UTINYINT:
             result = INT2FIX(duckdb_get_uint8(val));
             break;

--- a/lib/duckdb/scalar_function.rb
+++ b/lib/duckdb/scalar_function.rb
@@ -107,6 +107,7 @@ module DuckDB
       timestamp_tz
       tinyint
       ubigint
+      uhugeint
       uinteger
       usmallint
       utinyint
@@ -117,8 +118,8 @@ module DuckDB
 
     # Adds a parameter to the scalar function.
     # Currently supports BIGINT, BLOB, BOOLEAN, DATE, DOUBLE, FLOAT, HUGEINT, INTEGER, SMALLINT, TIME, TIMESTAMP,
-    # TIMESTAMP_S, TIMESTAMP_MS, TIMESTAMP_NS, TIME_TZ, TIMESTAMP_TZ, TINYINT, UBIGINT, UINTEGER, USMALLINT, UTINYINT,
-    # and VARCHAR types.
+    # TIMESTAMP_S, TIMESTAMP_MS, TIMESTAMP_NS, TIME_TZ, TIMESTAMP_TZ, TINYINT, UBIGINT, UHUGEINT,
+    # UINTEGER, USMALLINT, UTINYINT, and VARCHAR types.
     #
     # @param logical_type [DuckDB::LogicalType | :logical_type_symbol] the parameter type
     # @return [DuckDB::ScalarFunction] self
@@ -131,8 +132,8 @@ module DuckDB
 
     # Sets the return type for the scalar function.
     # Currently supports BIGINT, BLOB, BOOLEAN, DATE, DOUBLE, FLOAT, HUGEINT, INTEGER, SMALLINT, TIME, TIMESTAMP,
-    # TIMESTAMP_S, TIMESTAMP_MS, TIMESTAMP_NS, TIME_TZ, TIMESTAMP_TZ, TINYINT, UBIGINT, UINTEGER, USMALLINT, UTINYINT,
-    # and VARCHAR types.
+    # TIMESTAMP_S, TIMESTAMP_MS, TIMESTAMP_NS, TIME_TZ, TIMESTAMP_TZ, TINYINT, UBIGINT, UHUGEINT,
+    # UINTEGER, USMALLINT, UTINYINT, and VARCHAR types.
     #
     # @param logical_type [DuckDB::LogicalType | :logical_type_symbol] the return type
     # @return [DuckDB::ScalarFunction] self
@@ -163,8 +164,8 @@ module DuckDB
     # (e.g. a separator followed by a variable list of values).
     # The block receives fixed parameters positionally, then varargs as a splat (|fixed, *rest|).
     # Currently supports BIGINT, BLOB, BOOLEAN, DATE, DOUBLE, FLOAT, HUGEINT, INTEGER, SMALLINT, TIME, TIMESTAMP,
-    # TIMESTAMP_S, TIMESTAMP_MS, TIMESTAMP_NS, TIME_TZ, TIMESTAMP_TZ, TINYINT, UBIGINT, UINTEGER, USMALLINT, UTINYINT,
-    # and VARCHAR types.
+    # TIMESTAMP_S, TIMESTAMP_MS, TIMESTAMP_NS, TIME_TZ, TIMESTAMP_TZ, TINYINT, UBIGINT, UHUGEINT,
+    # UINTEGER, USMALLINT, UTINYINT, and VARCHAR types.
     #
     # @param logical_type [DuckDB::LogicalType | :logical_type_symbol] the varargs element type
     # @return [DuckDB::ScalarFunction] self

--- a/test/duckdb_test/expression_test.rb
+++ b/test/duckdb_test/expression_test.rb
@@ -253,6 +253,20 @@ module DuckDBTest
       assert_equal 18_446_744_073_709_551_616, value
     end
 
+    def test_fold_returns_integer_for_uhugeint_literal
+      expr, client_context = bind_argument_of(
+        'test_fold_uhugeint', :uhugeint,
+        'SELECT test_fold_uhugeint(170141183460469231731687303715884105728::UHUGEINT)',
+        return_type: :bigint,
+        function: ->(_v) { 0 }
+      )
+
+      value = expr.fold(client_context)
+
+      assert_instance_of Integer, value
+      assert_equal 170_141_183_460_469_231_731_687_303_715_884_105_728, value
+    end
+
     private
 
     # Registers a scalar function, executes sql, and returns


### PR DESCRIPTION
## Summary

Extract `rbduckdb_uhugeint_to_ruby(duckdb_uhugeint)` into `conveter.c`, following the same pattern as the HUGEINT converter in #1217.

The key difference from HUGEINT: both `lower` and `upper` fields are `uint64_t`, so both use `ULL2NUM` (vs `LL2NUM` for the signed upper of HUGEINT). The actual conversion logic reuses the existing `_to_hugeint_from_vector` Ruby method.

## Changes

- **`ext/duckdb/conveter.c`**: Add `rbduckdb_uhugeint_to_ruby(duckdb_uhugeint h)`
- **`ext/duckdb/converter.h`**: Declare the new shared helper
- **`ext/duckdb/result.c`**: Simplify `vector_uhugeint()` to a one-liner
- **`ext/duckdb/value_impl.c`**: Add `DUCKDB_TYPE_UHUGEINT` case using `duckdb_get_uhugeint(val)`
- **`lib/duckdb/scalar_function.rb`**: Add `:uhugeint` to `SUPPORTED_TYPES` and update doc comments
- **`test/duckdb_test/expression_test.rb`**: Add `test_fold_returns_integer_for_uhugeint_literal` using `170141183460469231731687303715884105728` (2^127, exceeds signed HUGEINT max)

Part of #1204.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for unsigned huge integer (UHUGEINT) values from DuckDB, enabling conversion and handling of 128-bit unsigned integers.
  * UHUGEINT now supported as a parameter, return type, and varargs element in scalar functions.

* **Tests**
  * Added test coverage for UHUGEINT literal conversion and type folding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->