### PR TITLE
Refactor: share uuid-to-Ruby conversion between vector and value paths

### DIFF
--- a/ext/duckdb/converter.h
+++ b/ext/duckdb/converter.h
@@ -8,6 +8,7 @@ extern ID id__to_interval_from_vector;
 extern ID id__to_hugeint_from_vector;
 extern ID id__to_decimal_from_hugeint;
 extern ID id__to_uuid_from_vector;
+extern ID id__to_uuid_from_uhugeint;
 extern ID id__to_time_from_duckdb_timestamp_s;
 extern ID id__to_time_from_duckdb_timestamp_ms;
 extern ID id__to_time_from_duckdb_timestamp_ns;
@@ -15,6 +16,8 @@ extern ID id__to_time_from_duckdb_time_tz;
 extern ID id__to_time_from_duckdb_timestamp_tz;
 extern ID id__to_infinity;
 
+VALUE rbduckdb_uuid_to_ruby(duckdb_hugeint h);
+VALUE rbduckdb_uuid_uhugeint_to_ruby(duckdb_uhugeint h);
 VALUE rbduckdb_interval_to_ruby(duckdb_interval i);
 VALUE rbduckdb_hugeint_to_ruby(duckdb_hugeint h);
 VALUE rbduckdb_uhugeint_to_ruby(duckdb_uhugeint h);

--- a/ext/duckdb/conveter.c
+++ b/ext/duckdb/conveter.c
@@ -9,6 +9,7 @@ ID id__to_interval_from_vector;
 ID id__to_hugeint_from_vector;
 ID id__to_decimal_from_hugeint;
 ID id__to_uuid_from_vector;
+ID id__to_uuid_from_uhugeint;
 ID id__to_time_from_duckdb_timestamp_s;
 ID id__to_time_from_duckdb_timestamp_ms;
 ID id__to_time_from_duckdb_timestamp_ns;
@@ -59,6 +60,20 @@ VALUE infinite_timestamp_ns_value(duckdb_timestamp_ns timestamp_ns) {
                          );
     }
     return Qnil;
+}
+
+VALUE rbduckdb_uuid_to_ruby(duckdb_hugeint h) {
+    return rb_funcall(mDuckDBConverter, id__to_uuid_from_vector, 2,
+                      ULL2NUM(h.lower),
+                      LL2NUM(h.upper)
+                      );
+}
+
+VALUE rbduckdb_uuid_uhugeint_to_ruby(duckdb_uhugeint h) {
+    return rb_funcall(mDuckDBConverter, id__to_uuid_from_uhugeint, 2,
+                      ULL2NUM(h.lower),
+                      ULL2NUM(h.upper)
+                      );
 }
 
 VALUE rbduckdb_interval_to_ruby(duckdb_interval i) {
@@ -182,6 +197,7 @@ void rbduckdb_init_duckdb_converter(void) {
     id__to_hugeint_from_vector = rb_intern("_to_hugeint_from_vector");
     id__to_decimal_from_hugeint = rb_intern("_to_decimal_from_hugeint");
     id__to_uuid_from_vector = rb_intern("_to_uuid_from_vector");
+    id__to_uuid_from_uhugeint = rb_intern("_to_uuid_from_uhugeint");
     id__to_time_from_duckdb_timestamp_s = rb_intern("_to_time_from_duckdb_timestamp_s");
     id__to_time_from_duckdb_timestamp_ms = rb_intern("_to_time_from_duckdb_timestamp_ms");
     id__to_time_from_duckdb_timestamp_ns = rb_intern("_to_time_from_duckdb_timestamp_ns");

--- a/ext/duckdb/result.c
+++ b/ext/duckdb/result.c
@@ -683,11 +683,7 @@ static VALUE vector_timestamp_tz(void* vector_data, idx_t row_idx) {
 }
 
 static VALUE vector_uuid(void* vector_data, idx_t row_idx) {
-    duckdb_hugeint hugeint = ((duckdb_hugeint *)vector_data)[row_idx];
-    return rb_funcall(mDuckDBConverter, id__to_uuid_from_vector, 2,
-                      ULL2NUM(hugeint.lower),
-                      LL2NUM(hugeint.upper)
-                      );
+    return rbduckdb_uuid_to_ruby(((duckdb_hugeint *)vector_data)[row_idx]);
 }
 
 static VALUE vector_value(duckdb_vector vector, idx_t row_idx) {

--- a/ext/duckdb/value_impl.c
+++ b/ext/duckdb/value_impl.c
@@ -117,6 +117,9 @@ VALUE rbduckdb_duckdb_value_to_ruby(duckdb_value val) {
             result = rb_str_new_cstr(str);
             duckdb_free(str);
             break;
+        case DUCKDB_TYPE_UUID:
+            result = rbduckdb_uuid_uhugeint_to_ruby(duckdb_get_uuid(val));
+            break;
         default:
             result = Qnil;
             break;

--- a/lib/duckdb/converter.rb
+++ b/lib/duckdb/converter.rb
@@ -117,6 +117,11 @@ module DuckDB
       "#{str[0, 8]}-#{str[8, 4]}-#{str[12, 4]}-#{str[16, 4]}-#{str[20, 12]}"
     end
 
+    def _to_uuid_from_uhugeint(lower, upper)
+      str = _to_hugeint_from_vector(lower, upper).to_s(16).rjust(32, '0')
+      "#{str[0, 8]}-#{str[8, 4]}-#{str[12, 4]}-#{str[16, 4]}-#{str[20, 12]}"
+    end
+
     def _parse_date(value)
       case value
       when Date, Time

--- a/lib/duckdb/logical_type.rb
+++ b/lib/duckdb/logical_type.rb
@@ -38,6 +38,7 @@ module DuckDB
       # array: 33,
       # uuid: 27,
       # union: 28,
+      uuid: 27,
       bit: 29,
       time_tz: 30,
       timestamp_tz: 31,

--- a/lib/duckdb/scalar_function.rb
+++ b/lib/duckdb/scalar_function.rb
@@ -112,6 +112,7 @@ module DuckDB
       uinteger
       usmallint
       utinyint
+      uuid
       varchar
     ].freeze
 
@@ -120,7 +121,7 @@ module DuckDB
     # Adds a parameter to the scalar function.
     # Currently supports BIGINT, BLOB, BOOLEAN, DATE, DOUBLE, FLOAT, HUGEINT, INTEGER, INTERVAL, SMALLINT, TIME,
     # TIMESTAMP, TIMESTAMP_S, TIMESTAMP_MS, TIMESTAMP_NS, TIME_TZ, TIMESTAMP_TZ, TINYINT, UBIGINT, UHUGEINT,
-    # UINTEGER, USMALLINT, UTINYINT, and VARCHAR types.
+    # UINTEGER, USMALLINT, UTINYINT, UUID, and VARCHAR types.
     #
     # @param logical_type [DuckDB::LogicalType | :logical_type_symbol] the parameter type
     # @return [DuckDB::ScalarFunction] self
@@ -134,7 +135,7 @@ module DuckDB
     # Sets the return type for the scalar function.
     # Currently supports BIGINT, BLOB, BOOLEAN, DATE, DOUBLE, FLOAT, HUGEINT, INTEGER, INTERVAL, SMALLINT, TIME,
     # TIMESTAMP, TIMESTAMP_S, TIMESTAMP_MS, TIMESTAMP_NS, TIME_TZ, TIMESTAMP_TZ, TINYINT, UBIGINT, UHUGEINT,
-    # UINTEGER, USMALLINT, UTINYINT, and VARCHAR types.
+    # UINTEGER, USMALLINT, UTINYINT, UUID, and VARCHAR types.
     #
     # @param logical_type [DuckDB::LogicalType | :logical_type_symbol] the return type
     # @return [DuckDB::ScalarFunction] self
@@ -166,7 +167,7 @@ module DuckDB
     # The block receives fixed parameters positionally, then varargs as a splat (|fixed, *rest|).
     # Currently supports BIGINT, BLOB, BOOLEAN, DATE, DOUBLE, FLOAT, HUGEINT, INTEGER, INTERVAL, SMALLINT, TIME,
     # TIMESTAMP, TIMESTAMP_S, TIMESTAMP_MS, TIMESTAMP_NS, TIME_TZ, TIMESTAMP_TZ, TINYINT, UBIGINT, UHUGEINT,
-    # UINTEGER, USMALLINT, UTINYINT, and VARCHAR types.
+    # UINTEGER, USMALLINT, UTINYINT, UUID, and VARCHAR types.
     #
     # @param logical_type [DuckDB::LogicalType | :logical_type_symbol] the varargs element type
     # @return [DuckDB::ScalarFunction] self

--- a/test/duckdb_test/expression_test.rb
+++ b/test/duckdb_test/expression_test.rb
@@ -283,6 +283,19 @@ module DuckDBTest
       assert_equal 14_706_000_000, value.interval_micros
     end
 
+    def test_fold_returns_string_for_uuid_literal
+      expr, client_context = bind_argument_of(
+        'test_fold_uuid', :uuid,
+        "SELECT test_fold_uuid('550e8400-e29b-41d4-a716-446655440000'::UUID)",
+        return_type: :varchar,
+        function: ->(_v) { '' }
+      )
+
+      value = expr.fold(client_context)
+
+      assert_equal '550e8400-e29b-41d4-a716-446655440000', value
+    end
+
     private
 
     # Registers a scalar function, executes sql, and returns


### PR DESCRIPTION
## Summary

Extract UUID→Ruby conversion helpers into `conveter.c`, following the same pattern as the other shared converters. UUID requires **two** C helpers because the vector and value paths expose different types:

| Path | Input type | Encoding |
|---|---|---|
| Vector (`vector_uuid`) | `duckdb_hugeint` | Sort-key encoded (high bit flipped) |
| Value (`duckdb_get_uuid`) | `duckdb_uhugeint` | Already decoded (flip undone by DuckDB) |

The conversion logic stays in Ruby:
- `_to_uuid_from_vector`: XORs the sort-key flip bit then formats as UUID string (existing method, unchanged)
- `_to_uuid_from_uhugeint`: formats the already-decoded uhugeint directly as UUID string (new method)

## Changes

- **`ext/duckdb/conveter.c`**: Add `rbduckdb_uuid_to_ruby(duckdb_hugeint)` and `rbduckdb_uuid_uhugeint_to_ruby(duckdb_uhugeint)`
- **`ext/duckdb/converter.h`**: Declare both new helpers and `id__to_uuid_from_uhugeint`
- **`ext/duckdb/result.c`**: Simplify `vector_uuid()` to a one-liner
- **`ext/duckdb/value_impl.c`**: Add `DUCKDB_TYPE_UUID` case using `duckdb_get_uuid(val)`
- **`lib/duckdb/logical_type.rb`**: Uncomment `uuid: 27`
- **`lib/duckdb/converter.rb`**: Add `_to_uuid_from_uhugeint`
- **`lib/duckdb/scalar_function.rb`**: Add `:uuid` to `SUPPORTED_TYPES`, update doc comments
- **`test/duckdb_test/expression_test.rb`**: Add `test_fold_returns_string_for_uuid_literal`

Part of #1204.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced UUID type support in scalar functions and value conversions, enabling UUID parameters and return types.
  * Added UUID literal expression folding support.

* **Bug Fixes**
  * Improved UUID conversion handling for different internal numeric representations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->