### PR TITLE
AggregateFunction Phase 2: destructor, special handling, error cleanup

### DIFF
--- a/ext/duckdb/aggregate_function.c
+++ b/ext/duckdb/aggregate_function.c
@@ -567,6 +567,11 @@ static void execute_finalize_callback_protected(void *user_data) {
     }
 
 cleanup:
+    /* Clean up registry entries for the current (failed) state and any
+       remaining unprocessed states so we don't leak GC-registered objects. */
+    for (; i < arg->count; i++) {
+        state_registry_remove(states[i]);
+    }
     duckdb_destroy_logical_type(&result_type);
 }
 

--- a/ext/duckdb/aggregate_function.c
+++ b/ext/duckdb/aggregate_function.c
@@ -40,7 +40,7 @@ static VALUE rbduckdb_aggregate_function_set_init(VALUE self);
 static VALUE rbduckdb_aggregate_function_set_update(VALUE self);
 static VALUE rbduckdb_aggregate_function_set_combine(VALUE self);
 static VALUE rbduckdb_aggregate_function_set_finalize(VALUE self);
-static VALUE rbduckdb_aggregate_function_set_special_handling(VALUE self);
+static VALUE rbduckdb_aggregate_function__set_special_handling(VALUE self);
 
 static const rb_data_type_t aggregate_function_data_type = {
     "DuckDB/AggregateFunction",
@@ -716,7 +716,8 @@ static VALUE rbduckdb_aggregate_function_set_finalize(VALUE self) {
     return self;
 }
 
-static VALUE rbduckdb_aggregate_function_set_special_handling(VALUE self) {
+/* :nodoc: */
+static VALUE rbduckdb_aggregate_function__set_special_handling(VALUE self) {
     rubyDuckDBAggregateFunction *p;
     TypedData_Get_Struct(self, rubyDuckDBAggregateFunction, &aggregate_function_data_type, p);
     duckdb_aggregate_function_set_special_handling(p->aggregate_function);
@@ -743,7 +744,7 @@ void rbduckdb_init_duckdb_aggregate_function(void) {
     rb_define_method(cDuckDBAggregateFunction, "set_update", rbduckdb_aggregate_function_set_update, 0);
     rb_define_method(cDuckDBAggregateFunction, "set_combine", rbduckdb_aggregate_function_set_combine, 0);
     rb_define_method(cDuckDBAggregateFunction, "set_finalize", rbduckdb_aggregate_function_set_finalize, 0);
-    rb_define_method(cDuckDBAggregateFunction, "set_special_handling", rbduckdb_aggregate_function_set_special_handling, 0);
+    rb_define_private_method(cDuckDBAggregateFunction, "_set_special_handling", rbduckdb_aggregate_function__set_special_handling, 0);
     rb_define_singleton_method(cDuckDBAggregateFunction, "_state_registry_size",
                                aggregate_function_state_registry_size, 0);
 

--- a/ext/duckdb/aggregate_function.c
+++ b/ext/duckdb/aggregate_function.c
@@ -313,6 +313,16 @@ static VALUE update_process_rows(VALUE varg) {
         ret = rb_protect(call_update_proc, (VALUE)&one, &exception_state);
         if (exception_state) {
             report_ruby_error_to_duckdb(arg->info);
+            /*
+             * DuckDB does not call the destroy callback on the update error
+             * path, so we must remove reachable states from the registry
+             * ourselves to avoid leaking Ruby VALUEs.  Iterate all rows in
+             * the chunk — multiple rows may share the same state (same
+             * group), but state_registry_remove is idempotent.
+             */
+            for (j = 0; j < arg->row_count; j++) {
+                state_registry_remove(states[j]);
+            }
             return Qnil;
         }
 

--- a/ext/duckdb/aggregate_function.c
+++ b/ext/duckdb/aggregate_function.c
@@ -4,15 +4,26 @@ VALUE cDuckDBAggregateFunction;
 
 /*
  * Global Ruby Hash used to keep aggregate state Ruby VALUEs alive during
- * aggregation. Keys identify the state buffer pointer (see state_registry_key),
- * values are the Ruby VALUE returned from the user's init_proc and later passed
- * to finalize_proc.
+ * aggregation. Keys are monotonic state IDs (see state_registry_key) that
+ * survive DuckDB's internal memcpy of state buffers. Values are the Ruby
+ * VALUE returned from the user's init_proc and later passed to
+ * finalize_proc.
  *
  * Protected from GC via rb_gc_register_mark_object on init.
  */
 static VALUE g_aggregate_state_registry;
 
+/*
+ * Monotonic counter for aggregate state IDs.  Each state_init_callback
+ * assigns the next ID; because DuckDB memcpy's state buffers internally
+ * (e.g. from a temporary allocation into the hash-table row layout), the
+ * embedded ID is the only reliable way to match a state across init /
+ * combine / finalize / destroy calls.
+ */
+static unsigned long long g_next_state_id = 0;
+
 typedef struct {
+    unsigned long long state_id;
     VALUE ruby_state;
 } ruby_aggregate_state;
 
@@ -127,11 +138,27 @@ static VALUE rbduckdb_aggregate_function_add_parameter(VALUE self, VALUE logical
 }
 
 /*
- * Build a Ruby Hash key that uniquely identifies a state buffer pointer.
+ * Build a Ruby Hash key from the state's embedded ID.
  * Used for the g_aggregate_state_registry GC root.
  */
 static inline VALUE state_registry_key(ruby_aggregate_state *state) {
-    return ULL2NUM((unsigned long long)(uintptr_t)state);
+    return ULL2NUM(state->state_id);
+}
+
+/*
+ * Store (or update) a Ruby VALUE in the global state registry so that
+ * it stays reachable by the GC for the lifetime of the aggregate state.
+ */
+static inline void state_registry_store(ruby_aggregate_state *state, VALUE value) {
+    rb_hash_aset(g_aggregate_state_registry, state_registry_key(state), value);
+}
+
+/*
+ * Remove a state entry from the registry.  Safe to call even if the
+ * entry was already removed (rb_hash_delete is a no-op for missing keys).
+ */
+static inline void state_registry_remove(ruby_aggregate_state *state) {
+    rb_hash_delete(g_aggregate_state_registry, state_registry_key(state));
 }
 
 /*
@@ -174,6 +201,7 @@ static void execute_init_callback_protected(void *user_data) {
 
     /* Initialise buffer to a safe value before calling Ruby. */
     state->ruby_state = Qnil;
+    state->state_id = ++g_next_state_id;
 
     result = rb_protect(call_init_proc, (VALUE)arg, &exception_state);
     if (exception_state) {
@@ -182,7 +210,7 @@ static void execute_init_callback_protected(void *user_data) {
     }
 
     state->ruby_state = result;
-    rb_hash_aset(g_aggregate_state_registry, state_registry_key(state), result);
+    state_registry_store(state, result);
 }
 
 static void state_init_callback(duckdb_function_info info, duckdb_aggregate_state state_p) {
@@ -196,6 +224,7 @@ static void state_init_callback(duckdb_function_info info, duckdb_aggregate_stat
          * buffer anyway to keep the Ruby state slot well-defined. */
         ruby_aggregate_state *state = (ruby_aggregate_state *)state_p;
         state->ruby_state = Qnil;
+        state->state_id = 0;
         return;
     }
 
@@ -287,7 +316,7 @@ static VALUE update_process_rows(VALUE varg) {
         }
 
         state->ruby_state = ret;
-        rb_hash_aset(g_aggregate_state_registry, state_registry_key(state), ret);
+        state_registry_store(state, ret);
     }
 
     return Qnil;
@@ -385,8 +414,9 @@ static void default_combine_callback(duckdb_function_info info,
          * from this context is unsafe and causes a SIGSEGV on Windows.
          *
          * The copied VALUE is already GC-protected via the source state's
-         * existing registry entry.  That entry leaks until the destructor
-         * callback is wired up in Phase 2.
+         * existing registry entry — which shares the same state_id (because
+         * DuckDB memcpy'd the buffer).  The destructor callback will clean
+         * up that entry when DuckDB frees the source state.
          */
     }
 }
@@ -436,13 +466,11 @@ static void execute_combine_callback_protected(void *user_data) {
         }
 
         tgt[i]->ruby_state = ret;
-        rb_hash_aset(g_aggregate_state_registry,
-                     state_registry_key(tgt[i]), ret);
+        state_registry_store(tgt[i], ret);
 
         /* source state is consumed by combine; release its registry entry
          * so the Ruby VALUE can be GC'd. */
-        rb_hash_delete(g_aggregate_state_registry,
-                       state_registry_key(src[i]));
+        state_registry_remove(src[i]);
     }
 }
 
@@ -534,7 +562,7 @@ static void execute_finalize_callback_protected(void *user_data) {
         }
 
         /* Release Ruby state from the GC registry. */
-        rb_hash_delete(g_aggregate_state_registry, state_registry_key(state));
+        state_registry_remove(state);
     }
 
 cleanup:
@@ -564,6 +592,41 @@ static void finalize_callback(duckdb_function_info info,
     rbduckdb_function_executor_dispatch(execute_finalize_callback_protected, &arg);
 }
 
+/* destroy_callback dispatch argument */
+struct destroy_callback_arg {
+    duckdb_aggregate_state *states;
+    idx_t count;
+};
+
+static void execute_destroy_callback(void *data) {
+    struct destroy_callback_arg *arg = (struct destroy_callback_arg *)data;
+    ruby_aggregate_state **s = (ruby_aggregate_state **)arg->states;
+    idx_t i;
+    for (i = 0; i < arg->count; i++) {
+        state_registry_remove(s[i]);
+    }
+}
+
+/*
+ * Called by DuckDB when it frees aggregate state buffers.  On success paths
+ * this runs after finalize has already removed the final-state entries, so
+ * the delete is a harmless no-op for those; for intermediate states created
+ * by DuckDB's internal memcpy, this is the only cleanup path.
+ *
+ * Dispatches through the executor thread so that rb_hash_delete is called
+ * with the GVL held.
+ *
+ * The executor thread is guaranteed to be running because
+ * maybe_set_functions() calls rbduckdb_function_executor_ensure_started()
+ * before registering this destructor.
+ */
+static void destroy_callback(duckdb_aggregate_state *states, idx_t count) {
+    struct destroy_callback_arg arg;
+    arg.states = states;
+    arg.count = count;
+    rbduckdb_function_executor_dispatch(execute_destroy_callback, &arg);
+}
+
 /*
  * Wire up all 5 DuckDB aggregate callbacks on the underlying aggregate_function.
  * Called once both init_proc and finalize_proc have been supplied.
@@ -581,6 +644,7 @@ static void maybe_set_functions(rubyDuckDBAggregateFunction *p) {
         (p->combine_proc != Qnil) ? combine_callback :
             ((p->update_proc != Qnil) ? default_combine_callback : noop_combine_callback),
         finalize_callback);
+    duckdb_aggregate_function_set_destructor(p->aggregate_function, destroy_callback);
 
     /* Ensure the global executor thread is running for multi-thread dispatch.
      * Deferred until callbacks are actually wired to DuckDB. */
@@ -651,6 +715,12 @@ static VALUE rbduckdb_aggregate_function_set_finalize(VALUE self) {
     return self;
 }
 
+/* Returns the number of Ruby states currently tracked in the registry. */
+static VALUE aggregate_function_state_registry_size(VALUE klass) {
+    (void)klass;
+    return LONG2NUM((long)RHASH_SIZE(g_aggregate_state_registry));
+}
+
 void rbduckdb_init_duckdb_aggregate_function(void) {
 #if 0
     VALUE mDuckDB = rb_define_module("DuckDB");
@@ -665,6 +735,8 @@ void rbduckdb_init_duckdb_aggregate_function(void) {
     rb_define_method(cDuckDBAggregateFunction, "set_update", rbduckdb_aggregate_function_set_update, 0);
     rb_define_method(cDuckDBAggregateFunction, "set_combine", rbduckdb_aggregate_function_set_combine, 0);
     rb_define_method(cDuckDBAggregateFunction, "set_finalize", rbduckdb_aggregate_function_set_finalize, 0);
+    rb_define_singleton_method(cDuckDBAggregateFunction, "_state_registry_size",
+                               aggregate_function_state_registry_size, 0);
 
     g_aggregate_state_registry = rb_hash_new();
     rb_gc_register_mark_object(g_aggregate_state_registry);

--- a/ext/duckdb/aggregate_function.c
+++ b/ext/duckdb/aggregate_function.c
@@ -40,6 +40,7 @@ static VALUE rbduckdb_aggregate_function_set_init(VALUE self);
 static VALUE rbduckdb_aggregate_function_set_update(VALUE self);
 static VALUE rbduckdb_aggregate_function_set_combine(VALUE self);
 static VALUE rbduckdb_aggregate_function_set_finalize(VALUE self);
+static VALUE rbduckdb_aggregate_function_set_special_handling(VALUE self);
 
 static const rb_data_type_t aggregate_function_data_type = {
     "DuckDB/AggregateFunction",
@@ -715,6 +716,13 @@ static VALUE rbduckdb_aggregate_function_set_finalize(VALUE self) {
     return self;
 }
 
+static VALUE rbduckdb_aggregate_function_set_special_handling(VALUE self) {
+    rubyDuckDBAggregateFunction *p;
+    TypedData_Get_Struct(self, rubyDuckDBAggregateFunction, &aggregate_function_data_type, p);
+    duckdb_aggregate_function_set_special_handling(p->aggregate_function);
+    return self;
+}
+
 /* Returns the number of Ruby states currently tracked in the registry. */
 static VALUE aggregate_function_state_registry_size(VALUE klass) {
     (void)klass;
@@ -735,6 +743,7 @@ void rbduckdb_init_duckdb_aggregate_function(void) {
     rb_define_method(cDuckDBAggregateFunction, "set_update", rbduckdb_aggregate_function_set_update, 0);
     rb_define_method(cDuckDBAggregateFunction, "set_combine", rbduckdb_aggregate_function_set_combine, 0);
     rb_define_method(cDuckDBAggregateFunction, "set_finalize", rbduckdb_aggregate_function_set_finalize, 0);
+    rb_define_method(cDuckDBAggregateFunction, "set_special_handling", rbduckdb_aggregate_function_set_special_handling, 0);
     rb_define_singleton_method(cDuckDBAggregateFunction, "_state_registry_size",
                                aggregate_function_state_registry_size, 0);
 

--- a/lib/duckdb/aggregate_function.rb
+++ b/lib/duckdb/aggregate_function.rb
@@ -21,5 +21,19 @@ module DuckDB
     def add_parameter(logical_type)
       _add_parameter(logical_type)
     end
+
+    # Sets special NULL handling for the aggregate function.
+    # By default DuckDB skips rows with NULL input values.  Calling this
+    # method disables that behaviour so the update callback is invoked even
+    # when inputs are NULL, receiving +nil+ for each NULL argument.  This
+    # lets the function implement its own NULL semantics (e.g. counting
+    # NULLs).
+    #
+    # Wraps +duckdb_aggregate_function_set_special_handling+.
+    #
+    # @return [DuckDB::AggregateFunction] self
+    def set_special_handling
+      _set_special_handling
+    end
   end
 end

--- a/test/duckdb_test/aggregate_function_test.rb
+++ b/test/duckdb_test/aggregate_function_test.rb
@@ -104,6 +104,26 @@ module DuckDBTest
                    'state registry must not leak after a finalize callback error'
     end
 
+    def test_aggregate_update_error_surfaces_and_leaks_one_registry_entry
+      # When the update block raises, the error is surfaced as DuckDB::Error.
+      # However, DuckDB does NOT call the destroy callback on the update error
+      # path, so the init'd state's registry entry leaks.  This is a known
+      # DuckDB limitation — we document it here rather than assert zero delta.
+      baseline = DuckDB::AggregateFunction._state_registry_size
+      update_proc = lambda { |state, value|
+        raise 'boom in update' if value == 5
+
+        state + value
+      }
+      register_aggregate('err_update', init: -> { 0 }, update: update_proc, finalize: ->(state) { state })
+
+      error = assert_raises(DuckDB::Error) { @con.query('SELECT err_update(i) FROM range(10) t(i)') }
+
+      assert_match(/boom in update/, error.message)
+      assert_equal 1, DuckDB::AggregateFunction._state_registry_size - baseline,
+                   'DuckDB does not call destroy after update error — 1 entry leaks'
+    end
+
     def test_aggregate_combine_merges_partial_states_in_parallel
       register_aggregate('my_parallel_sum',
                          init: -> { 0 },

--- a/test/duckdb_test/aggregate_function_test.rb
+++ b/test/duckdb_test/aggregate_function_test.rb
@@ -104,11 +104,10 @@ module DuckDBTest
                    'state registry must not leak after a finalize callback error'
     end
 
-    def test_aggregate_update_error_surfaces_and_leaks_one_registry_entry
+    def test_aggregate_update_error_surfaces_without_registry_leak
       # When the update block raises, the error is surfaced as DuckDB::Error.
-      # However, DuckDB does NOT call the destroy callback on the update error
-      # path, so the init'd state's registry entry leaks.  This is a known
-      # DuckDB limitation — we document it here rather than assert zero delta.
+      # DuckDB does NOT call the destroy callback on the update error path,
+      # so we clean up reachable states ourselves in the update error handler.
       baseline = DuckDB::AggregateFunction._state_registry_size
       update_proc = lambda { |state, value|
         raise 'boom in update' if value == 5
@@ -120,8 +119,8 @@ module DuckDBTest
       error = assert_raises(DuckDB::Error) { @con.query('SELECT err_update(i) FROM range(10) t(i)') }
 
       assert_match(/boom in update/, error.message)
-      assert_equal 1, DuckDB::AggregateFunction._state_registry_size - baseline,
-                   'DuckDB does not call destroy after update error — 1 entry leaks'
+      assert_equal baseline, DuckDB::AggregateFunction._state_registry_size,
+                   'state registry must not leak after an update callback error'
     end
 
     def test_aggregate_combine_merges_partial_states_in_parallel

--- a/test/duckdb_test/aggregate_function_test.rb
+++ b/test/duckdb_test/aggregate_function_test.rb
@@ -68,6 +68,38 @@ module DuckDBTest
       assert_equal 'abc', result.first.first
     end
 
+    def test_aggregate_destructor_cleans_up_states_after_error
+      # Register an aggregate whose update block deliberately raises for a
+      # specific input value so the query fails before finalize is called.
+      af = build_aggregate('error_sum',
+                           init: -> { 0 },
+                           update: ->(state, value) {
+                             raise 'deliberate error' if value == 50
+                             state + value
+                           },
+                           finalize: ->(state) { state })
+      @con.register_aggregate_function(af)
+
+      # The query must fail — the update block raises for input 50.
+      assert_raises(DuckDB::Error) do
+        @con.query('SELECT error_sum(i) FROM range(100) t(i)')
+      end
+
+      # Apply GC pressure.  Without a destructor registered via
+      # duckdb_aggregate_function_set_destructor the g_aggregate_state_registry
+      # still holds entries for every state DuckDB freed without calling
+      # finalize — those entries will never be removed.
+      GC.start
+      GC.compact if GC.respond_to?(:compact)
+      GC.start
+
+      # With the destructor wired the registry must be empty now.
+      # _state_registry_size is a C-level helper exposed specifically to make
+      # this invariant observable from Ruby tests.
+      assert_equal 0, DuckDB::AggregateFunction._state_registry_size,
+                   'state registry must be empty after all aggregate states are destroyed'
+    end
+
     def test_aggregate_combine_merges_partial_states_in_parallel
       af = build_aggregate('my_parallel_sum',
                            init: -> { 0 },

--- a/test/duckdb_test/aggregate_function_test.rb
+++ b/test/duckdb_test/aggregate_function_test.rb
@@ -15,10 +15,9 @@ module DuckDBTest
     end
 
     def test_minimal_aggregate_returns_initial_state
-      af = build_aggregate('my_agg',
-                           init: -> { 42 },
-                           finalize: ->(state) { state })
-      @con.register_aggregate_function(af)
+      register_aggregate('my_agg',
+                         init: -> { 42 },
+                         finalize: ->(state) { state })
 
       result = @con.query('SELECT my_agg(i) FROM range(100) t(i)')
 
@@ -26,11 +25,10 @@ module DuckDBTest
     end
 
     def test_aggregate_update_sums_values
-      af = build_aggregate('my_sum',
-                           init: -> { 0 },
-                           update: ->(state, value) { state + value },
-                           finalize: ->(state) { state })
-      @con.register_aggregate_function(af)
+      register_aggregate('my_sum',
+                         init: -> { 0 },
+                         update: ->(state, value) { state + value },
+                         finalize: ->(state) { state })
 
       result = @con.query('SELECT my_sum(i) FROM range(100) t(i)')
 
@@ -40,13 +38,12 @@ module DuckDBTest
 
     def test_aggregate_double_return_and_input
       double_type = DuckDB::LogicalType::DOUBLE
-      af = build_aggregate('my_dsum',
-                           type: double_type,
-                           init: -> { 0.0 },
-                           update: ->(state, value) { state + value },
-                           combine: ->(s1, s2) { s1 + s2 },
-                           finalize: ->(state) { state })
-      @con.register_aggregate_function(af)
+      register_aggregate('my_dsum',
+                         type: double_type,
+                         init: -> { 0.0 },
+                         update: ->(state, value) { state + value },
+                         combine: ->(s1, s2) { s1 + s2 },
+                         finalize: ->(state) { state })
 
       result = @con.query('SELECT my_dsum(i::DOUBLE) FROM range(10) t(i)')
       # sum(0.0..9.0) == 45.0
@@ -55,13 +52,12 @@ module DuckDBTest
 
     def test_aggregate_varchar_return_and_input
       varchar_type = DuckDB::LogicalType::VARCHAR
-      af = build_aggregate('my_concat',
-                           type: varchar_type,
-                           init: -> { +'' },
-                           update: ->(state, value) { state + value },
-                           combine: ->(s1, s2) { s1 + s2 },
-                           finalize: ->(state) { state })
-      @con.register_aggregate_function(af)
+      register_aggregate('my_concat',
+                         type: varchar_type,
+                         init: -> { +'' },
+                         update: ->(state, value) { state + value },
+                         combine: ->(s1, s2) { s1 + s2 },
+                         finalize: ->(state) { state })
 
       result = @con.query("SELECT my_concat(x) FROM (VALUES ('a'), ('b'), ('c')) t(x)")
 
@@ -74,11 +70,10 @@ module DuckDBTest
       baseline = DuckDB::AggregateFunction._state_registry_size
 
       # Register and run a normal aggregate query that succeeds.
-      af = build_aggregate('cleanup_sum',
-                           init: -> { 0 },
-                           update: ->(state, value) { state + value },
-                           finalize: ->(state) { state })
-      @con.register_aggregate_function(af)
+      register_aggregate('cleanup_sum',
+                         init: -> { 0 },
+                         update: ->(state, value) { state + value },
+                         finalize: ->(state) { state })
 
       result = @con.query('SELECT cleanup_sum(i) FROM range(100) t(i)')
 
@@ -96,11 +91,10 @@ module DuckDBTest
     def test_aggregate_state_cleanup_after_finalize_error
       baseline = DuckDB::AggregateFunction._state_registry_size
 
-      af = build_aggregate('err_finalize',
-                           init: -> { 0 },
-                           update: ->(state, value) { state + value },
-                           finalize: ->(_state) { raise 'finalize boom' })
-      @con.register_aggregate_function(af)
+      register_aggregate('err_finalize',
+                         init: -> { 0 },
+                         update: ->(state, value) { state + value },
+                         finalize: ->(_state) { raise 'finalize boom' })
 
       assert_raises(DuckDB::Error) do
         @con.query('SELECT err_finalize(i) FROM range(10) t(i)')
@@ -111,12 +105,11 @@ module DuckDBTest
     end
 
     def test_aggregate_combine_merges_partial_states_in_parallel
-      af = build_aggregate('my_parallel_sum',
-                           init: -> { 0 },
-                           update: ->(state, value) { state + value },
-                           combine: ->(s1, s2) { s1 + s2 },
-                           finalize: ->(state) { state })
-      @con.register_aggregate_function(af)
+      register_aggregate('my_parallel_sum',
+                         init: -> { 0 },
+                         update: ->(state, value) { state + value },
+                         combine: ->(s1, s2) { s1 + s2 },
+                         finalize: ->(state) { state })
       force_parallel_execution(@con)
 
       result = @con.query('SELECT my_parallel_sum(i) FROM range(100000) t(i)')
@@ -159,6 +152,11 @@ module DuckDBTest
       af.add_parameter(type)
       set_callbacks(af, callbacks)
       af
+    end
+
+    def register_aggregate(name, **)
+      af = build_aggregate(name, **)
+      @con.register_aggregate_function(af)
     end
 
     def set_callbacks(func, callbacks)

--- a/test/duckdb_test/aggregate_function_test.rb
+++ b/test/duckdb_test/aggregate_function_test.rb
@@ -93,6 +93,23 @@ module DuckDBTest
                    'state registry must not grow after a successful aggregate query'
     end
 
+    def test_aggregate_state_cleanup_after_finalize_error
+      baseline = DuckDB::AggregateFunction._state_registry_size
+
+      af = build_aggregate('err_finalize',
+                           init: -> { 0 },
+                           update: ->(state, value) { state + value },
+                           finalize: ->(_state) { raise 'finalize boom' })
+      @con.register_aggregate_function(af)
+
+      assert_raises(DuckDB::Error) do
+        @con.query('SELECT err_finalize(i) FROM range(10) t(i)')
+      end
+
+      assert_equal baseline, DuckDB::AggregateFunction._state_registry_size,
+                   'state registry must not leak after a finalize callback error'
+    end
+
     def test_aggregate_combine_merges_partial_states_in_parallel
       af = build_aggregate('my_parallel_sum',
                            init: -> { 0 },

--- a/test/duckdb_test/aggregate_function_test.rb
+++ b/test/duckdb_test/aggregate_function_test.rb
@@ -68,36 +68,29 @@ module DuckDBTest
       assert_equal 'abc', result.first.first
     end
 
-    def test_aggregate_destructor_cleans_up_states_after_error
-      # Register an aggregate whose update block deliberately raises for a
-      # specific input value so the query fails before finalize is called.
-      af = build_aggregate('error_sum',
+    def test_aggregate_destructor_cleans_up_states_after_successful_query
+      # Record baseline — previous tests may have left entries in the
+      # global registry (the registry is process-global).
+      baseline = DuckDB::AggregateFunction._state_registry_size
+
+      # Register and run a normal aggregate query that succeeds.
+      af = build_aggregate('cleanup_sum',
                            init: -> { 0 },
-                           update: ->(state, value) {
-                             raise 'deliberate error' if value == 50
-                             state + value
-                           },
+                           update: ->(state, value) { state + value },
                            finalize: ->(state) { state })
       @con.register_aggregate_function(af)
 
-      # The query must fail — the update block raises for input 50.
-      assert_raises(DuckDB::Error) do
-        @con.query('SELECT error_sum(i) FROM range(100) t(i)')
-      end
+      result = @con.query('SELECT cleanup_sum(i) FROM range(100) t(i)')
 
-      # Apply GC pressure.  Without a destructor registered via
-      # duckdb_aggregate_function_set_destructor the g_aggregate_state_registry
-      # still holds entries for every state DuckDB freed without calling
-      # finalize — those entries will never be removed.
-      GC.start
-      GC.compact if GC.respond_to?(:compact)
-      GC.start
+      assert_equal 4950, result.first.first
 
-      # With the destructor wired the registry must be empty now.
-      # _state_registry_size is a C-level helper exposed specifically to make
-      # this invariant observable from Ruby tests.
-      assert_equal 0, DuckDB::AggregateFunction._state_registry_size,
-                   'state registry must be empty after all aggregate states are destroyed'
+      # With the destructor wired via duckdb_aggregate_function_set_destructor,
+      # all states allocated during the query are cleaned up through either
+      # finalize (for the final state) or destroy (for intermediate states
+      # that DuckDB memcpy'd internally).  The registry must return to
+      # baseline.
+      assert_equal baseline, DuckDB::AggregateFunction._state_registry_size,
+                   'state registry must not grow after a successful aggregate query'
     end
 
     def test_aggregate_combine_merges_partial_states_in_parallel

--- a/test/duckdb_test/aggregate_function_test.rb
+++ b/test/duckdb_test/aggregate_function_test.rb
@@ -107,6 +107,25 @@ module DuckDBTest
       assert_equal 4_999_950_000, result.first.first
     end
 
+    def test_set_special_handling_passes_null_values_to_update
+      af = build_aggregate('count_with_nulls',
+                           init: -> { 0 },
+                           update: ->(state, _value) { state + 1 },
+                           finalize: ->(state) { state })
+      af.set_special_handling
+      @con.register_aggregate_function(af)
+
+      @con.query('CREATE TABLE null_test (i BIGINT)')
+      @con.query('INSERT INTO null_test VALUES (1), (NULL), (3), (NULL), (5)')
+
+      result = @con.query('SELECT count_with_nulls(i) FROM null_test')
+
+      # Without set_special_handling DuckDB would skip the 2 NULL rows and
+      # return 3.  With it the update callback receives all 5 rows (NULLs
+      # arrive as nil), so the count must be 5.
+      assert_equal 5, result.first.first
+    end
+
     private
 
     # Force DuckDB to actually parallelise aggregation so the combine callback


### PR DESCRIPTION
## Summary

Phase 2 of AggregateFunction implementation: destructor callback, special handling, and error path cleanup.

### Destructor callback
- Embed monotonic `state_id` in `ruby_aggregate_state` struct so registry keys survive DuckDB's internal memcpy of state buffers (pointer addresses differ between init and destroy)
- Register `destroy_callback` via `duckdb_aggregate_function_set_destructor` — dispatches through executor thread to safely call `rb_hash_delete` with GVL
- Extract `state_registry_store()` / `state_registry_remove()` helpers
- Add `_state_registry_size` singleton method for testing

### Special handling
- Add `AggregateFunction#set_special_handling` wrapping `duckdb_aggregate_function_set_special_handling`
- When enabled, DuckDB passes NULL values to the update callback as `nil` instead of skipping them

### Error path cleanup
- Fix finalize error path: `goto cleanup` now removes remaining states from registry
- Fix update error path: iterate all states in the chunk and remove from registry (DuckDB does not call destroy after update errors)
- Error messages from Ruby exceptions propagate to `DuckDB::Error`

### Tests (9 total, all pass)
- `test_aggregate_destructor_cleans_up_states_after_successful_query`
- `test_aggregate_update_error_surfaces_without_registry_leak`
- `test_aggregate_state_cleanup_after_finalize_error`
- `test_set_special_handling_passes_null_values_to_update`
- Plus 5 existing Phase 1 tests

993 tests pass, rubocop clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added special NULL handling mode for aggregate functions, allowing custom NULL semantics by passing `nil` values to update callbacks.

* **Bug Fixes**
  * Improved memory management and cleanup of aggregate function states.
  * Fixed potential registry leaks when aggregate callbacks raise exceptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->