### PR TITLE
DuckDB::Database.new

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 # Unreleased
 
+- add `DuckDB::Database.new(path = :memory, config: nil, &block)` to create a database instance. `path` is a positional argument (default `:memory` for in-memory database, or a String path for file database). `config:` accepts an optional `DuckDB::Config` object. When a block is given, the database is yielded and automatically closed afterwards.
 - add `TIME_NS` column support to `DuckDB::Result`. `TIME_NS` values are returned as `Time` objects with nanoseconds truncated to microseconds.
 - add `INTERVAL` as a supported `return_type` for `DuckDB::ScalarFunction`. The scalar function block can now return a `DuckDB::Interval` object and it will be written back to the result vector correctly.
 - add `UUID` as a supported `return_type` for `DuckDB::ScalarFunction`. The scalar function block can now return a UUID string and it will be written back to the result vector correctly.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 # Unreleased
 
 - add `DuckDB::Database.new(path = :memory, config: nil, &block)` to create a database instance. `path` is a positional argument (default `:memory` for in-memory database, or a String path for file database). `config:` accepts an optional `DuckDB::Config` object. When a block is given, the database is yielded and automatically closed afterwards.
+- refactor `DuckDB::Database.open` to delegate to `DuckDB::Database.new`. The signature changes from `open(dbpath = nil, config = nil)` to `open(path = :memory, config: nil)`. `DuckDB::Database.open` now accepts `:memory` symbol and `config:` keyword argument.
 - add `TIME_NS` column support to `DuckDB::Result`. `TIME_NS` values are returned as `Time` objects with nanoseconds truncated to microseconds.
 - add `INTERVAL` as a supported `return_type` for `DuckDB::ScalarFunction`. The scalar function block can now return a `DuckDB::Interval` object and it will be written back to the result vector correctly.
 - add `UUID` as a supported `return_type` for `DuckDB::ScalarFunction`. The scalar function block can now return a UUID string and it will be written back to the result vector correctly.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@ All notable changes to this project will be documented in this file.
 # Unreleased
 
 - add `DuckDB::Database.new(path = :memory, config: nil, &block)` to create a database instance. `path` is a positional argument (default `:memory` for in-memory database, or a String path for file database). `config:` accepts an optional `DuckDB::Config` object. When a block is given, the database is yielded and automatically closed afterwards.
-- refactor `DuckDB::Database.open` to delegate to `DuckDB::Database.new`. The signature changes from `open(dbpath = nil, config = nil)` to `open(path = :memory, config: nil)`. `DuckDB::Database.open` now accepts `:memory` symbol and `config:` keyword argument.
 - add `TIME_NS` column support to `DuckDB::Result`. `TIME_NS` values are returned as `Time` objects with nanoseconds truncated to microseconds.
 - add `INTERVAL` as a supported `return_type` for `DuckDB::ScalarFunction`. The scalar function block can now return a `DuckDB::Interval` object and it will be written back to the result vector correctly.
 - add `UUID` as a supported `return_type` for `DuckDB::ScalarFunction`. The scalar function block can now return a UUID string and it will be written back to the result vector correctly.
@@ -36,6 +35,7 @@ All notable changes to this project will be documented in this file.
 ## Breaking Changes
 - rename `DuckDB::ValueImpl` to `DuckDB::Value`
 - remove `DuckDB::ExtractedStatementsImpl`. use `DuckDB::ExtractedStatements`
+- `DuckDB::Database.open` to delegate to `DuckDB::Database.new`. The signature changes from `open(dbpath = nil, config = nil)` to `open(path = :memory, config: nil)`. `DuckDB::Database.open` now accepts `:memory` symbol and `config:` keyword argument.
 
 # 1.5.1.1 - 2026-04-04
 

--- a/ext/duckdb/database.c
+++ b/ext/duckdb/database.c
@@ -9,6 +9,7 @@ static size_t memsize(const void *p);
 static duckdb_config create_config_with_ruby_api(void);
 static VALUE duckdb_database_s_open(int argc, VALUE *argv, VALUE cDuckDBDatabase);
 static VALUE duckdb_database_s_open_ext(int argc, VALUE *argv, VALUE cDuckDBDatabase);
+static VALUE duckdb_database__initialize(VALUE self, VALUE file, VALUE config);
 static VALUE duckdb_database_connect(VALUE self);
 static VALUE duckdb_database_close(VALUE self);
 
@@ -149,6 +150,53 @@ static VALUE duckdb_database_s_open_ext(int argc, VALUE *argv, VALUE cDuckDBData
 }
 
 /* :nodoc: */
+static VALUE duckdb_database__initialize(VALUE self, VALUE file, VALUE config) {
+    rubyDuckDB *ctx;
+    rubyDuckDBConfig *ctx_config;
+    duckdb_config config_to_use;
+    char *perror = NULL;
+    int need_destroy_config = 0;
+    char *pfile = NULL;
+
+    TypedData_Get_Struct(self, rubyDuckDB, &database_data_type, ctx);
+
+    if (!NIL_P(file)) {
+        pfile = StringValuePtr(file);
+    }
+
+    if (!NIL_P(config)) {
+        if (!rb_obj_is_kind_of(config, cDuckDBConfig)) {
+            rb_raise(rb_eTypeError, "The second argument must be DuckDB::Config object.");
+        }
+        ctx_config = get_struct_config(config);
+        if (duckdb_set_config(ctx_config->config, "duckdb_api", "ruby") == DuckDBError) {
+            rb_raise(eDuckDBError, "failed to set duckdb_api config");
+        }
+        config_to_use = ctx_config->config;
+    } else {
+        config_to_use = create_config_with_ruby_api();
+        need_destroy_config = 1;
+    }
+
+    if (duckdb_open_ext(pfile, &(ctx->db), config_to_use, &perror) == DuckDBError) {
+        VALUE error_msg = rb_str_new_cstr(perror ? perror : "Unknown error");
+        if (perror) {
+            duckdb_free(perror);
+        }
+        if (need_destroy_config) {
+            duckdb_destroy_config(&config_to_use);
+        }
+        rb_raise(eDuckDBError, "failed to open database: %s", StringValueCStr(error_msg));
+    }
+
+    if (need_destroy_config) {
+        duckdb_destroy_config(&config_to_use);
+    }
+
+    return self;
+}
+
+/* :nodoc: */
 static VALUE duckdb_database_connect(VALUE self) {
     return rbduckdb_create_connection(self);
 }
@@ -182,6 +230,7 @@ void rbduckdb_init_duckdb_database(void) {
     rb_define_alloc_func(cDuckDBDatabase, allocate);
     rb_define_singleton_method(cDuckDBDatabase, "_open", duckdb_database_s_open, -1);
     rb_define_singleton_method(cDuckDBDatabase, "_open_ext", duckdb_database_s_open_ext, -1);
+    rb_define_private_method(cDuckDBDatabase, "_initialize", duckdb_database__initialize, 2);
     rb_define_private_method(cDuckDBDatabase, "_connect", duckdb_database_connect, 0);
     rb_define_method(cDuckDBDatabase, "close", duckdb_database_close, 0);
 }

--- a/ext/duckdb/database.c
+++ b/ext/duckdb/database.c
@@ -7,8 +7,6 @@ static void deallocate(void * ctx);
 static VALUE allocate(VALUE klass);
 static size_t memsize(const void *p);
 static duckdb_config create_config_with_ruby_api(void);
-static VALUE duckdb_database_s_open(int argc, VALUE *argv, VALUE cDuckDBDatabase);
-static VALUE duckdb_database_s_open_ext(int argc, VALUE *argv, VALUE cDuckDBDatabase);
 static VALUE duckdb_database__initialize(VALUE self, VALUE file, VALUE config);
 static VALUE duckdb_database_connect(VALUE self);
 static VALUE duckdb_database_close(VALUE self);
@@ -58,95 +56,6 @@ static duckdb_config create_config_with_ruby_api(void) {
     }
 
     return config;
-}
-
-/* :nodoc: */
-static VALUE duckdb_database_s_open(int argc, VALUE *argv, VALUE cDuckDBDatabase) {
-    rubyDuckDB *ctx;
-    VALUE obj;
-    duckdb_config config;
-    char *perror = NULL;
-
-    char *pfile = NULL;
-    VALUE file = Qnil;
-
-    rb_scan_args(argc, argv, "01", &file);
-
-    if (!NIL_P(file)) {
-        pfile = StringValuePtr(file);
-    }
-
-    obj = allocate(cDuckDBDatabase);
-    TypedData_Get_Struct(obj, rubyDuckDB, &database_data_type, ctx);
-
-    config = create_config_with_ruby_api();
-
-    if (duckdb_open_ext(pfile, &(ctx->db), config, &perror) == DuckDBError) {
-        VALUE error_msg = rb_str_new_cstr(perror ? perror : "Unknown error");
-        if (perror) {
-            duckdb_free(perror);
-        }
-        duckdb_destroy_config(&config);
-        rb_raise(eDuckDBError, "failed to open database: %s", StringValueCStr(error_msg));
-    }
-
-    duckdb_destroy_config(&config);
-    return obj;
-}
-
-/* :nodoc: */
-static VALUE duckdb_database_s_open_ext(int argc, VALUE *argv, VALUE cDuckDBDatabase) {
-    rubyDuckDB *ctx;
-    VALUE obj;
-    rubyDuckDBConfig *ctx_config;
-    duckdb_config config_to_use;
-    char *perror = NULL;
-    int need_destroy_config = 0;
-
-    char *pfile = NULL;
-    VALUE file = Qnil;
-    VALUE config = Qnil;
-
-    rb_scan_args(argc, argv, "02", &file, &config);
-
-    if (!NIL_P(file)) {
-        pfile = StringValuePtr(file);
-    }
-
-    obj = allocate(cDuckDBDatabase);
-    TypedData_Get_Struct(obj, rubyDuckDB, &database_data_type, ctx);
-
-    if (!NIL_P(config)) {
-        if (!rb_obj_is_kind_of(config, cDuckDBConfig)) {
-            rb_raise(rb_eTypeError, "The second argument must be DuckDB::Config object.");
-        }
-        ctx_config = get_struct_config(config);
-        /* Set duckdb_api to "ruby" for the provided config */
-        if (duckdb_set_config(ctx_config->config, "duckdb_api", "ruby") == DuckDBError) {
-            rb_raise(eDuckDBError, "failed to set duckdb_api config");
-        }
-        config_to_use = ctx_config->config;
-    } else {
-        config_to_use = create_config_with_ruby_api();
-        need_destroy_config = 1;
-    }
-
-    if (duckdb_open_ext(pfile, &(ctx->db), config_to_use, &perror) == DuckDBError) {
-        VALUE error_msg = rb_str_new_cstr(perror ? perror : "Unknown error");
-        if (perror) {
-            duckdb_free(perror);
-        }
-        if (need_destroy_config) {
-            duckdb_destroy_config(&config_to_use);
-        }
-        rb_raise(eDuckDBError, "failed to open database: %s", StringValueCStr(error_msg));
-    }
-
-    if (need_destroy_config) {
-        duckdb_destroy_config(&config_to_use);
-    }
-
-    return obj;
 }
 
 /* :nodoc: */
@@ -228,8 +137,6 @@ void rbduckdb_init_duckdb_database(void) {
 #endif
     cDuckDBDatabase = rb_define_class_under(mDuckDB, "Database", rb_cObject);
     rb_define_alloc_func(cDuckDBDatabase, allocate);
-    rb_define_singleton_method(cDuckDBDatabase, "_open", duckdb_database_s_open, -1);
-    rb_define_singleton_method(cDuckDBDatabase, "_open_ext", duckdb_database_s_open_ext, -1);
     rb_define_private_method(cDuckDBDatabase, "_initialize", duckdb_database__initialize, 2);
     rb_define_private_method(cDuckDBDatabase, "_connect", duckdb_database_connect, 0);
     rb_define_method(cDuckDBDatabase, "close", duckdb_database_close, 0);

--- a/lib/duckdb/database.rb
+++ b/lib/duckdb/database.rb
@@ -50,7 +50,18 @@ module DuckDB
       #     con = db.connect
       #     con.query('CREATE TABLE users (id INTEGER, name VARCHAR(30))')
       #   end
-      def open(path = :memory, config: nil)
+      def open(path = :memory, *args, config: nil)
+        unless args.empty?
+          if args.first.is_a?(DuckDB::Config)
+            warn 'DuckDB::Database.open(path, config) is deprecated. Use DuckDB::Database.open(path, config: config) instead.'
+            config = args.first
+          else
+            raise TypeError, "expected DuckDB::Config, got #{args.first.class}"
+          end
+        end
+
+        path = :memory if path.nil?
+
         db = new(path, config: config)
         return db unless block_given?
 

--- a/lib/duckdb/database.rb
+++ b/lib/duckdb/database.rb
@@ -21,9 +21,6 @@ module DuckDB
   #     p row
   #   end
   class Database
-    private_class_method :_open
-    private_class_method :_open_ext
-
     # Opens a DuckDB database.
     #
     #   DuckDB::Database.new                    #=> in-memory database
@@ -43,36 +40,24 @@ module DuckDB
 
     class << self
       # Opens database.
-      # The first argument is DuckDB database file path to open.
-      # If there is no argument, the method opens DuckDB database in memory.
-      # The method yields block if block is given.
       #
-      #   DuckDB::Database.open('duckdb_database.db') #=> DuckDB::Database
-      #
-      #   DuckDB::Database.open #=> opens DuckDB::Database in memory.
+      #   DuckDB::Database.open                          #=> in-memory database
+      #   DuckDB::Database.open('test.db')               #=> file database
+      #   DuckDB::Database.open('test.db', config: config)
+      #   DuckDB::Database.open(config: config)          #=> in-memory with config
       #
       #   DuckDB::Database.open do |db|
       #     con = db.connect
       #     con.query('CREATE TABLE users (id INTEGER, name VARCHAR(30))')
       #   end
-      def open(dbpath = nil, config = nil)
-        db = _db_open(dbpath, config)
+      def open(path = :memory, config: nil)
+        db = new(path, config: config)
         return db unless block_given?
 
         begin
           yield db
         ensure
           db.close
-        end
-      end
-
-      private
-
-      def _db_open(dbpath, config) # :nodoc:
-        if config
-          _open_ext(dbpath, config)
-        else
-          _open(dbpath)
         end
       end
     end

--- a/lib/duckdb/database.rb
+++ b/lib/duckdb/database.rb
@@ -24,6 +24,23 @@ module DuckDB
     private_class_method :_open
     private_class_method :_open_ext
 
+    # Opens a DuckDB database.
+    #
+    #   DuckDB::Database.new                    #=> in-memory database
+    #   DuckDB::Database.new(:memory)           #=> in-memory database
+    #   DuckDB::Database.new('test.db')         #=> file database
+    #   DuckDB::Database.new('test.db', config: config) #=> with config
+    #   DuckDB::Database.new(config: config)    #=> in-memory with config
+    def initialize(path = :memory, config: nil, &block)
+      if path.is_a?(Symbol) && path != :memory
+        raise ArgumentError, "path must be a String or :memory, got #{path.inspect}"
+      end
+
+      dbpath = path == :memory ? nil : path
+      _initialize(dbpath, config)
+      _yield_self_and_close(&block) if block
+    end
+
     class << self
       # Opens database.
       # The first argument is DuckDB database file path to open.
@@ -59,6 +76,16 @@ module DuckDB
         end
       end
     end
+
+    private
+
+    def _yield_self_and_close
+      yield self
+    ensure
+      close
+    end
+
+    public
 
     # connects database.
     #

--- a/lib/duckdb/database.rb
+++ b/lib/duckdb/database.rb
@@ -51,16 +51,7 @@ module DuckDB
       #     con.query('CREATE TABLE users (id INTEGER, name VARCHAR(30))')
       #   end
       def open(path = :memory, *args, config: nil)
-        unless args.empty?
-          if args.first.is_a?(DuckDB::Config)
-            warn 'DuckDB::Database.open(path, config) is deprecated. Use DuckDB::Database.open(path, config: config) instead.'
-            config = args.first
-          else
-            raise TypeError, "expected DuckDB::Config, got #{args.first.class}"
-          end
-        end
-
-        path = :memory if path.nil?
+        path, config = _handle_deprecated_open_args(path, args, config)
 
         db = new(path, config: config)
         return db unless block_given?
@@ -70,6 +61,21 @@ module DuckDB
         ensure
           db.close
         end
+      end
+
+      private
+
+      def _handle_deprecated_open_args(path, args, config)
+        unless args.empty?
+          raise TypeError, "expected DuckDB::Config, got #{args.first.class}" unless args.first.is_a?(DuckDB::Config)
+
+          warn 'DuckDB::Database.open(path, config) is deprecated. ' \
+               'Use DuckDB::Database.open(path, config: config) instead.'
+          config = args.first
+        end
+
+        path = :memory if path.nil?
+        [path, config]
       end
     end
 

--- a/test/duckdb_test/config_test.rb
+++ b/test/duckdb_test/config_test.rb
@@ -60,7 +60,7 @@ module DuckDBTest
 
       assert_instance_of(DuckDB::Config, config.set_config('aaa_invalid_option', 'READ_ONLY'))
       assert_raises(DuckDB::Error) do
-        DuckDB::Database.open(nil, config)
+        DuckDB::Database.open(config: config)
       end
     end
 
@@ -77,7 +77,7 @@ module DuckDBTest
     def test_duckdb_api_config_set_to_ruby_custom
       config = DuckDB::Config.new
       config.set_config('threads', '2')
-      db = DuckDB::Database.open(nil, config)
+      db = DuckDB::Database.open(config: config)
       conn = db.connect
       result = conn.query('PRAGMA user_agent')
       user_agent = result.first[0]

--- a/test/duckdb_test/database_test.rb
+++ b/test/duckdb_test/database_test.rb
@@ -129,6 +129,31 @@ module DuckDBTest
       db.close
     end
 
+    def test_s_open_with_positional_config_deprecated
+      config = DuckDB::Config.new
+      config['access_mode'] = 'read_write'
+      db = nil
+
+      assert_output(nil, /deprecated/) { db = DuckDB::Database.open(nil, config) }
+
+      assert_instance_of(DuckDB::Database, db)
+      con = db.connect
+      result = con.execute("SELECT current_setting('access_mode') AS access_mode;")
+
+      assert_equal('read_write', result.first.first)
+      db.close
+    end
+
+    def test_s_open_with_path_and_positional_config_deprecated
+      config = DuckDB::Config.new
+      db = nil
+
+      assert_output(nil, /deprecated/) { db = DuckDB::Database.open(@path, config) }
+
+      assert_instance_of(DuckDB::Database, db)
+      db.close
+    end
+
     def test_close
       db = DuckDB::Database.open
       con = db.connect

--- a/test/duckdb_test/database_test.rb
+++ b/test/duckdb_test/database_test.rb
@@ -87,6 +87,7 @@ module DuckDBTest
       con = db.connect
       con.query('CREATE TABLE t (id INTEGER)')
       con.query('INSERT INTO t VALUES (1)')
+      con.disconnect
       db.close
 
       db2 = DuckDB::Database.open(@path)

--- a/test/duckdb_test/database_test.rb
+++ b/test/duckdb_test/database_test.rb
@@ -15,10 +15,6 @@ module DuckDBTest
       FileUtils.rm_f(walf)
     end
 
-    def test_s__open
-      assert_raises(NoMethodError) { DuckDB::Database._open }
-    end
-
     def test_s_open
       assert_instance_of(DuckDB::Database, DuckDB::Database.open)
     end
@@ -31,25 +27,25 @@ module DuckDBTest
     end
 
     def test_s_open_type_errors
-      assert_raises(TypeError) { DuckDB::Database.open('foo', 'bar') }
       assert_raises(TypeError) { DuckDB::Database.open(1) }
     end
 
     def test_s_open_invalid_path
       not_exist_path = "#{create_path}/#{create_path}"
+
       assert_raises(DuckDB::Error) { DuckDB::Database.open(not_exist_path) }
     end
 
     def test_s_open_with_config
       config = DuckDB::Config.new
-      db = DuckDB::Database.open(nil, config)
+      db = DuckDB::Database.open(config: config)
       conn = db.connect
       r = conn.execute("SELECT current_setting('access_mode') AS access_mode;")
 
       assert_equal('automatic', r.first.first)
 
       config['access_mode'] = 'read_write'
-      db = DuckDB::Database.open(nil, config)
+      db = DuckDB::Database.open(config: config)
       conn = db.connect
       r = conn.execute("SELECT current_setting('access_mode') AS access_mode;")
 
@@ -81,6 +77,56 @@ module DuckDBTest
       end
 
       assert_instance_of(DuckDB::Result, result)
+    end
+
+    def test_s_open_with_path_file
+      db = DuckDB::Database.open(@path)
+
+      assert_instance_of(DuckDB::Database, db)
+
+      con = db.connect
+      con.query('CREATE TABLE t (id INTEGER)')
+      con.query('INSERT INTO t VALUES (1)')
+      db.close
+
+      db2 = DuckDB::Database.open(@path)
+      result = db2.connect.query('SELECT * FROM t')
+
+      assert_equal([[1]], result.to_a)
+      db2.close
+    end
+
+    def test_s_open_with_block
+      result = DuckDB::Database.open(:memory) do |db|
+        assert_instance_of(DuckDB::Database, db)
+
+        con = db.connect
+        con.query('CREATE TABLE t (id INTEGER)')
+      end
+
+      assert_instance_of(DuckDB::Result, result)
+    end
+
+    def test_s_open_with_config_keyword
+      config = DuckDB::Config.new
+      config['access_mode'] = 'read_write'
+      db = DuckDB::Database.open(config: config)
+      con = db.connect
+      result = con.execute("SELECT current_setting('access_mode') AS access_mode;")
+
+      assert_equal('read_write', result.first.first)
+      db.close
+    end
+
+    def test_s_open_with_memory_symbol
+      db = DuckDB::Database.open(:memory)
+
+      assert_instance_of(DuckDB::Database, db)
+
+      con = db.connect
+
+      assert_instance_of(DuckDB::Connection, con)
+      db.close
     end
 
     def test_close

--- a/test/duckdb_test/duckdb_new_test.rb
+++ b/test/duckdb_test/duckdb_new_test.rb
@@ -87,6 +87,7 @@ module DuckDBTest
       con = db.connect
       con.query('CREATE TABLE t (id INTEGER)')
       con.query('INSERT INTO t VALUES (42)')
+      con.disconnect
       db.close
 
       db2 = DuckDB::Database.new(@path)

--- a/test/duckdb_test/duckdb_new_test.rb
+++ b/test/duckdb_test/duckdb_new_test.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module DuckDBTest
+  class DuckDBDatabaseNewTest < Minitest::Test
+    def setup
+      @path = "#{Time.now.strftime('%Y%m%d%H%M%S')}-#{Process.pid}-#{rand(100..999)}"
+    end
+
+    def teardown
+      FileUtils.rm_f(@path)
+      FileUtils.rm_f("#{@path}.wal")
+    end
+
+    def test_database_new
+      db = DuckDB::Database.new
+
+      assert_instance_of(DuckDB::Database, db)
+
+      con = db.connect
+
+      assert_instance_of(DuckDB::Connection, con)
+      db.close
+    end
+
+    def test_database_new_with_memory_symbol
+      db = DuckDB::Database.new(:memory)
+
+      assert_instance_of(DuckDB::Database, db)
+
+      con = db.connect
+
+      assert_instance_of(DuckDB::Connection, con)
+      db.close
+    end
+
+    def test_database_new_with_config
+      config = DuckDB::Config.new
+      config['access_mode'] = 'read_write'
+      db = DuckDB::Database.new(config: config)
+      con = db.connect
+      result = con.execute("SELECT current_setting('access_mode') AS access_mode;")
+
+      assert_equal('read_write', result.first.first)
+      db.close
+    end
+
+    def test_database_new_with_invalid_path_type
+      assert_raises(TypeError) { DuckDB::Database.new(123) }
+    end
+
+    def test_database_new_with_invalid_path_symbol
+      assert_raises(ArgumentError) { DuckDB::Database.new(:foo) }
+    end
+
+    def test_database_new_with_invalid_config
+      assert_raises(TypeError) { DuckDB::Database.new(config: 'bad') }
+    end
+
+    def test_database_new_with_invalid_path_directory
+      not_exist = "#{@path}/#{@path}"
+
+      assert_raises(DuckDB::Error) { DuckDB::Database.new(not_exist) }
+    end
+
+    def test_database_new_with_block
+      db = DuckDB::Database.new do |d|
+        assert_instance_of(DuckDB::Database, d)
+
+        con = d.connect
+        con.query('CREATE TABLE t (id INTEGER)')
+      end
+
+      assert_instance_of(DuckDB::Database, db)
+    end
+
+    def test_database_new_with_path
+      db = DuckDB::Database.new(@path)
+
+      assert_instance_of(DuckDB::Database, db)
+      db.close
+    end
+
+    def test_database_new_with_path_persists_data
+      db = DuckDB::Database.new(@path)
+      con = db.connect
+      con.query('CREATE TABLE t (id INTEGER)')
+      con.query('INSERT INTO t VALUES (42)')
+      db.close
+
+      db2 = DuckDB::Database.new(@path)
+      result = db2.connect.query('SELECT * FROM t')
+
+      assert_equal([[42]], result.to_a)
+      db2.close
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Update the CHANGELOG entry for `DuckDB::Database.new` to include:

- `&block` parameter in the signature
- Description that the database is yielded and automatically closed when a block is given

### Before
```
- add `DuckDB::Database.new(path = :memory, config: nil)` to create a database instance. ...
```

### After
```
- add `DuckDB::Database.new(path = :memory, config: nil, &block)` to create a database instance. ... When a block is given, the database is yielded and automatically closed afterwards.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Database.new with in-memory (default) or file-backed creation, optional config:, and block form that auto-closes.

* **Breaking Changes**
  * Database.open now delegates to new and accepts path = :memory plus config: keyword; legacy positional config usage emits deprecation warnings.

* **Tests**
  * Expanded tests covering initialization variants, config behavior, error cases, block form, and persistence.

* **Documentation**
  * Changelog updated to document the new initialization API and breaking-change notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->