### PR TITLE
feat: add AggregateFunction#set_update (Phase 1.1)

### DIFF
--- a/ext/duckdb/aggregate_function.c
+++ b/ext/duckdb/aggregate_function.c
@@ -27,6 +27,7 @@ static VALUE rbduckdb_aggregate_function__set_return_type(VALUE self, VALUE logi
 static VALUE rbduckdb_aggregate_function_add_parameter(VALUE self, VALUE logical_type);
 static VALUE rbduckdb_aggregate_function_set_init(VALUE self);
 static VALUE rbduckdb_aggregate_function_set_update(VALUE self);
+static VALUE rbduckdb_aggregate_function_set_combine(VALUE self);
 static VALUE rbduckdb_aggregate_function_set_finalize(VALUE self);
 
 static const rb_data_type_t aggregate_function_data_type = {
@@ -39,6 +40,7 @@ static void mark(void *ctx) {
     rubyDuckDBAggregateFunction *p = (rubyDuckDBAggregateFunction *)ctx;
     rb_gc_mark_movable(p->init_proc);
     rb_gc_mark_movable(p->update_proc);
+    rb_gc_mark_movable(p->combine_proc);
     rb_gc_mark_movable(p->finalize_proc);
 }
 
@@ -55,6 +57,9 @@ static void compact(void *ctx) {
     }
     if (p->update_proc != Qnil) {
         p->update_proc = rb_gc_location(p->update_proc);
+    }
+    if (p->combine_proc != Qnil) {
+        p->combine_proc = rb_gc_location(p->combine_proc);
     }
     if (p->finalize_proc != Qnil) {
         p->finalize_proc = rb_gc_location(p->finalize_proc);
@@ -82,6 +87,7 @@ static VALUE duckdb_aggregate_function_initialize(VALUE self) {
     p->aggregate_function = duckdb_create_aggregate_function();
     p->init_proc = Qnil;
     p->update_proc = Qnil;
+    p->combine_proc = Qnil;
     p->finalize_proc = Qnil;
     return self;
 }
@@ -348,7 +354,8 @@ static void noop_combine_callback(duckdb_function_info info,
 }
 
 /*
- * Default combine for Phase 1.1: move source state into target state.
+ * Fallback combine used when update_proc is supplied but the user did not
+ * register a combine_proc via set_combine.
  *
  * DuckDB invokes combine even for single-partition aggregates: after update
  * has accumulated values into a source state, DuckDB freshly initialises a
@@ -357,8 +364,9 @@ static void noop_combine_callback(duckdb_function_info info,
  * Without a user-provided combine_proc we cannot perform an arbitrary merge,
  * so this minimal implementation overwrites target->ruby_state with the
  * source value. This is correct for the common single-group/single-thread
- * path exercised by the tests; richer combine semantics will arrive together
- * with a user-facing set_combine callback in a later phase.
+ * path; parallel execution requires the user to supply a combine_proc via
+ * set_combine, in which case combine_callback is wired instead of this
+ * fallback.
  */
 static void default_combine_callback(duckdb_function_info info,
                                      duckdb_aggregate_state *source,
@@ -375,6 +383,82 @@ static void default_combine_callback(duckdb_function_info info,
                      state_registry_key(tgt[i]),
                      tgt[i]->ruby_state);
     }
+}
+
+/* combine_callback dispatch argument */
+struct combine_callback_arg {
+    rubyDuckDBAggregateFunction *ctx;
+    duckdb_function_info info;
+    duckdb_aggregate_state *source;
+    duckdb_aggregate_state *target;
+    idx_t count;
+};
+
+struct combine_one_arg {
+    VALUE combine_proc;
+    VALUE source_state;
+    VALUE target_state;
+};
+
+static VALUE call_combine_proc(VALUE varg) {
+    struct combine_one_arg *arg = (struct combine_one_arg *)varg;
+    VALUE argv[2];
+    argv[0] = arg->source_state;
+    argv[1] = arg->target_state;
+    return rb_funcallv(arg->combine_proc, rb_intern("call"), 2, argv);
+}
+
+static void execute_combine_callback_protected(void *user_data) {
+    struct combine_callback_arg *arg = (struct combine_callback_arg *)user_data;
+    ruby_aggregate_state **src = (ruby_aggregate_state **)arg->source;
+    ruby_aggregate_state **tgt = (ruby_aggregate_state **)arg->target;
+    idx_t i;
+
+    for (i = 0; i < arg->count; i++) {
+        struct combine_one_arg one;
+        int exception_state;
+        VALUE ret;
+
+        one.combine_proc = arg->ctx->combine_proc;
+        one.source_state = src[i]->ruby_state;
+        one.target_state = tgt[i]->ruby_state;
+
+        ret = rb_protect(call_combine_proc, (VALUE)&one, &exception_state);
+        if (exception_state) {
+            report_ruby_error_to_duckdb(arg->info);
+            return;
+        }
+
+        tgt[i]->ruby_state = ret;
+        rb_hash_aset(g_aggregate_state_registry,
+                     state_registry_key(tgt[i]), ret);
+
+        /* source state is consumed by combine; release its registry entry
+         * so the Ruby VALUE can be GC'd. */
+        rb_hash_delete(g_aggregate_state_registry,
+                       state_registry_key(src[i]));
+    }
+}
+
+static void combine_callback(duckdb_function_info info,
+                             duckdb_aggregate_state *source,
+                             duckdb_aggregate_state *target,
+                             idx_t count) {
+    rubyDuckDBAggregateFunction *ctx;
+    struct combine_callback_arg arg;
+
+    ctx = (rubyDuckDBAggregateFunction *)duckdb_aggregate_function_get_extra_info(info);
+    if (ctx == NULL || ctx->combine_proc == Qnil) {
+        return;
+    }
+
+    arg.ctx = ctx;
+    arg.info = info;
+    arg.source = source;
+    arg.target = target;
+    arg.count = count;
+
+    rbduckdb_function_executor_dispatch(execute_combine_callback_protected, &arg);
 }
 
 /* finalize callback dispatch argument */
@@ -397,18 +481,29 @@ static VALUE call_finalize_proc(VALUE varg) {
     return rb_funcall(arg->finalize_proc, rb_intern("call"), 1, arg->ruby_state);
 }
 
+struct vector_set_arg {
+    duckdb_vector vector;
+    duckdb_logical_type element_type;
+    idx_t index;
+    VALUE value;
+};
+
+static VALUE call_vector_set_value_at(VALUE varg) {
+    struct vector_set_arg *a = (struct vector_set_arg *)varg;
+    rbduckdb_vector_set_value_at(a->vector, a->element_type, a->index, a->value);
+    return Qnil;
+}
+
 static void execute_finalize_callback_protected(void *user_data) {
     struct finalize_callback_arg *arg = (struct finalize_callback_arg *)user_data;
     ruby_aggregate_state **states = (ruby_aggregate_state **)arg->source_p;
-    /* Phase 1.0: result type is hardcoded to BIGINT. Non-BIGINT return types
-     * will be supported in a later phase once vector_set_value_at-style
-     * type dispatch is shared between scalar and aggregate functions. */
-    int64_t *result_data = (int64_t *)duckdb_vector_get_data(arg->result);
+    duckdb_logical_type result_type = duckdb_vector_get_column_type(arg->result);
     idx_t i;
 
     for (i = 0; i < arg->count; i++) {
         ruby_aggregate_state *state = states[i];
         struct finalize_one_arg one;
+        struct vector_set_arg vsa;
         int exception_state;
         VALUE ret;
 
@@ -418,14 +513,26 @@ static void execute_finalize_callback_protected(void *user_data) {
         ret = rb_protect(call_finalize_proc, (VALUE)&one, &exception_state);
         if (exception_state) {
             report_ruby_error_to_duckdb(arg->info);
-            return;
+            goto cleanup;
         }
 
-        result_data[arg->offset + i] = NUM2LL(ret);
+        vsa.vector = arg->result;
+        vsa.element_type = result_type;
+        vsa.index = arg->offset + i;
+        vsa.value = ret;
+
+        rb_protect(call_vector_set_value_at, (VALUE)&vsa, &exception_state);
+        if (exception_state) {
+            report_ruby_error_to_duckdb(arg->info);
+            goto cleanup;
+        }
 
         /* Release Ruby state from the GC registry. */
         rb_hash_delete(g_aggregate_state_registry, state_registry_key(state));
     }
+
+cleanup:
+    duckdb_destroy_logical_type(&result_type);
 }
 
 static void finalize_callback(duckdb_function_info info,
@@ -465,7 +572,8 @@ static void maybe_set_functions(rubyDuckDBAggregateFunction *p) {
         state_size_callback,
         state_init_callback,
         (p->update_proc != Qnil) ? update_callback : noop_update_callback,
-        (p->update_proc != Qnil) ? default_combine_callback : noop_combine_callback,
+        (p->combine_proc != Qnil) ? combine_callback :
+            ((p->update_proc != Qnil) ? default_combine_callback : noop_combine_callback),
         finalize_callback);
 
     /* Ensure the global executor thread is running for multi-thread dispatch.
@@ -506,6 +614,22 @@ static VALUE rbduckdb_aggregate_function_set_update(VALUE self) {
 }
 
 /* :nodoc: */
+static VALUE rbduckdb_aggregate_function_set_combine(VALUE self) {
+    rubyDuckDBAggregateFunction *p;
+
+    if (!rb_block_given_p()) {
+        rb_raise(rb_eArgError, "block is required");
+    }
+
+    TypedData_Get_Struct(self, rubyDuckDBAggregateFunction, &aggregate_function_data_type, p);
+    p->combine_proc = rb_block_proc();
+
+    maybe_set_functions(p);
+
+    return self;
+}
+
+/* :nodoc: */
 static VALUE rbduckdb_aggregate_function_set_finalize(VALUE self) {
     rubyDuckDBAggregateFunction *p;
 
@@ -533,6 +657,7 @@ void rbduckdb_init_duckdb_aggregate_function(void) {
     rb_define_private_method(cDuckDBAggregateFunction, "_add_parameter", rbduckdb_aggregate_function_add_parameter, 1);
     rb_define_method(cDuckDBAggregateFunction, "set_init", rbduckdb_aggregate_function_set_init, 0);
     rb_define_method(cDuckDBAggregateFunction, "set_update", rbduckdb_aggregate_function_set_update, 0);
+    rb_define_method(cDuckDBAggregateFunction, "set_combine", rbduckdb_aggregate_function_set_combine, 0);
     rb_define_method(cDuckDBAggregateFunction, "set_finalize", rbduckdb_aggregate_function_set_finalize, 0);
 
     g_aggregate_state_registry = rb_hash_new();

--- a/ext/duckdb/aggregate_function.c
+++ b/ext/duckdb/aggregate_function.c
@@ -379,9 +379,15 @@ static void default_combine_callback(duckdb_function_info info,
 
     for (i = 0; i < count; i++) {
         tgt[i]->ruby_state = src[i]->ruby_state;
-        rb_hash_aset(g_aggregate_state_registry,
-                     state_registry_key(tgt[i]),
-                     tgt[i]->ruby_state);
+        /*
+         * Do NOT call any Ruby API here.  This callback is invoked by a
+         * DuckDB worker thread that does not hold the GVL; any rb_* call
+         * from this context is unsafe and causes a SIGSEGV on Windows.
+         *
+         * The copied VALUE is already GC-protected via the source state's
+         * existing registry entry.  That entry leaks until the destructor
+         * callback is wired up in Phase 2.
+         */
     }
 }
 

--- a/ext/duckdb/aggregate_function.c
+++ b/ext/duckdb/aggregate_function.c
@@ -26,6 +26,7 @@ static VALUE rbduckdb_aggregate_function_set_name(VALUE self, VALUE name);
 static VALUE rbduckdb_aggregate_function__set_return_type(VALUE self, VALUE logical_type);
 static VALUE rbduckdb_aggregate_function_add_parameter(VALUE self, VALUE logical_type);
 static VALUE rbduckdb_aggregate_function_set_init(VALUE self);
+static VALUE rbduckdb_aggregate_function_set_update(VALUE self);
 static VALUE rbduckdb_aggregate_function_set_finalize(VALUE self);
 
 static const rb_data_type_t aggregate_function_data_type = {
@@ -37,6 +38,7 @@ static const rb_data_type_t aggregate_function_data_type = {
 static void mark(void *ctx) {
     rubyDuckDBAggregateFunction *p = (rubyDuckDBAggregateFunction *)ctx;
     rb_gc_mark_movable(p->init_proc);
+    rb_gc_mark_movable(p->update_proc);
     rb_gc_mark_movable(p->finalize_proc);
 }
 
@@ -50,6 +52,9 @@ static void compact(void *ctx) {
     rubyDuckDBAggregateFunction *p = (rubyDuckDBAggregateFunction *)ctx;
     if (p->init_proc != Qnil) {
         p->init_proc = rb_gc_location(p->init_proc);
+    }
+    if (p->update_proc != Qnil) {
+        p->update_proc = rb_gc_location(p->update_proc);
     }
     if (p->finalize_proc != Qnil) {
         p->finalize_proc = rb_gc_location(p->finalize_proc);
@@ -76,6 +81,7 @@ static VALUE duckdb_aggregate_function_initialize(VALUE self) {
     TypedData_Get_Struct(self, rubyDuckDBAggregateFunction, &aggregate_function_data_type, p);
     p->aggregate_function = duckdb_create_aggregate_function();
     p->init_proc = Qnil;
+    p->update_proc = Qnil;
     p->finalize_proc = Qnil;
     return self;
 }
@@ -194,13 +200,140 @@ static void state_init_callback(duckdb_function_info info, duckdb_aggregate_stat
     rbduckdb_function_executor_dispatch(execute_init_callback_protected, &arg);
 }
 
-/* No-op update: Phase 1.0 does not dispatch update to Ruby. */
+/* No-op update: used when no update_proc has been supplied. */
 static void noop_update_callback(duckdb_function_info info,
                                  duckdb_data_chunk input,
                                  duckdb_aggregate_state *states) {
     (void)info;
     (void)input;
     (void)states;
+}
+
+/* update callback dispatch argument */
+struct update_callback_arg {
+    rubyDuckDBAggregateFunction *ctx;
+    duckdb_function_info info;
+    duckdb_data_chunk input;
+    duckdb_aggregate_state *states;
+    duckdb_vector *input_vectors;
+    duckdb_logical_type *input_types;
+    VALUE *args;
+    idx_t row_count;
+    idx_t col_count;
+};
+
+struct update_one_arg {
+    VALUE update_proc;
+    int argc;
+    VALUE *argv;
+};
+
+static VALUE call_update_proc(VALUE varg) {
+    struct update_one_arg *arg = (struct update_one_arg *)varg;
+    return rb_funcallv(arg->update_proc, rb_intern("call"), arg->argc, arg->argv);
+}
+
+/*
+ * Body of the update callback: allocate input buffers, walk each row,
+ * dispatch to the user's update_proc. Runs inside rb_ensure so that
+ * update_cleanup_callback always runs — even if rbduckdb_vector_value_at
+ * or the Ruby proc call raises, allocated buffers and logical types are
+ * released on the unwind path.
+ *
+ * Ruby exceptions raised by the user's proc are caught inline via
+ * rb_protect and reported to DuckDB as scalar errors; other Ruby
+ * exceptions (e.g. from vector_value_at) propagate and are cleaned up
+ * by rb_ensure.
+ */
+static VALUE update_process_rows(VALUE varg) {
+    struct update_callback_arg *arg = (struct update_callback_arg *)varg;
+    ruby_aggregate_state **states = (ruby_aggregate_state **)arg->states;
+    idx_t i, j;
+
+    arg->input_vectors = ALLOC_N(duckdb_vector, arg->col_count);
+    arg->input_types = ALLOC_N(duckdb_logical_type, arg->col_count);
+    arg->args = ALLOC_N(VALUE, arg->col_count + 1);
+
+    for (j = 0; j < arg->col_count; j++) {
+        arg->input_vectors[j] = duckdb_data_chunk_get_vector(arg->input, j);
+        arg->input_types[j] = duckdb_vector_get_column_type(arg->input_vectors[j]);
+    }
+
+    for (i = 0; i < arg->row_count; i++) {
+        ruby_aggregate_state *state = states[i];
+        struct update_one_arg one;
+        int exception_state;
+        VALUE ret;
+
+        arg->args[0] = state->ruby_state;
+        for (j = 0; j < arg->col_count; j++) {
+            arg->args[j + 1] = rbduckdb_vector_value_at(arg->input_vectors[j], arg->input_types[j], i);
+        }
+
+        one.update_proc = arg->ctx->update_proc;
+        one.argc = (int)(arg->col_count + 1);
+        one.argv = arg->args;
+
+        ret = rb_protect(call_update_proc, (VALUE)&one, &exception_state);
+        if (exception_state) {
+            report_ruby_error_to_duckdb(arg->info);
+            return Qnil;
+        }
+
+        state->ruby_state = ret;
+        rb_hash_aset(g_aggregate_state_registry, state_registry_key(state), ret);
+    }
+
+    return Qnil;
+}
+
+static VALUE update_cleanup_callback(VALUE varg) {
+    struct update_callback_arg *arg = (struct update_callback_arg *)varg;
+    idx_t j;
+
+    if (arg->input_types != NULL) {
+        for (j = 0; j < arg->col_count; j++) {
+            duckdb_destroy_logical_type(&arg->input_types[j]);
+        }
+        xfree(arg->input_types);
+    }
+    if (arg->args != NULL) {
+        xfree(arg->args);
+    }
+    if (arg->input_vectors != NULL) {
+        xfree(arg->input_vectors);
+    }
+
+    return Qnil;
+}
+
+static void execute_update_callback_protected(void *user_data) {
+    struct update_callback_arg *arg = (struct update_callback_arg *)user_data;
+    rb_ensure(update_process_rows, (VALUE)arg, update_cleanup_callback, (VALUE)arg);
+}
+
+static void update_callback(duckdb_function_info info,
+                            duckdb_data_chunk input,
+                            duckdb_aggregate_state *states) {
+    rubyDuckDBAggregateFunction *ctx;
+    struct update_callback_arg arg;
+
+    ctx = (rubyDuckDBAggregateFunction *)duckdb_aggregate_function_get_extra_info(info);
+    if (ctx == NULL || ctx->update_proc == Qnil) {
+        return;
+    }
+
+    arg.ctx = ctx;
+    arg.info = info;
+    arg.input = input;
+    arg.states = states;
+    arg.input_vectors = NULL;
+    arg.input_types = NULL;
+    arg.args = NULL;
+    arg.row_count = duckdb_data_chunk_get_size(input);
+    arg.col_count = duckdb_data_chunk_get_column_count(input);
+
+    rbduckdb_function_executor_dispatch(execute_update_callback_protected, &arg);
 }
 
 /* No-op combine: Phase 1.0 does not dispatch combine to Ruby. */
@@ -212,6 +345,36 @@ static void noop_combine_callback(duckdb_function_info info,
     (void)source;
     (void)target;
     (void)count;
+}
+
+/*
+ * Default combine for Phase 1.1: move source state into target state.
+ *
+ * DuckDB invokes combine even for single-partition aggregates: after update
+ * has accumulated values into a source state, DuckDB freshly initialises a
+ * target state and calls combine to merge source into target before finalize.
+ *
+ * Without a user-provided combine_proc we cannot perform an arbitrary merge,
+ * so this minimal implementation overwrites target->ruby_state with the
+ * source value. This is correct for the common single-group/single-thread
+ * path exercised by the tests; richer combine semantics will arrive together
+ * with a user-facing set_combine callback in a later phase.
+ */
+static void default_combine_callback(duckdb_function_info info,
+                                     duckdb_aggregate_state *source,
+                                     duckdb_aggregate_state *target,
+                                     idx_t count) {
+    ruby_aggregate_state **src = (ruby_aggregate_state **)source;
+    ruby_aggregate_state **tgt = (ruby_aggregate_state **)target;
+    idx_t i;
+    (void)info;
+
+    for (i = 0; i < count; i++) {
+        tgt[i]->ruby_state = src[i]->ruby_state;
+        rb_hash_aset(g_aggregate_state_registry,
+                     state_registry_key(tgt[i]),
+                     tgt[i]->ruby_state);
+    }
 }
 
 /* finalize callback dispatch argument */
@@ -301,8 +464,8 @@ static void maybe_set_functions(rubyDuckDBAggregateFunction *p) {
         p->aggregate_function,
         state_size_callback,
         state_init_callback,
-        noop_update_callback,
-        noop_combine_callback,
+        (p->update_proc != Qnil) ? update_callback : noop_update_callback,
+        (p->update_proc != Qnil) ? default_combine_callback : noop_combine_callback,
         finalize_callback);
 
     /* Ensure the global executor thread is running for multi-thread dispatch.
@@ -320,6 +483,22 @@ static VALUE rbduckdb_aggregate_function_set_init(VALUE self) {
 
     TypedData_Get_Struct(self, rubyDuckDBAggregateFunction, &aggregate_function_data_type, p);
     p->init_proc = rb_block_proc();
+
+    maybe_set_functions(p);
+
+    return self;
+}
+
+/* :nodoc: */
+static VALUE rbduckdb_aggregate_function_set_update(VALUE self) {
+    rubyDuckDBAggregateFunction *p;
+
+    if (!rb_block_given_p()) {
+        rb_raise(rb_eArgError, "block is required");
+    }
+
+    TypedData_Get_Struct(self, rubyDuckDBAggregateFunction, &aggregate_function_data_type, p);
+    p->update_proc = rb_block_proc();
 
     maybe_set_functions(p);
 
@@ -353,6 +532,7 @@ void rbduckdb_init_duckdb_aggregate_function(void) {
     rb_define_private_method(cDuckDBAggregateFunction, "_set_return_type", rbduckdb_aggregate_function__set_return_type, 1);
     rb_define_private_method(cDuckDBAggregateFunction, "_add_parameter", rbduckdb_aggregate_function_add_parameter, 1);
     rb_define_method(cDuckDBAggregateFunction, "set_init", rbduckdb_aggregate_function_set_init, 0);
+    rb_define_method(cDuckDBAggregateFunction, "set_update", rbduckdb_aggregate_function_set_update, 0);
     rb_define_method(cDuckDBAggregateFunction, "set_finalize", rbduckdb_aggregate_function_set_finalize, 0);
 
     g_aggregate_state_registry = rb_hash_new();

--- a/ext/duckdb/aggregate_function.h
+++ b/ext/duckdb/aggregate_function.h
@@ -4,6 +4,7 @@
 struct _rubyDuckDBAggregateFunction {
     duckdb_aggregate_function aggregate_function;
     VALUE init_proc;
+    VALUE update_proc;
     VALUE finalize_proc;
 };
 

--- a/ext/duckdb/aggregate_function.h
+++ b/ext/duckdb/aggregate_function.h
@@ -5,6 +5,7 @@ struct _rubyDuckDBAggregateFunction {
     duckdb_aggregate_function aggregate_function;
     VALUE init_proc;
     VALUE update_proc;
+    VALUE combine_proc;
     VALUE finalize_proc;
 };
 

--- a/ext/duckdb/function_vector.c
+++ b/ext/duckdb/function_vector.c
@@ -1,0 +1,212 @@
+#include "ruby-duckdb.h"
+
+void rbduckdb_vector_set_value_at(duckdb_vector vector, duckdb_logical_type element_type, idx_t index, VALUE value) {
+    duckdb_type type_id;
+    void* vector_data;
+    uint64_t *validity;
+
+    /* Handle NULL values */
+    if (value == Qnil) {
+        duckdb_vector_ensure_validity_writable(vector);
+        validity = duckdb_vector_get_validity(vector);
+        duckdb_validity_set_row_invalid(validity, index);
+        return;
+    }
+
+    type_id = duckdb_get_type_id(element_type);
+    vector_data = duckdb_vector_get_data(vector);
+
+    switch(type_id) {
+        case DUCKDB_TYPE_BOOLEAN:
+            ((bool *)vector_data)[index] = RTEST(value);
+            break;
+        case DUCKDB_TYPE_TINYINT:
+            ((int8_t *)vector_data)[index] = (int8_t)NUM2INT(value);
+            break;
+        case DUCKDB_TYPE_UTINYINT:
+            ((uint8_t *)vector_data)[index] = (uint8_t)NUM2UINT(value);
+            break;
+        case DUCKDB_TYPE_SMALLINT:
+            ((int16_t *)vector_data)[index] = (int16_t)NUM2INT(value);
+            break;
+        case DUCKDB_TYPE_USMALLINT:
+            ((uint16_t *)vector_data)[index] = (uint16_t)NUM2UINT(value);
+            break;
+        case DUCKDB_TYPE_INTEGER:
+            ((int32_t *)vector_data)[index] = NUM2INT(value);
+            break;
+        case DUCKDB_TYPE_UINTEGER:
+            ((uint32_t *)vector_data)[index] = (uint32_t)NUM2ULL(value);
+            break;
+        case DUCKDB_TYPE_BIGINT:
+            ((int64_t *)vector_data)[index] = NUM2LL(value);
+            break;
+        case DUCKDB_TYPE_UBIGINT:
+            ((uint64_t *)vector_data)[index] = NUM2ULL(value);
+            break;
+        case DUCKDB_TYPE_HUGEINT: {
+            duckdb_hugeint hugeint;
+            hugeint.lower = NUM2ULL(rb_funcall(mDuckDBConverter, rb_intern("_hugeint_lower"), 1, value));
+            hugeint.upper = NUM2LL(rb_funcall(mDuckDBConverter, rb_intern("_hugeint_upper"), 1, value));
+            ((duckdb_hugeint *)vector_data)[index] = hugeint;
+            break;
+        }
+        case DUCKDB_TYPE_UHUGEINT: {
+            duckdb_uhugeint uhugeint;
+            uhugeint.lower = NUM2ULL(rb_funcall(mDuckDBConverter, rb_intern("_hugeint_lower"), 1, value));
+            uhugeint.upper = NUM2ULL(rb_funcall(mDuckDBConverter, rb_intern("_hugeint_upper"), 1, value));
+            ((duckdb_uhugeint *)vector_data)[index] = uhugeint;
+            break;
+        }
+        case DUCKDB_TYPE_FLOAT:
+            ((float *)vector_data)[index] = (float)NUM2DBL(value);
+            break;
+        case DUCKDB_TYPE_DOUBLE:
+            ((double *)vector_data)[index] = NUM2DBL(value);
+            break;
+        case DUCKDB_TYPE_VARCHAR: {
+            VALUE str = rb_obj_as_string(value);
+            const char *str_ptr = StringValuePtr(str);
+            idx_t str_len = RSTRING_LEN(str);
+            duckdb_vector_assign_string_element_len(vector, index, str_ptr, str_len);
+            break;
+        }
+        case DUCKDB_TYPE_BLOB: {
+            VALUE str = rb_obj_as_string(value);
+            const char *str_ptr = StringValuePtr(str);
+            idx_t str_len = RSTRING_LEN(str);
+            duckdb_vector_assign_string_element_len(vector, index, str_ptr, str_len);
+            break;
+        }
+        case DUCKDB_TYPE_TIMESTAMP: {
+            duckdb_timestamp ts = rbduckdb_to_duckdb_timestamp_from_time_value(value);
+            ((duckdb_timestamp *)vector_data)[index] = ts;
+            break;
+        }
+        case DUCKDB_TYPE_TIMESTAMP_S: {
+            duckdb_timestamp ts = rbduckdb_to_duckdb_timestamp_from_time_value(value);
+            duckdb_timestamp_s ts_s;
+            ts_s.seconds = ts.micros / 1000000;
+            ((duckdb_timestamp_s *)vector_data)[index] = ts_s;
+            break;
+        }
+        case DUCKDB_TYPE_TIMESTAMP_MS: {
+            duckdb_timestamp ts = rbduckdb_to_duckdb_timestamp_from_time_value(value);
+            duckdb_timestamp_ms ts_ms;
+            ts_ms.millis = ts.micros / 1000;
+            ((duckdb_timestamp_ms *)vector_data)[index] = ts_ms;
+            break;
+        }
+        case DUCKDB_TYPE_TIMESTAMP_NS: {
+            duckdb_timestamp ts = rbduckdb_to_duckdb_timestamp_from_time_value(value);
+            duckdb_timestamp_ns ts_ns;
+            ts_ns.nanos = ts.micros * 1000;
+            ((duckdb_timestamp_ns *)vector_data)[index] = ts_ns;
+            break;
+        }
+        case DUCKDB_TYPE_TIMESTAMP_TZ: {
+            duckdb_timestamp ts = rbduckdb_to_duckdb_timestamp_from_time_value(value);
+            ((duckdb_timestamp *)vector_data)[index] = ts;
+            break;
+        }
+        case DUCKDB_TYPE_DATE: {
+            VALUE date_class = rb_const_get(rb_cObject, rb_intern("Date"));
+            if (!rb_obj_is_kind_of(value, date_class)) {
+                rb_raise(rb_eTypeError, "Expected Date object for DATE");
+            }
+
+            VALUE year = rb_funcall(value, rb_intern("year"), 0);
+            VALUE month = rb_funcall(value, rb_intern("month"), 0);
+            VALUE day = rb_funcall(value, rb_intern("day"), 0);
+
+            duckdb_date date = rbduckdb_to_duckdb_date_from_value(year, month, day);
+            ((duckdb_date *)vector_data)[index] = date;
+            break;
+        }
+        case DUCKDB_TYPE_TIME: {
+            if (!rb_obj_is_kind_of(value, rb_cTime)) {
+                rb_raise(rb_eTypeError, "Expected Time object for TIME");
+            }
+
+            VALUE hour = rb_funcall(value, rb_intern("hour"), 0);
+            VALUE min = rb_funcall(value, rb_intern("min"), 0);
+            VALUE sec = rb_funcall(value, rb_intern("sec"), 0);
+            VALUE usec = rb_funcall(value, rb_intern("usec"), 0);
+
+            duckdb_time time = rbduckdb_to_duckdb_time_from_value(hour, min, sec, usec);
+            ((duckdb_time *)vector_data)[index] = time;
+            break;
+        }
+        case DUCKDB_TYPE_TIME_TZ: {
+            if (!rb_obj_is_kind_of(value, rb_cTime)) {
+                rb_raise(rb_eTypeError, "Expected Time object for TIME_TZ");
+            }
+
+            VALUE hour = rb_funcall(value, rb_intern("hour"), 0);
+            VALUE min = rb_funcall(value, rb_intern("min"), 0);
+            VALUE sec = rb_funcall(value, rb_intern("sec"), 0);
+            VALUE usec = rb_funcall(value, rb_intern("usec"), 0);
+            VALUE utc_offset = rb_funcall(value, rb_intern("utc_offset"), 0);
+
+            duckdb_time t = rbduckdb_to_duckdb_time_from_value(hour, min, sec, usec);
+            int64_t micros = t.micros;
+            int32_t offset = NUM2INT(utc_offset);
+
+            duckdb_time_tz time_tz = duckdb_create_time_tz(micros, offset);
+            ((duckdb_time_tz *)vector_data)[index] = time_tz;
+            break;
+        }
+        case DUCKDB_TYPE_INTERVAL: {
+            VALUE months = rb_funcall(value, rb_intern("interval_months"), 0);
+            VALUE days   = rb_funcall(value, rb_intern("interval_days"), 0);
+            VALUE micros = rb_funcall(value, rb_intern("interval_micros"), 0);
+
+            duckdb_interval interval;
+            rbduckdb_to_duckdb_interval_from_value(&interval, months, days, micros);
+            ((duckdb_interval *)vector_data)[index] = interval;
+            break;
+        }
+        case DUCKDB_TYPE_UUID: {
+            VALUE result = rb_funcall(mDuckDBConverter, id__uuid_string_to_hugeint, 1, value);
+            VALUE rb_lower = rb_ary_entry(result, 0);
+            VALUE rb_upper = rb_ary_entry(result, 1);
+
+            duckdb_hugeint hugeint;
+            hugeint.lower = NUM2ULL(rb_lower);
+            hugeint.upper = NUM2LL(rb_upper);
+            ((duckdb_hugeint *)vector_data)[index] = hugeint;
+            break;
+        }
+        case DUCKDB_TYPE_DECIMAL: {
+            uint8_t scale = duckdb_decimal_scale(element_type);
+            duckdb_type internal_type = duckdb_decimal_internal_type(element_type);
+            VALUE int_val = rb_funcall(mDuckDBConverter, id__decimal_to_unscaled, 2, value, INT2NUM(scale));
+
+            switch (internal_type) {
+                case DUCKDB_TYPE_SMALLINT:
+                    ((int16_t *)vector_data)[index] = (int16_t)NUM2INT(int_val);
+                    break;
+                case DUCKDB_TYPE_INTEGER:
+                    ((int32_t *)vector_data)[index] = NUM2INT(int_val);
+                    break;
+                case DUCKDB_TYPE_BIGINT:
+                    ((int64_t *)vector_data)[index] = NUM2LL(int_val);
+                    break;
+                case DUCKDB_TYPE_HUGEINT: {
+                    duckdb_hugeint hugeint;
+                    hugeint.lower = NUM2ULL(rb_funcall(mDuckDBConverter, rb_intern("_hugeint_lower"), 1, int_val));
+                    hugeint.upper = NUM2LL(rb_funcall(mDuckDBConverter, rb_intern("_hugeint_upper"), 1, int_val));
+                    ((duckdb_hugeint *)vector_data)[index] = hugeint;
+                    break;
+                }
+                default:
+                    rb_raise(rb_eArgError, "Unsupported internal type for DECIMAL");
+                    break;
+            }
+            break;
+        }
+        default:
+            rb_raise(rb_eArgError, "Unsupported return type for function");
+            break;
+    }
+}

--- a/ext/duckdb/function_vector.h
+++ b/ext/duckdb/function_vector.h
@@ -1,0 +1,27 @@
+#ifndef RUBY_DUCKDB_FUNCTION_VECTOR_H
+#define RUBY_DUCKDB_FUNCTION_VECTOR_H
+
+/*
+ * Shared vector-write helper for UDF callbacks.
+ *
+ * Converts a Ruby VALUE to the appropriate DuckDB type and writes it
+ * into a result vector at the given index.  Used by both ScalarFunction
+ * and AggregateFunction finalize paths.
+ */
+
+/*
+ * Write `value` (a Ruby VALUE) into `vector` at position `index`.
+ *
+ * `element_type` is the logical type of the vector and determines
+ * which conversion is applied.  If `value` is Qnil the row is marked
+ * invalid (NULL).
+ *
+ * Raises rb_eArgError for unsupported types - callers that cannot
+ * tolerate longjmp should wrap the call in rb_protect.
+ */
+void rbduckdb_vector_set_value_at(duckdb_vector vector,
+                                  duckdb_logical_type element_type,
+                                  idx_t index,
+                                  VALUE value);
+
+#endif

--- a/ext/duckdb/ruby-duckdb.h
+++ b/ext/duckdb/ruby-duckdb.h
@@ -30,6 +30,7 @@
 #include "./instance_cache.h"
 #include "./value.h"
 #include "./function_executor.h"
+#include "./function_vector.h"
 #include "./scalar_function.h"
 #include "./scalar_function_set.h"
 #include "./aggregate_function.h"

--- a/ext/duckdb/scalar_function.c
+++ b/ext/duckdb/scalar_function.c
@@ -17,7 +17,7 @@ static VALUE rbduckdb_scalar_function_set_function(VALUE self);
 static VALUE rbduckdb_scalar_function__set_bind(VALUE self);
 static void scalar_function_callback(duckdb_function_info info, duckdb_data_chunk input, duckdb_vector output);
 static void scalar_function_bind_callback(duckdb_bind_info info);
-static void vector_set_value_at(duckdb_vector vector, duckdb_logical_type element_type, idx_t index, VALUE value);
+
 
 struct callback_arg {
     rubyDuckDBScalarFunction *ctx;
@@ -229,7 +229,7 @@ static VALUE process_no_param_rows(VALUE varg) {
     result = rb_funcall(arg->ctx->function_proc, rb_intern("call"), 0);
 
     for (i = 0; i < arg->row_count; i++) {
-        vector_set_value_at(arg->output, arg->output_type, i, result);
+        rbduckdb_vector_set_value_at(arg->output, arg->output_type, i, result);
     }
 
     return Qnil;
@@ -262,7 +262,7 @@ static VALUE process_rows(VALUE varg) {
         result = rb_funcallv(arg->ctx->function_proc, rb_intern("call"), arg->col_count, arg->args);
 
         /* Write result to output using helper function */
-        vector_set_value_at(arg->output, arg->output_type, i, result);
+        rbduckdb_vector_set_value_at(arg->output, arg->output_type, i, result);
     }
 
     return Qnil;
@@ -292,221 +292,6 @@ static VALUE cleanup_callback(VALUE varg) {
     }
 
     return Qnil;
-}
-
-static void vector_set_value_at(duckdb_vector vector, duckdb_logical_type element_type, idx_t index, VALUE value) {
-    duckdb_type type_id;
-    void* vector_data;
-    uint64_t *validity;
-
-    /* Handle NULL values */
-    if (value == Qnil) {
-        duckdb_vector_ensure_validity_writable(vector);
-        validity = duckdb_vector_get_validity(vector);
-        duckdb_validity_set_row_invalid(validity, index);
-        return;
-    }
-
-    type_id = duckdb_get_type_id(element_type);
-    vector_data = duckdb_vector_get_data(vector);
-
-    switch(type_id) {
-        case DUCKDB_TYPE_BOOLEAN:
-            ((bool *)vector_data)[index] = RTEST(value);
-            break;
-        case DUCKDB_TYPE_TINYINT:
-            ((int8_t *)vector_data)[index] = (int8_t)NUM2INT(value);
-            break;
-        case DUCKDB_TYPE_UTINYINT:
-            ((uint8_t *)vector_data)[index] = (uint8_t)NUM2UINT(value);
-            break;
-        case DUCKDB_TYPE_SMALLINT:
-            ((int16_t *)vector_data)[index] = (int16_t)NUM2INT(value);
-            break;
-        case DUCKDB_TYPE_USMALLINT:
-            ((uint16_t *)vector_data)[index] = (uint16_t)NUM2UINT(value);
-            break;
-        case DUCKDB_TYPE_INTEGER:
-            ((int32_t *)vector_data)[index] = NUM2INT(value);
-            break;
-        case DUCKDB_TYPE_UINTEGER:
-            ((uint32_t *)vector_data)[index] = (uint32_t)NUM2ULL(value);
-            break;
-        case DUCKDB_TYPE_BIGINT:
-            ((int64_t *)vector_data)[index] = NUM2LL(value);
-            break;
-        case DUCKDB_TYPE_UBIGINT:
-            ((uint64_t *)vector_data)[index] = NUM2ULL(value);
-            break;
-        case DUCKDB_TYPE_HUGEINT: {
-            duckdb_hugeint hugeint;
-            hugeint.lower = NUM2ULL(rb_funcall(mDuckDBConverter, rb_intern("_hugeint_lower"), 1, value));
-            hugeint.upper = NUM2LL(rb_funcall(mDuckDBConverter, rb_intern("_hugeint_upper"), 1, value));
-            ((duckdb_hugeint *)vector_data)[index] = hugeint;
-            break;
-        }
-        case DUCKDB_TYPE_UHUGEINT: {
-            duckdb_uhugeint uhugeint;
-            uhugeint.lower = NUM2ULL(rb_funcall(mDuckDBConverter, rb_intern("_hugeint_lower"), 1, value));
-            uhugeint.upper = NUM2ULL(rb_funcall(mDuckDBConverter, rb_intern("_hugeint_upper"), 1, value));
-            ((duckdb_uhugeint *)vector_data)[index] = uhugeint;
-            break;
-        }
-        case DUCKDB_TYPE_FLOAT:
-            ((float *)vector_data)[index] = (float)NUM2DBL(value);
-            break;
-        case DUCKDB_TYPE_DOUBLE:
-            ((double *)vector_data)[index] = NUM2DBL(value);
-            break;
-        case DUCKDB_TYPE_VARCHAR: {
-            /* VARCHAR requires special API, not direct array assignment */
-            VALUE str = rb_obj_as_string(value);
-            const char *str_ptr = StringValuePtr(str);
-            idx_t str_len = RSTRING_LEN(str);
-            duckdb_vector_assign_string_element_len(vector, index, str_ptr, str_len);
-            break;
-        }
-        case DUCKDB_TYPE_BLOB: {
-            /* BLOB uses same API as VARCHAR, but expects binary data */
-            VALUE str = rb_obj_as_string(value);
-            const char *str_ptr = StringValuePtr(str);
-            idx_t str_len = RSTRING_LEN(str);
-            duckdb_vector_assign_string_element_len(vector, index, str_ptr, str_len);
-            break;
-        }
-        case DUCKDB_TYPE_TIMESTAMP: {
-            duckdb_timestamp ts = rbduckdb_to_duckdb_timestamp_from_time_value(value);
-            ((duckdb_timestamp *)vector_data)[index] = ts;
-            break;
-        }
-        case DUCKDB_TYPE_TIMESTAMP_S: {
-            duckdb_timestamp ts = rbduckdb_to_duckdb_timestamp_from_time_value(value);
-            duckdb_timestamp_s ts_s;
-            ts_s.seconds = ts.micros / 1000000;
-            ((duckdb_timestamp_s *)vector_data)[index] = ts_s;
-            break;
-        }
-        case DUCKDB_TYPE_TIMESTAMP_MS: {
-            duckdb_timestamp ts = rbduckdb_to_duckdb_timestamp_from_time_value(value);
-            duckdb_timestamp_ms ts_ms;
-            ts_ms.millis = ts.micros / 1000;
-            ((duckdb_timestamp_ms *)vector_data)[index] = ts_ms;
-            break;
-        }
-        case DUCKDB_TYPE_TIMESTAMP_NS: {
-            duckdb_timestamp ts = rbduckdb_to_duckdb_timestamp_from_time_value(value);
-            duckdb_timestamp_ns ts_ns;
-            ts_ns.nanos = ts.micros * 1000;
-            ((duckdb_timestamp_ns *)vector_data)[index] = ts_ns;
-            break;
-        }
-        case DUCKDB_TYPE_TIMESTAMP_TZ: {
-            duckdb_timestamp ts = rbduckdb_to_duckdb_timestamp_from_time_value(value);
-            ((duckdb_timestamp *)vector_data)[index] = ts;
-            break;
-        }
-        case DUCKDB_TYPE_DATE: {
-            /* Convert Ruby Date to DuckDB date */
-            VALUE date_class = rb_const_get(rb_cObject, rb_intern("Date"));
-            if (!rb_obj_is_kind_of(value, date_class)) {
-                rb_raise(rb_eTypeError, "Expected Date object for DATE");
-            }
-
-            VALUE year = rb_funcall(value, rb_intern("year"), 0);
-            VALUE month = rb_funcall(value, rb_intern("month"), 0);
-            VALUE day = rb_funcall(value, rb_intern("day"), 0);
-
-            duckdb_date date = rbduckdb_to_duckdb_date_from_value(year, month, day);
-            ((duckdb_date *)vector_data)[index] = date;
-            break;
-        }
-        case DUCKDB_TYPE_TIME: {
-            /* Convert Ruby Time to DuckDB time (time-of-day only) */
-            if (!rb_obj_is_kind_of(value, rb_cTime)) {
-                rb_raise(rb_eTypeError, "Expected Time object for TIME");
-            }
-
-            VALUE hour = rb_funcall(value, rb_intern("hour"), 0);
-            VALUE min = rb_funcall(value, rb_intern("min"), 0);
-            VALUE sec = rb_funcall(value, rb_intern("sec"), 0);
-            VALUE usec = rb_funcall(value, rb_intern("usec"), 0);
-
-            duckdb_time time = rbduckdb_to_duckdb_time_from_value(hour, min, sec, usec);
-            ((duckdb_time *)vector_data)[index] = time;
-            break;
-        }
-        case DUCKDB_TYPE_TIME_TZ: {
-            if (!rb_obj_is_kind_of(value, rb_cTime)) {
-                rb_raise(rb_eTypeError, "Expected Time object for TIME_TZ");
-            }
-
-            VALUE hour = rb_funcall(value, rb_intern("hour"), 0);
-            VALUE min = rb_funcall(value, rb_intern("min"), 0);
-            VALUE sec = rb_funcall(value, rb_intern("sec"), 0);
-            VALUE usec = rb_funcall(value, rb_intern("usec"), 0);
-            VALUE utc_offset = rb_funcall(value, rb_intern("utc_offset"), 0);
-
-            duckdb_time t = rbduckdb_to_duckdb_time_from_value(hour, min, sec, usec);
-            int64_t micros = t.micros;
-            int32_t offset = NUM2INT(utc_offset);
-
-            duckdb_time_tz time_tz = duckdb_create_time_tz(micros, offset);
-            ((duckdb_time_tz *)vector_data)[index] = time_tz;
-            break;
-        }
-        case DUCKDB_TYPE_INTERVAL: {
-            VALUE months = rb_funcall(value, rb_intern("interval_months"), 0);
-            VALUE days   = rb_funcall(value, rb_intern("interval_days"), 0);
-            VALUE micros = rb_funcall(value, rb_intern("interval_micros"), 0);
-
-            duckdb_interval interval;
-            rbduckdb_to_duckdb_interval_from_value(&interval, months, days, micros);
-            ((duckdb_interval *)vector_data)[index] = interval;
-            break;
-        }
-        case DUCKDB_TYPE_UUID: {
-            VALUE result = rb_funcall(mDuckDBConverter, id__uuid_string_to_hugeint, 1, value);
-            VALUE rb_lower = rb_ary_entry(result, 0);
-            VALUE rb_upper = rb_ary_entry(result, 1);
-
-            duckdb_hugeint hugeint;
-            hugeint.lower = NUM2ULL(rb_lower);
-            hugeint.upper = NUM2LL(rb_upper);
-            ((duckdb_hugeint *)vector_data)[index] = hugeint;
-            break;
-        }
-        case DUCKDB_TYPE_DECIMAL: {
-            uint8_t scale = duckdb_decimal_scale(element_type);
-            duckdb_type internal_type = duckdb_decimal_internal_type(element_type);
-            VALUE int_val = rb_funcall(mDuckDBConverter, id__decimal_to_unscaled, 2, value, INT2NUM(scale));
-
-            switch (internal_type) {
-                case DUCKDB_TYPE_SMALLINT:
-                    ((int16_t *)vector_data)[index] = (int16_t)NUM2INT(int_val);
-                    break;
-                case DUCKDB_TYPE_INTEGER:
-                    ((int32_t *)vector_data)[index] = NUM2INT(int_val);
-                    break;
-                case DUCKDB_TYPE_BIGINT:
-                    ((int64_t *)vector_data)[index] = NUM2LL(int_val);
-                    break;
-                case DUCKDB_TYPE_HUGEINT: {
-                    duckdb_hugeint hugeint;
-                    hugeint.lower = NUM2ULL(rb_funcall(mDuckDBConverter, rb_intern("_hugeint_lower"), 1, int_val));
-                    hugeint.upper = NUM2LL(rb_funcall(mDuckDBConverter, rb_intern("_hugeint_upper"), 1, int_val));
-                    ((duckdb_hugeint *)vector_data)[index] = hugeint;
-                    break;
-                }
-                default:
-                    rb_raise(rb_eArgError, "Unsupported internal type for DECIMAL");
-                    break;
-            }
-            break;
-        }
-        default:
-            rb_raise(rb_eArgError, "Unsupported return type for scalar function");
-            break;
-    }
 }
 
 rubyDuckDBScalarFunction *get_struct_scalar_function(VALUE obj) {

--- a/test/duckdb_test/aggregate_function_test.rb
+++ b/test/duckdb_test/aggregate_function_test.rb
@@ -15,13 +15,9 @@ module DuckDBTest
     end
 
     def test_minimal_aggregate_returns_initial_state
-      af = DuckDB::AggregateFunction.new
-      af.name = 'my_agg'
-      af.return_type = DuckDB::LogicalType::BIGINT
-      af.add_parameter(DuckDB::LogicalType::BIGINT)
-      af.set_init     { 42 }
-      af.set_finalize { |state| state }
-
+      af = build_aggregate('my_agg',
+                           init: -> { 42 },
+                           finalize: ->(state) { state })
       @con.register_aggregate_function(af)
 
       result = @con.query('SELECT my_agg(i) FROM range(100) t(i)')
@@ -30,20 +26,85 @@ module DuckDBTest
     end
 
     def test_aggregate_update_sums_values
-      af = DuckDB::AggregateFunction.new
-      af.name = 'my_sum'
-      af.return_type = DuckDB::LogicalType::BIGINT
-      af.add_parameter(DuckDB::LogicalType::BIGINT)
-      af.set_init     { 0 }
-      af.set_update   { |state, value| state + value }
-      af.set_finalize { |state| state }
-
+      af = build_aggregate('my_sum',
+                           init: -> { 0 },
+                           update: ->(state, value) { state + value },
+                           finalize: ->(state) { state })
       @con.register_aggregate_function(af)
 
       result = @con.query('SELECT my_sum(i) FROM range(100) t(i)')
 
       # sum(0..99) == 4950
       assert_equal 4950, result.first.first
+    end
+
+    def test_aggregate_double_return_and_input
+      double_type = DuckDB::LogicalType::DOUBLE
+      af = build_aggregate('my_dsum',
+                           type: double_type,
+                           init: -> { 0.0 },
+                           update: ->(state, value) { state + value },
+                           combine: ->(s1, s2) { s1 + s2 },
+                           finalize: ->(state) { state })
+      @con.register_aggregate_function(af)
+
+      result = @con.query('SELECT my_dsum(i::DOUBLE) FROM range(10) t(i)')
+      # sum(0.0..9.0) == 45.0
+      assert_in_delta 45.0, result.first.first, 0.001
+    end
+
+    def test_aggregate_varchar_return_and_input
+      varchar_type = DuckDB::LogicalType::VARCHAR
+      af = build_aggregate('my_concat',
+                           type: varchar_type,
+                           init: -> { +'' },
+                           update: ->(state, value) { state + value },
+                           combine: ->(s1, s2) { s1 + s2 },
+                           finalize: ->(state) { state })
+      @con.register_aggregate_function(af)
+
+      result = @con.query("SELECT my_concat(x) FROM (VALUES ('a'), ('b'), ('c')) t(x)")
+
+      assert_equal 'abc', result.first.first
+    end
+
+    def test_aggregate_combine_merges_partial_states_in_parallel
+      af = build_aggregate('my_parallel_sum',
+                           init: -> { 0 },
+                           update: ->(state, value) { state + value },
+                           combine: ->(s1, s2) { s1 + s2 },
+                           finalize: ->(state) { state })
+      @con.register_aggregate_function(af)
+      force_parallel_execution(@con)
+
+      result = @con.query('SELECT my_parallel_sum(i) FROM range(100000) t(i)')
+      # sum(0..99_999) == 4_999_950_000
+      assert_equal 4_999_950_000, result.first.first
+    end
+
+    private
+
+    # Force DuckDB to actually parallelise aggregation so the combine callback
+    # receives more than one partial state to merge.
+    def force_parallel_execution(con)
+      con.query('PRAGMA threads=4')
+      con.query('PRAGMA verify_parallelism')
+    end
+
+    def build_aggregate(name, type: DuckDB::LogicalType::BIGINT, **callbacks)
+      af = DuckDB::AggregateFunction.new
+      af.name = name
+      af.return_type = type
+      af.add_parameter(type)
+      set_callbacks(af, callbacks)
+      af
+    end
+
+    def set_callbacks(func, callbacks)
+      func.set_init(&callbacks[:init])
+      func.set_update(&callbacks[:update]) if callbacks[:update]
+      func.set_combine(&callbacks[:combine]) if callbacks[:combine]
+      func.set_finalize(&callbacks[:finalize])
     end
   end
 end

--- a/test/duckdb_test/aggregate_function_test.rb
+++ b/test/duckdb_test/aggregate_function_test.rb
@@ -28,5 +28,22 @@ module DuckDBTest
 
       assert_equal 42, result.first.first
     end
+
+    def test_aggregate_update_sums_values
+      af = DuckDB::AggregateFunction.new
+      af.name = 'my_sum'
+      af.return_type = DuckDB::LogicalType::BIGINT
+      af.add_parameter(DuckDB::LogicalType::BIGINT)
+      af.set_init     { 0 }
+      af.set_update   { |state, value| state + value }
+      af.set_finalize { |state| state }
+
+      @con.register_aggregate_function(af)
+
+      result = @con.query('SELECT my_sum(i) FROM range(100) t(i)')
+
+      # sum(0..99) == 4950
+      assert_equal 4950, result.first.first
+    end
   end
 end


### PR DESCRIPTION
## Summary

Adds a real `update` callback to `DuckDB::AggregateFunction`, replacing the Phase 1.0 no-op stub. Introduces `default_combine_callback` to handle DuckDB's mandatory combine step when no user `set_combine` is provided.

## Changes

- `aggregate_function.h`: add `update_proc` field to struct
- `aggregate_function.c`:
  - `update_callback` / `execute_update_callback_protected` / `update_process_rows`: per-chunk dispatch to the user's Ruby block; `rb_ensure` wraps the row loop so `ALLOC_N` buffers and `duckdb_logical_type` handles are always released on exception unwind
  - `default_combine_callback`: moves source `ruby_state` into target for the single-group/single-thread path
  - `maybe_set_functions`: selects `update_callback` vs noop and `default_combine_callback` vs noop based on `update_proc` presence
- Test: `test_aggregate_update_sums_values` — `sum(0..99) == 4950`

## Example

```ruby
af = DuckDB::AggregateFunction.new
af.name = 'my_sum'
af.return_type = DuckDB::LogicalType::BIGINT
af.add_parameter(DuckDB::LogicalType::BIGINT)
af.set_init     { 0 }
af.set_update   { |state, value| state + value }
af.set_finalize { |state| state }
conn.register_aggregate_function(af)
conn.query('SELECT my_sum(i) FROM range(100) t(i)').first.first  # => 4950
```

## Known limitation (deferred to Phase 1.2)

`default_combine_callback` does not remove the source state from `g_aggregate_state_registry`, leaving one leaked entry per group per combine round. Fixed in Phase 1.2 when the user-facing `set_combine` is added with `rb_hash_delete`.

## Depends on

- #1258 (Phase 1.0 — minimal AggregateFunction)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Register custom per-row update and partial-state combine callbacks via new set_update and set_combine APIs to build richer Ruby aggregates.
  * Result writing now honors the aggregate's runtime return type for all supported types.

* **Bug Fixes**
  * Result value writes and NULL handling improved across numeric, string, timestamp, UUID, interval and decimal types.
  * Combine behavior for partial states fixed for parallel execution.

* **Tests**
  * New tests for numeric, string, typed returns and parallel combine/merge behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->