### PR TITLE
Fix GVL-unsafe callbacks in table_function.c

### DIFF
--- a/ext/duckdb/table_function.c
+++ b/ext/duckdb/table_function.c
@@ -209,6 +209,8 @@ static VALUE rbduckdb_table_function_set_bind(VALUE self) {
 
     duckdb_table_function_set_bind(ctx->table_function, table_function_bind_callback);
 
+    rbduckdb_function_executor_ensure_started();
+
     return self;
 }
 
@@ -217,33 +219,43 @@ static VALUE call_bind_proc(VALUE arg) {
     return rb_funcall(args[0], rb_intern("call"), 1, args[1]);
 }
 
-static void table_function_bind_callback(duckdb_bind_info info) {
+struct bind_dispatch_arg {
     rubyDuckDBTableFunction *ctx;
+    duckdb_bind_info info;
+};
+
+static void execute_bind_callback_protected(void *user_data) {
+    struct bind_dispatch_arg *darg = (struct bind_dispatch_arg *)user_data;
     rubyDuckDBBindInfo *bind_info_ctx;
     VALUE bind_info_obj;
     int state = 0;
 
-    // Get the C struct pointer (safe with GC compaction)
-    ctx = (rubyDuckDBTableFunction *)duckdb_bind_get_extra_info(info);
-    if (!ctx || ctx->bind_proc == Qnil) {
-        return;
-    }
-
-    // Create BindInfo wrapper
     bind_info_obj = rb_class_new_instance(0, NULL, cDuckDBTableFunctionBindInfo);
     bind_info_ctx = get_struct_bind_info(bind_info_obj);
-    bind_info_ctx->bind_info = info;
+    bind_info_ctx->bind_info = darg->info;
 
-    // Call Ruby block with exception protection
-    VALUE call_args[2] = { ctx->bind_proc, bind_info_obj };
+    VALUE call_args[2] = { darg->ctx->bind_proc, bind_info_obj };
     rb_protect(call_bind_proc, (VALUE)call_args, &state);
 
     if (state) {
         VALUE err = rb_errinfo();
         VALUE msg = rb_funcall(err, rb_intern("message"), 0);
-        duckdb_bind_set_error(info, StringValueCStr(msg));
-        rb_set_errinfo(Qnil); // Clear the error
+        duckdb_bind_set_error(darg->info, StringValueCStr(msg));
+        rb_set_errinfo(Qnil);
     }
+}
+
+static void table_function_bind_callback(duckdb_bind_info info) {
+    rubyDuckDBTableFunction *ctx;
+    struct bind_dispatch_arg darg;
+
+    ctx = (rubyDuckDBTableFunction *)duckdb_bind_get_extra_info(info);
+    if (!ctx || ctx->bind_proc == Qnil) return;
+
+    darg.ctx = ctx;
+    darg.info = info;
+
+    rbduckdb_function_executor_dispatch(execute_bind_callback_protected, &darg);
 }
 
 /*
@@ -273,6 +285,8 @@ static VALUE rbduckdb_table_function_set_init(VALUE self) {
     ctx->init_proc = rb_block_proc();
     duckdb_table_function_set_init(ctx->table_function, table_function_init_callback);
 
+    rbduckdb_function_executor_ensure_started();
+
     return self;
 }
 
@@ -281,33 +295,43 @@ static VALUE call_init_proc(VALUE args_val) {
     return rb_funcall(args[0], rb_intern("call"), 1, args[1]);
 }
 
-static void table_function_init_callback(duckdb_init_info info) {
+struct init_dispatch_arg {
     rubyDuckDBTableFunction *ctx;
+    duckdb_init_info info;
+};
+
+static void execute_init_callback_protected(void *user_data) {
+    struct init_dispatch_arg *darg = (struct init_dispatch_arg *)user_data;
     VALUE init_info_obj;
     rubyDuckDBInitInfo *init_info_ctx;
     int state = 0;
 
-    // Get the C struct pointer (safe with GC compaction)
-    ctx = (rubyDuckDBTableFunction *)duckdb_init_get_extra_info(info);
-    if (!ctx || ctx->init_proc == Qnil) {
-        return;
-    }
-
-    // Create InitInfo wrapper
     init_info_obj = rb_class_new_instance(0, NULL, cDuckDBTableFunctionInitInfo);
     init_info_ctx = get_struct_init_info(init_info_obj);
-    init_info_ctx->info = info;
+    init_info_ctx->info = darg->info;
 
-    // Call Ruby block with exception protection
-    VALUE call_args[2] = { ctx->init_proc, init_info_obj };
+    VALUE call_args[2] = { darg->ctx->init_proc, init_info_obj };
     rb_protect(call_init_proc, (VALUE)call_args, &state);
 
     if (state) {
         VALUE err = rb_errinfo();
         VALUE msg = rb_funcall(err, rb_intern("message"), 0);
-        duckdb_init_set_error(info, StringValueCStr(msg));
-        rb_set_errinfo(Qnil); // Clear the error
+        duckdb_init_set_error(darg->info, StringValueCStr(msg));
+        rb_set_errinfo(Qnil);
     }
+}
+
+static void table_function_init_callback(duckdb_init_info info) {
+    rubyDuckDBTableFunction *ctx;
+    struct init_dispatch_arg darg;
+
+    ctx = (rubyDuckDBTableFunction *)duckdb_init_get_extra_info(info);
+    if (!ctx || ctx->init_proc == Qnil) return;
+
+    darg.ctx = ctx;
+    darg.info = info;
+
+    rbduckdb_function_executor_dispatch(execute_init_callback_protected, &darg);
 }
 
 /*
@@ -335,6 +359,8 @@ static VALUE rbduckdb_table_function_set_execute(VALUE self) {
     ctx->execute_proc = rb_block_proc();
     duckdb_table_function_set_function(ctx->table_function, table_function_execute_callback);
 
+    rbduckdb_function_executor_ensure_started();
+
     return self;
 }
 
@@ -343,40 +369,51 @@ static VALUE call_execute_proc(VALUE args_val) {
     return rb_funcall(args[0], rb_intern("call"), 2, args[1], args[2]);
 }
 
-static void table_function_execute_callback(duckdb_function_info info, duckdb_data_chunk output) {
+struct execute_dispatch_arg {
     rubyDuckDBTableFunction *ctx;
+    duckdb_function_info info;
+    duckdb_data_chunk output;
+};
+
+static void execute_execute_callback_protected(void *user_data) {
+    struct execute_dispatch_arg *darg = (struct execute_dispatch_arg *)user_data;
     VALUE func_info_obj;
     VALUE data_chunk_obj;
     rubyDuckDBFunctionInfo *func_info_ctx;
     rubyDuckDBDataChunk *data_chunk_ctx;
     int state = 0;
 
-    // Get the C struct pointer (safe with GC compaction)
-    ctx = (rubyDuckDBTableFunction *)duckdb_function_get_extra_info(info);
-    if (!ctx || ctx->execute_proc == Qnil) {
-        return;
-    }
-
-    // Create FunctionInfo wrapper
     func_info_obj = rb_class_new_instance(0, NULL, cDuckDBTableFunctionFunctionInfo);
     func_info_ctx = get_struct_function_info(func_info_obj);
-    func_info_ctx->info = info;
+    func_info_ctx->info = darg->info;
 
-    // Create DataChunk wrapper
     data_chunk_obj = rb_class_new_instance(0, NULL, cDuckDBDataChunk);
     data_chunk_ctx = get_struct_data_chunk(data_chunk_obj);
-    data_chunk_ctx->data_chunk = output;
+    data_chunk_ctx->data_chunk = darg->output;
 
-    // Call Ruby block with exception protection
-    VALUE call_args[3] = { ctx->execute_proc, func_info_obj, data_chunk_obj };
+    VALUE call_args[3] = { darg->ctx->execute_proc, func_info_obj, data_chunk_obj };
     rb_protect(call_execute_proc, (VALUE)call_args, &state);
 
     if (state) {
         VALUE err = rb_errinfo();
         VALUE msg = rb_funcall(err, rb_intern("message"), 0);
-        duckdb_function_set_error(info, StringValueCStr(msg));
-        rb_set_errinfo(Qnil); // Clear the error
+        duckdb_function_set_error(darg->info, StringValueCStr(msg));
+        rb_set_errinfo(Qnil);
     }
+}
+
+static void table_function_execute_callback(duckdb_function_info info, duckdb_data_chunk output) {
+    rubyDuckDBTableFunction *ctx;
+    struct execute_dispatch_arg darg;
+
+    ctx = (rubyDuckDBTableFunction *)duckdb_function_get_extra_info(info);
+    if (!ctx || ctx->execute_proc == Qnil) return;
+
+    darg.ctx = ctx;
+    darg.info = info;
+    darg.output = output;
+
+    rbduckdb_function_executor_dispatch(execute_execute_callback_protected, &darg);
 }
 
 rubyDuckDBTableFunction *get_struct_table_function(VALUE self) {


### PR DESCRIPTION
Wrap bind, init, and execute callbacks with
rbduckdb_function_executor_dispatch to ensure Ruby C API calls run with the GVL held. Without this, callbacks invoked from duckdb_query (which runs without GVL) could cause intermittent hangs or crashes, especially on Windows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and reporting for custom table function callbacks, with clearer error messages when issues occur during binding, initialization, or execution phases

* **Refactor**
  * Optimized callback execution architecture to enhance reliability and stability of table function operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->