### PR TITLE
feat: add DuckDB::Value.create_blob

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file.
 - add `DuckDB::Value.create_float`.
 - add `DuckDB::Value.create_double`.
 - add `DuckDB::Value.create_varchar`.
+- add `DuckDB::Value.create_blob`.
 - add `DuckDB::Appender#append_value`.
 
 ## Breaking Changes

--- a/ext/duckdb/value.c
+++ b/ext/duckdb/value.c
@@ -17,6 +17,7 @@ static VALUE duckdb_value_s__create_uint64(VALUE klass, VALUE val);
 static VALUE duckdb_value_s__create_float(VALUE klass, VALUE val);
 static VALUE duckdb_value_s__create_double(VALUE klass, VALUE val);
 static VALUE duckdb_value_s__create_varchar(VALUE klass, VALUE str);
+static VALUE duckdb_value_s__create_blob(VALUE klass, VALUE str);
 static VALUE duckdb_value_s_create_null(VALUE klass);
 
 static const rb_data_type_t value_data_type = {
@@ -100,6 +101,13 @@ static VALUE duckdb_value_s__create_varchar(VALUE klass, VALUE str) {
     const char *str_ptr = StringValuePtr(str);
     idx_t str_len = RSTRING_LEN(str);
     duckdb_value value = duckdb_create_varchar_length(str_ptr, str_len);
+    return rbduckdb_value_new(value);
+}
+
+static VALUE duckdb_value_s__create_blob(VALUE klass, VALUE str) {
+    const uint8_t *data_ptr = (const uint8_t *)StringValuePtr(str);
+    idx_t data_len = RSTRING_LEN(str);
+    duckdb_value value = duckdb_create_blob(data_ptr, data_len);
     return rbduckdb_value_new(value);
 }
 
@@ -245,6 +253,7 @@ void rbduckdb_init_duckdb_value(void) {
     rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_float", duckdb_value_s__create_float, 1);
     rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_double", duckdb_value_s__create_double, 1);
     rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_varchar", duckdb_value_s__create_varchar, 1);
+    rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_blob", duckdb_value_s__create_blob, 1);
     rb_define_singleton_method(cDuckDBValue, "create_null", duckdb_value_s_create_null, 0);
 }
 

--- a/lib/duckdb/value.rb
+++ b/lib/duckdb/value.rb
@@ -176,6 +176,19 @@ module DuckDB
         _create_varchar(value)
       end
 
+      # Creates a DuckDB::Value of BLOB type.
+      #
+      #   value = DuckDB::Value.create_blob("\x00\x01\x02".b)
+      #
+      # @param value [String] the binary string value.
+      # @return [DuckDB::Value] the created Value object.
+      # @raise [ArgumentError] if +value+ is not a BINARY encoded String.
+      def create_blob(value)
+        check_type!(value, String)
+        check_binary!(value)
+        _create_blob(value)
+      end
+
       private
 
       def check_range!(value, range, type_name)
@@ -187,6 +200,12 @@ module DuckDB
         return if types.any? { |type| value.is_a?(type) }
 
         raise ArgumentError, "expected #{types.map(&:name).join(' or ')}, got #{value.class.name}"
+      end
+
+      def check_binary!(value)
+        return if value.encoding == Encoding::BINARY
+
+        raise ArgumentError, "expected BINARY encoding, got #{value.encoding}"
       end
 
       def check_utf8_compatible!(value)

--- a/test/duckdb_test/value_test.rb
+++ b/test/duckdb_test/value_test.rb
@@ -462,6 +462,18 @@ module DuckDBTest
       assert_instance_of(DuckDB::Value, value)
     end
 
+    def test_create_blob_with_binary_duckdb_blob
+      value = DuckDB::Value.create_blob(DuckDB::Blob.new("\x00\x01\x02".b))
+
+      assert_instance_of(DuckDB::Value, value)
+    end
+
+    def test_create_blob_with_utf8_duckdb_blob_raises_argument_error
+      assert_raises(ArgumentError) do
+        DuckDB::Value.create_blob(DuckDB::Blob.new('hello'))
+      end
+    end
+
     def test_create_blob_with_utf8_string_raises_argument_error
       assert_raises(ArgumentError) do
         DuckDB::Value.create_blob('hello')

--- a/test/duckdb_test/value_test.rb
+++ b/test/duckdb_test/value_test.rb
@@ -450,6 +450,30 @@ module DuckDBTest
       end
     end
 
+    def test_create_blob
+      value = DuckDB::Value.create_blob("\x00\x01\x02".b)
+
+      assert_instance_of(DuckDB::Value, value)
+    end
+
+    def test_create_blob_with_empty_string
+      value = DuckDB::Value.create_blob(''.b)
+
+      assert_instance_of(DuckDB::Value, value)
+    end
+
+    def test_create_blob_with_utf8_string_raises_argument_error
+      assert_raises(ArgumentError) do
+        DuckDB::Value.create_blob('hello')
+      end
+    end
+
+    def test_create_blob_with_integer_raises_argument_error
+      assert_raises(ArgumentError) do
+        DuckDB::Value.create_blob(123)
+      end
+    end
+
     def test_create_int32_bind_value
       @con.query('CREATE TABLE e2e_int32 (id INTEGER, val INTEGER)')
       stmt = DuckDB::PreparedStatement.new(@con, 'INSERT INTO e2e_int32 VALUES (1, ?)')
@@ -548,6 +572,16 @@ module DuckDBTest
       result = @con.query('SELECT val FROM e2e_varchar WHERE id = 1')
 
       assert_equal('Hello DuckDB', result.first[0])
+    end
+
+    def test_create_blob_bind_value
+      @con.query('CREATE TABLE e2e_blob (id INTEGER, val BLOB)')
+      stmt = DuckDB::PreparedStatement.new(@con, 'INSERT INTO e2e_blob VALUES (1, ?)')
+      stmt.bind_value(1, DuckDB::Value.create_blob("\x00\x01\x02\xff".b))
+      stmt.execute
+      result = @con.query('SELECT val FROM e2e_blob WHERE id = 1')
+
+      assert_equal("\x00\x01\x02\xff".b, result.first[0])
     end
   end
 end


### PR DESCRIPTION
GitHub: refs GH-695

Wrap `duckdb_create_blob` C API to create BLOB type values.
This enables binding binary data via `PreparedStatement#bind_value`.
- ref: https://duckdb.org/docs/stable/clients/c/api.html#duckdb_create_blob

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added DuckDB::Value.create_blob() to create BLOB values with validation for binary-encoded input.

* **Tests**
  * Added tests covering BLOB creation, input validation, and prepared-statement bind/round-trip scenarios.

* **Documentation**
  * Changelog updated with an entry announcing DuckDB::Value.create_blob.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->