### PR TITLE
Refactor: share interval-to-Ruby conversion between vector and value paths

### DIFF
--- a/ext/duckdb/converter.h
+++ b/ext/duckdb/converter.h
@@ -15,6 +15,7 @@ extern ID id__to_time_from_duckdb_time_tz;
 extern ID id__to_time_from_duckdb_timestamp_tz;
 extern ID id__to_infinity;
 
+VALUE rbduckdb_interval_to_ruby(duckdb_interval i);
 VALUE rbduckdb_hugeint_to_ruby(duckdb_hugeint h);
 VALUE rbduckdb_uhugeint_to_ruby(duckdb_uhugeint h);
 VALUE rbduckdb_timestamp_s_to_ruby(duckdb_timestamp_s ts);

--- a/ext/duckdb/conveter.c
+++ b/ext/duckdb/conveter.c
@@ -61,6 +61,14 @@ VALUE infinite_timestamp_ns_value(duckdb_timestamp_ns timestamp_ns) {
     return Qnil;
 }
 
+VALUE rbduckdb_interval_to_ruby(duckdb_interval i) {
+    return rb_funcall(mDuckDBConverter, id__to_interval_from_vector, 3,
+                      INT2NUM(i.months),
+                      INT2NUM(i.days),
+                      LL2NUM(i.micros)
+                      );
+}
+
 VALUE rbduckdb_hugeint_to_ruby(duckdb_hugeint h) {
     return rb_funcall(mDuckDBConverter, id__to_hugeint_from_vector, 2,
                       ULL2NUM(h.lower),

--- a/ext/duckdb/result.c
+++ b/ext/duckdb/result.c
@@ -287,12 +287,7 @@ static VALUE vector_time(void* vector_data, idx_t row_idx) {
 
 
 static VALUE vector_interval(void* vector_data, idx_t row_idx) {
-    duckdb_interval data = ((duckdb_interval *)vector_data)[row_idx];
-    return rb_funcall(mDuckDBConverter, id__to_interval_from_vector, 3,
-                      INT2NUM(data.months),
-                      INT2NUM(data.days),
-                      LL2NUM(data.micros)
-                      );
+    return rbduckdb_interval_to_ruby(((duckdb_interval *)vector_data)[row_idx]);
 }
 
 static VALUE vector_blob(void* vector_data, idx_t row_idx) {

--- a/ext/duckdb/value_impl.c
+++ b/ext/duckdb/value_impl.c
@@ -94,6 +94,9 @@ VALUE rbduckdb_duckdb_value_to_ruby(duckdb_value val) {
         case DUCKDB_TYPE_TIME:
             result = rbduckdb_time_to_ruby(duckdb_get_time(val));
             break;
+        case DUCKDB_TYPE_INTERVAL:
+            result = rbduckdb_interval_to_ruby(duckdb_get_interval(val));
+            break;
         case DUCKDB_TYPE_TIMESTAMP_S:
             result = rbduckdb_timestamp_s_to_ruby(duckdb_get_timestamp_s(val));
             break;

--- a/lib/duckdb/scalar_function.rb
+++ b/lib/duckdb/scalar_function.rb
@@ -97,6 +97,7 @@ module DuckDB
       float
       hugeint
       integer
+      interval
       smallint
       time
       timestamp
@@ -117,8 +118,8 @@ module DuckDB
     private_constant :SUPPORTED_TYPES
 
     # Adds a parameter to the scalar function.
-    # Currently supports BIGINT, BLOB, BOOLEAN, DATE, DOUBLE, FLOAT, HUGEINT, INTEGER, SMALLINT, TIME, TIMESTAMP,
-    # TIMESTAMP_S, TIMESTAMP_MS, TIMESTAMP_NS, TIME_TZ, TIMESTAMP_TZ, TINYINT, UBIGINT, UHUGEINT,
+    # Currently supports BIGINT, BLOB, BOOLEAN, DATE, DOUBLE, FLOAT, HUGEINT, INTEGER, INTERVAL, SMALLINT, TIME,
+    # TIMESTAMP, TIMESTAMP_S, TIMESTAMP_MS, TIMESTAMP_NS, TIME_TZ, TIMESTAMP_TZ, TINYINT, UBIGINT, UHUGEINT,
     # UINTEGER, USMALLINT, UTINYINT, and VARCHAR types.
     #
     # @param logical_type [DuckDB::LogicalType | :logical_type_symbol] the parameter type
@@ -131,8 +132,8 @@ module DuckDB
     end
 
     # Sets the return type for the scalar function.
-    # Currently supports BIGINT, BLOB, BOOLEAN, DATE, DOUBLE, FLOAT, HUGEINT, INTEGER, SMALLINT, TIME, TIMESTAMP,
-    # TIMESTAMP_S, TIMESTAMP_MS, TIMESTAMP_NS, TIME_TZ, TIMESTAMP_TZ, TINYINT, UBIGINT, UHUGEINT,
+    # Currently supports BIGINT, BLOB, BOOLEAN, DATE, DOUBLE, FLOAT, HUGEINT, INTEGER, INTERVAL, SMALLINT, TIME,
+    # TIMESTAMP, TIMESTAMP_S, TIMESTAMP_MS, TIMESTAMP_NS, TIME_TZ, TIMESTAMP_TZ, TINYINT, UBIGINT, UHUGEINT,
     # UINTEGER, USMALLINT, UTINYINT, and VARCHAR types.
     #
     # @param logical_type [DuckDB::LogicalType | :logical_type_symbol] the return type
@@ -163,8 +164,8 @@ module DuckDB
     # given type. Can be combined with add_parameter to add fixed leading parameters
     # (e.g. a separator followed by a variable list of values).
     # The block receives fixed parameters positionally, then varargs as a splat (|fixed, *rest|).
-    # Currently supports BIGINT, BLOB, BOOLEAN, DATE, DOUBLE, FLOAT, HUGEINT, INTEGER, SMALLINT, TIME, TIMESTAMP,
-    # TIMESTAMP_S, TIMESTAMP_MS, TIMESTAMP_NS, TIME_TZ, TIMESTAMP_TZ, TINYINT, UBIGINT, UHUGEINT,
+    # Currently supports BIGINT, BLOB, BOOLEAN, DATE, DOUBLE, FLOAT, HUGEINT, INTEGER, INTERVAL, SMALLINT, TIME,
+    # TIMESTAMP, TIMESTAMP_S, TIMESTAMP_MS, TIMESTAMP_NS, TIME_TZ, TIMESTAMP_TZ, TINYINT, UBIGINT, UHUGEINT,
     # UINTEGER, USMALLINT, UTINYINT, and VARCHAR types.
     #
     # @param logical_type [DuckDB::LogicalType | :logical_type_symbol] the varargs element type

--- a/test/duckdb_test/expression_test.rb
+++ b/test/duckdb_test/expression_test.rb
@@ -267,6 +267,22 @@ module DuckDBTest
       assert_equal 170_141_183_460_469_231_731_687_303_715_884_105_728, value
     end
 
+    def test_fold_returns_interval_for_interval_literal # rubocop:disable Minitest/MultipleAssertions, Metrics/MethodLength
+      expr, client_context = bind_argument_of(
+        'test_fold_interval', :interval,
+        "SELECT test_fold_interval('1 year 2 months 3 days 04:05:06'::INTERVAL)",
+        return_type: :bigint,
+        function: ->(_v) { 0 }
+      )
+
+      value = expr.fold(client_context)
+
+      assert_instance_of DuckDB::Interval, value
+      assert_equal 14,             value.interval_months
+      assert_equal 3,              value.interval_days
+      assert_equal 14_706_000_000, value.interval_micros
+    end
+
     private
 
     # Registers a scalar function, executes sql, and returns

--- a/test/duckdb_test/scalar_function_test.rb
+++ b/test/duckdb_test/scalar_function_test.rb
@@ -37,10 +37,10 @@ module DuckDBTest
 
     def test_return_type_setter_raises_error_for_unsupported_type
       sf = DuckDB::ScalarFunction.new
-      interval_type = DuckDB::LogicalType::INTERVAL # Unsupported type for testing
+      bit_type = DuckDB::LogicalType::BIT # Unsupported type for testing
 
       error = assert_raises(DuckDB::Error) do
-        sf.return_type = interval_type
+        sf.return_type = bit_type
       end
 
       assert_match(/not supported/i, error.message)
@@ -79,10 +79,10 @@ module DuckDBTest
 
     def test_add_parameter_raises_error_for_unsupported_type
       sf = DuckDB::ScalarFunction.new
-      interval_type = DuckDB::LogicalType::INTERVAL # Unsupported type for testing
+      bit_type = DuckDB::LogicalType::BIT # Unsupported type for testing
 
       error = assert_raises(DuckDB::Error) do
-        sf.add_parameter(interval_type)
+        sf.add_parameter(bit_type)
       end
 
       assert_match(/not supported/i, error.message)
@@ -702,12 +702,12 @@ module DuckDBTest
 
     def test_varargs_type_setter_raises_error_for_unsupported_type
       # varargs_type= should raise DuckDB::Error when given a type not in
-      # SUPPORTED_TYPES (e.g. INTERVAL), mirroring the behaviour of add_parameter.
+      # SUPPORTED_TYPES (e.g. BIT), mirroring the behaviour of add_parameter.
 
       sf = DuckDB::ScalarFunction.new
 
       error = assert_raises(DuckDB::Error) do
-        sf.varargs_type = DuckDB::LogicalType::INTERVAL
+        sf.varargs_type = DuckDB::LogicalType::BIT
       end
 
       assert_match(/not supported/i, error.message)


### PR DESCRIPTION
## Summary

Extract `rbduckdb_interval_to_ruby(duckdb_interval)` into `conveter.c`, following the same pattern as the other shared struct→Ruby converters. The actual conversion logic reuses the existing `_to_interval_from_vector` Ruby method (no new logic).

## Changes

- **`ext/duckdb/conveter.c`**: Add `rbduckdb_interval_to_ruby(duckdb_interval i)`
- **`ext/duckdb/converter.h`**: Declare the new shared helper
- **`ext/duckdb/result.c`**: Simplify `vector_interval()` to a one-liner
- **`ext/duckdb/value_impl.c`**: Add `DUCKDB_TYPE_INTERVAL` case using `duckdb_get_interval(val)`
- **`lib/duckdb/scalar_function.rb`**: Add `:interval` to `SUPPORTED_TYPES` and update doc comments
- **`test/duckdb_test/expression_test.rb`**: Add `test_fold_returns_interval_for_interval_literal` — verifies months=14, days=3, micros=14706000000
- **`test/duckdb_test/scalar_function_test.rb`**: Replace `INTERVAL` with `BIT` as the unsupported-type stand-in (since INTERVAL is now supported)

Part of #1204.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Interval type is now fully supported for scalar functions and proper conversion of interval values in results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->