### PR TITLE
Add DataChunk construction and appender chunk append support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ All notable changes to this project will be documented in this file.
 - add `DuckDB::Value.create_hugeint`.
 - add `DuckDB::Value.create_uhugeint`.
 - add `DuckDB::Appender#append_value`.
+- add `DuckDB::Appender#append_data_chunk` to append a `DuckDB::DataChunk` in one call.
+- add `DuckDB::DataChunk.new(types)` to create an owned data chunk from Ruby logical types.
 - add `DuckDB::AggregateFunction`.
 
 ## Breaking Changes

--- a/ext/duckdb/appender.c
+++ b/ext/duckdb/appender.c
@@ -1,6 +1,7 @@
 #include "ruby-duckdb.h"
 
 static VALUE cDuckDBAppender;
+extern VALUE cDuckDBDataChunk;
 
 static void deallocate(void *);
 static VALUE allocate(VALUE klass);
@@ -34,6 +35,7 @@ static VALUE appender__append_timestamp(VALUE self, VALUE year, VALUE month, VAL
 static VALUE appender__append_hugeint(VALUE self, VALUE lower, VALUE upper);
 static VALUE appender__append_uhugeint(VALUE self, VALUE lower, VALUE upper);
 static VALUE appender__append_value(VALUE self, VALUE val);
+static VALUE appender__append_data_chunk(VALUE self, VALUE chunk);
 static VALUE appender__flush(VALUE self);
 static VALUE appender__close(VALUE self);
 static VALUE duckdb_state_to_bool_value(duckdb_state state);
@@ -428,6 +430,17 @@ static VALUE appender__append_value(VALUE self, VALUE val) {
 }
 
 /* :nodoc: */
+static VALUE appender__append_data_chunk(VALUE self, VALUE chunk) {
+    rubyDuckDBAppender *ctx;
+    rubyDuckDBDataChunk *chunk_ctx;
+
+    TypedData_Get_Struct(self, rubyDuckDBAppender, &appender_data_type, ctx);
+    chunk_ctx = get_struct_data_chunk(chunk);
+
+    return duckdb_state_to_bool_value(duckdb_append_data_chunk(ctx->appender, chunk_ctx->data_chunk));
+}
+
+/* :nodoc: */
 static VALUE appender__flush(VALUE self) {
     rubyDuckDBAppender *ctx;
     TypedData_Get_Struct(self, rubyDuckDBAppender, &appender_data_type, ctx);
@@ -485,4 +498,5 @@ void rbduckdb_init_duckdb_appender(void) {
     rb_define_private_method(cDuckDBAppender, "_append_hugeint", appender__append_hugeint, 2);
     rb_define_private_method(cDuckDBAppender, "_append_uhugeint", appender__append_uhugeint, 2);
     rb_define_private_method(cDuckDBAppender, "_append_value", appender__append_value, 1);
+    rb_define_private_method(cDuckDBAppender, "_append_data_chunk", appender__append_data_chunk, 1);
 }

--- a/ext/duckdb/data_chunk.c
+++ b/ext/duckdb/data_chunk.c
@@ -6,6 +6,7 @@ extern VALUE cDuckDBVector;
 static void deallocate(void *ctx);
 static VALUE allocate(VALUE klass);
 static size_t memsize(const void *p);
+static VALUE initialize(int argc, VALUE *argv, VALUE self);
 static VALUE rbduckdb_data_chunk_column_count(VALUE self);
 static VALUE rbduckdb_data_chunk_get_size(VALUE self);
 static VALUE rbduckdb_data_chunk_set_size(VALUE self, VALUE size);
@@ -19,6 +20,11 @@ static const rb_data_type_t data_chunk_data_type = {
 
 static void deallocate(void *ctx) {
     rubyDuckDBDataChunk *p = (rubyDuckDBDataChunk *)ctx;
+
+    if (p->owned && p->data_chunk) {
+        duckdb_destroy_data_chunk(&(p->data_chunk));
+    }
+
     xfree(p);
 }
 
@@ -35,6 +41,48 @@ rubyDuckDBDataChunk *get_struct_data_chunk(VALUE obj) {
     rubyDuckDBDataChunk *ctx;
     TypedData_Get_Struct(obj, rubyDuckDBDataChunk, &data_chunk_data_type, ctx);
     return ctx;
+}
+
+static VALUE initialize(int argc, VALUE *argv, VALUE self) {
+    rubyDuckDBDataChunk *ctx;
+    VALUE logical_types;
+    idx_t column_count;
+    duckdb_logical_type *types;
+    long i;
+
+    TypedData_Get_Struct(self, rubyDuckDBDataChunk, &data_chunk_data_type, ctx);
+
+    rb_scan_args(argc, argv, "01", &logical_types);
+    if (NIL_P(logical_types)) {
+        return self;
+    }
+
+    Check_Type(logical_types, T_ARRAY);
+
+    if (ctx->owned && ctx->data_chunk) {
+        duckdb_destroy_data_chunk(&(ctx->data_chunk));
+        ctx->owned = false;
+    }
+
+    column_count = (idx_t)RARRAY_LEN(logical_types);
+    types = ALLOC_N(duckdb_logical_type, column_count);
+
+    for (i = 0; i < RARRAY_LEN(logical_types); i++) {
+        VALUE logical_type = rb_ary_entry(logical_types, i);
+        rubyDuckDBLogicalType *logical_type_ctx = get_struct_logical_type(logical_type);
+        types[i] = logical_type_ctx->logical_type;
+    }
+
+    ctx->data_chunk = duckdb_create_data_chunk(types, column_count);
+    xfree(types);
+
+    if (!ctx->data_chunk) {
+        rb_raise(eDuckDBError, "Failed to create data chunk");
+    }
+
+    ctx->owned = true;
+
+    return self;
 }
 
 /*
@@ -130,6 +178,7 @@ void rbduckdb_init_duckdb_data_chunk(void) {
     cDuckDBDataChunk = rb_define_class_under(mDuckDB, "DataChunk", rb_cObject);
     rb_define_alloc_func(cDuckDBDataChunk, allocate);
 
+    rb_define_method(cDuckDBDataChunk, "initialize", initialize, -1);
     rb_define_method(cDuckDBDataChunk, "column_count", rbduckdb_data_chunk_column_count, 0);
     rb_define_method(cDuckDBDataChunk, "size", rbduckdb_data_chunk_get_size, 0);
     rb_define_method(cDuckDBDataChunk, "size=", rbduckdb_data_chunk_set_size, 1);

--- a/ext/duckdb/data_chunk.h
+++ b/ext/duckdb/data_chunk.h
@@ -3,6 +3,7 @@
 
 struct _rubyDuckDBDataChunk {
     duckdb_data_chunk data_chunk;
+    bool owned;
 };
 
 typedef struct _rubyDuckDBDataChunk rubyDuckDBDataChunk;

--- a/lib/duckdb/appender.rb
+++ b/lib/duckdb/appender.rb
@@ -585,6 +585,16 @@ module DuckDB
       raise_appender_error('failed to append_value')
     end
 
+    # call-seq:
+    #   appender.append_data_chunk(chunk) -> self
+    def append_data_chunk(chunk)
+      raise ArgumentError, "expected DuckDB::DataChunk, got #{chunk.class}" unless chunk.is_a?(DuckDB::DataChunk)
+
+      return self if _append_data_chunk(chunk)
+
+      raise_appender_error('failed to append_data_chunk')
+    end
+
     # appends value.
     #
     #   require 'duckdb'

--- a/lib/duckdb/data_chunk.rb
+++ b/lib/duckdb/data_chunk.rb
@@ -46,9 +46,8 @@ module DuckDB
     #
     # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength
     def set_value(col_idx, row_idx, value)
-      vector = get_vector(col_idx)
-      logical_type = vector.logical_type
-      type_id = logical_type.type
+      vector = cached_vector(col_idx)
+      type_id = cached_type_id(col_idx, vector)
 
       # Handle NULL
       if value.nil?
@@ -58,51 +57,37 @@ module DuckDB
 
       case type_id
       when :boolean
-        data = vector.get_data
-        MemoryHelper.write_boolean(data, row_idx, value)
+        MemoryHelper.write_boolean(cached_data(col_idx, vector), row_idx, value)
       when :tinyint
-        data = vector.get_data
-        MemoryHelper.write_tinyint(data, row_idx, value)
+        MemoryHelper.write_tinyint(cached_data(col_idx, vector), row_idx, value)
       when :smallint
-        data = vector.get_data
-        MemoryHelper.write_smallint(data, row_idx, value)
+        MemoryHelper.write_smallint(cached_data(col_idx, vector), row_idx, value)
       when :integer
-        data = vector.get_data
-        MemoryHelper.write_integer(data, row_idx, value)
+        MemoryHelper.write_integer(cached_data(col_idx, vector), row_idx, value)
       when :bigint
-        data = vector.get_data
-        MemoryHelper.write_bigint(data, row_idx, value)
+        MemoryHelper.write_bigint(cached_data(col_idx, vector), row_idx, value)
       when :utinyint
-        data = vector.get_data
-        MemoryHelper.write_utinyint(data, row_idx, value)
+        MemoryHelper.write_utinyint(cached_data(col_idx, vector), row_idx, value)
       when :usmallint
-        data = vector.get_data
-        MemoryHelper.write_usmallint(data, row_idx, value)
+        MemoryHelper.write_usmallint(cached_data(col_idx, vector), row_idx, value)
       when :uinteger
-        data = vector.get_data
-        MemoryHelper.write_uinteger(data, row_idx, value)
+        MemoryHelper.write_uinteger(cached_data(col_idx, vector), row_idx, value)
       when :ubigint
-        data = vector.get_data
-        MemoryHelper.write_ubigint(data, row_idx, value)
+        MemoryHelper.write_ubigint(cached_data(col_idx, vector), row_idx, value)
       when :float
-        data = vector.get_data
-        MemoryHelper.write_float(data, row_idx, value)
+        MemoryHelper.write_float(cached_data(col_idx, vector), row_idx, value)
       when :double
-        data = vector.get_data
-        MemoryHelper.write_double(data, row_idx, value)
+        MemoryHelper.write_double(cached_data(col_idx, vector), row_idx, value)
       when :varchar
         vector.assign_string_element(row_idx, value.to_s)
       when :blob
         vector.assign_string_element_len(row_idx, value.to_s)
       when :timestamp
-        data = vector.get_data
-        MemoryHelper.write_timestamp(data, row_idx, value)
+        MemoryHelper.write_timestamp(cached_data(col_idx, vector), row_idx, value)
       when :timestamp_tz
-        data = vector.get_data
-        MemoryHelper.write_timestamp_tz(data, row_idx, value)
+        MemoryHelper.write_timestamp_tz(cached_data(col_idx, vector), row_idx, value)
       when :date
-        data = vector.get_data
-        MemoryHelper.write_date(data, row_idx, value)
+        MemoryHelper.write_date(cached_data(col_idx, vector), row_idx, value)
       else
         raise ArgumentError, "Unsupported type for DataChunk#set_value: #{type_id} for value `#{value.inspect}`"
       end
@@ -110,5 +95,22 @@ module DuckDB
       value
     end
     # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength
+
+    private
+
+    def cached_vector(col_idx)
+      @vector_cache ||= {}
+      @vector_cache[col_idx] ||= get_vector(col_idx)
+    end
+
+    def cached_type_id(col_idx, vector)
+      @type_id_cache ||= {}
+      @type_id_cache[col_idx] ||= vector.logical_type.type
+    end
+
+    def cached_data(col_idx, vector)
+      @data_cache ||= {}
+      @data_cache[col_idx] ||= vector.get_data
+    end
   end
 end

--- a/test/duckdb_test/appender_test.rb
+++ b/test/duckdb_test/appender_test.rb
@@ -253,6 +253,23 @@ module DuckDBTest
       assert_raises(ArgumentError) { @appender.append_value(nil) }
     end
 
+    def test_append_data_chunk
+      create_table('id BIGINT, value VARCHAR')
+      appender = DuckDB::Appender.new(@con, '', table)
+      chunk = DuckDB::DataChunk.new([DuckDB::LogicalType::BIGINT, DuckDB::LogicalType::VARCHAR])
+
+      chunk.set_value(0, 0, 42)
+      chunk.set_value(1, 0, 'Alice')
+      chunk.set_value(0, 1, 84)
+      chunk.set_value(1, 1, 'Bob')
+      chunk.size = 2
+
+      appender.append_data_chunk(chunk)
+      appender.close
+
+      assert_equal([[42, 'Alice'], [84, 'Bob']], @con.query("SELECT * FROM #{table} ORDER BY id").to_a)
+    end
+
     def test_append_uint32
       assert_duckdb_appender(4_294_967_295, 'BIGINT') { |a| a.append_uint32(4_294_967_295) }
     end

--- a/test/duckdb_test/data_chunk_test.rb
+++ b/test/duckdb_test/data_chunk_test.rb
@@ -435,5 +435,13 @@ module DuckDBTest
       assert_equal time2.utc, rows[1].first.utc
       assert_equal time1.utc, rows[2].first.utc # time3 (JST) equals time1 (UTC) as same instant
     end
+
+    def test_s_new_constructs_owned_data_chunk # rubocop:disable Minitest/MultipleAssertions
+      data_chunk = DuckDB::DataChunk.new([DuckDB::LogicalType::BIGINT, DuckDB::LogicalType::VARCHAR])
+
+      assert_equal 2, data_chunk.column_count
+      assert_equal :bigint, data_chunk.get_vector(0).logical_type.type
+      assert_equal :varchar, data_chunk.get_vector(1).logical_type.type
+    end
   end
 end

--- a/test/duckdb_test/data_chunk_test.rb
+++ b/test/duckdb_test/data_chunk_test.rb
@@ -436,7 +436,7 @@ module DuckDBTest
       assert_equal time1.utc, rows[2].first.utc # time3 (JST) equals time1 (UTC) as same instant
     end
 
-    def test_s_new_constructs_owned_data_chunk # rubocop:disable Minitest/MultipleAssertions
+    def test_s_new_constructs_owned_data_chunk
       data_chunk = DuckDB::DataChunk.new([DuckDB::LogicalType::BIGINT, DuckDB::LogicalType::VARCHAR])
 
       assert_equal 2, data_chunk.column_count


### PR DESCRIPTION
## Summary
- add owned `DuckDB::DataChunk.new(types)` support
- add `DuckDB::Appender#append_data_chunk` for chunk-wise appends
- document the new APIs in the changelog

## Related
- Related to #1275
- Related to #1271

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `DuckDB::Appender#append_data_chunk` method for efficient bulk appending of data chunks in a single operation.
  * Added `DuckDB::DataChunk.new(types)` constructor to create and own DataChunks directly from logical type specifications, enabling schema-driven data chunk construction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->