### PR TITLE
Enable bundler caching in CI workflows

### DIFF
--- a/.github/workflows/test_on_macos.yml
+++ b/.github/workflows/test_on_macos.yml
@@ -54,10 +54,6 @@ jobs:
         mkdir libduckdb-osx-universal
         unzip libduckdb-osx-universal.zip -d libduckdb-osx-universal
 
-    - name: bundle install with Ruby ${{ matrix.ruby }}
-      run: |
-        bundle install --jobs 4 --retry 3
-
     - name: Build test with DUCKDB_API_NO_DEPRECATED and Ruby ${{ matrix.ruby }}
       run: |
         env DUCKDB_API_NO_DEPRECATED=1 bundle exec rake build -- --with-duckdb-include=${GITHUB_WORKSPACE}/libduckdb-osx-universal --with-duckdb-lib=${GITHUB_WORKSPACE}/libduckdb-osx-universal

--- a/.github/workflows/test_on_macos.yml
+++ b/.github/workflows/test_on_macos.yml
@@ -30,6 +30,7 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
+        bundler-cache: true
 
     - name: duckdb cache
       id: duckdb-cache

--- a/.github/workflows/test_on_macos.yml
+++ b/.github/workflows/test_on_macos.yml
@@ -90,7 +90,7 @@ jobs:
         MYSQL_TEST: 1
         DYLD_LIBRARY_PATH: ${{ github.workspace }}/libduckdb-osx-universal
       run: |
-        env RUBYOPT=-W:deprecated rake test
+        env RUBYOPT=-W:deprecated bundle exec rake test
 
   post-test:
     name: All tests passed on macos

--- a/.github/workflows/test_on_ubuntu.yml
+++ b/.github/workflows/test_on_ubuntu.yml
@@ -71,10 +71,6 @@ jobs:
         sudo cp libduckdb-linux-amd64/libduckdb.so /usr/local/lib/
         sudo ldconfig
 
-    - name: bundle install with Ruby ${{ matrix.ruby }}
-      run: |
-        bundle install --jobs 4 --retry 3
-
     - name: Build test with DUCKDB_API_NO_DEPRECATED and Ruby ${{ matrix.ruby }}
       run: |
         env DUCKDB_API_NO_DEPRECATED=1 bundle exec rake build -- --with-duckdb-include=${GITHUB_WORKSPACE}/libduckdb-linux-amd64 --with-duckdb-lib=${GITHUB_WORKSPACE}/libduckdb-linux-amd64

--- a/.github/workflows/test_on_ubuntu.yml
+++ b/.github/workflows/test_on_ubuntu.yml
@@ -42,6 +42,7 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
+        bundler-cache: true
 
     - name: duckdb cache
       id: duckdb-cache

--- a/.github/workflows/test_on_ubuntu.yml
+++ b/.github/workflows/test_on_ubuntu.yml
@@ -95,7 +95,7 @@ jobs:
       env:
         MYSQL_TEST: 1
       run: |
-        env RUBYOPT=-W:deprecated rake test
+        env RUBYOPT=-W:deprecated bundle exec rake test
 
   post-test:
     name: All tests passed on Ubuntu

--- a/.github/workflows/test_on_windows.yml
+++ b/.github/workflows/test_on_windows.yml
@@ -54,7 +54,6 @@ jobs:
 
     - name: Build with Rake with Ruby ${{ matrix.ruby }}
       run: |
-        bundle install
         bundle exec rake build -- --with-duckdb-include=../../../../libduckdb-windows-amd64 --with-duckdb-lib=../../../../libduckdb-windows-amd64
 
     - name: rake test

--- a/.github/workflows/test_on_windows.yml
+++ b/.github/workflows/test_on_windows.yml
@@ -30,6 +30,7 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
+        bundler-cache: true
 
     - name: duckdb cache
       id: duckdb-cache

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,6 +58,9 @@ PLATFORMS
   aarch64-linux
   arm-linux
   arm64-darwin
+  x64-mingw-ucrt
+  x64-mingw32
+  x64-mswin64
   x86-linux
   x86_64-darwin
   x86_64-linux


### PR DESCRIPTION
This PR adds `bundler-cache: true` to the `ruby/setup-ruby` action across all three platforms (Windows, Ubuntu, macOS).

## Benefits
- Speeds up CI runs by caching gem dependencies
- Reduces gem download/install time on subsequent runs
- Works consistently across all platforms

## Changes
- Updated `.github/workflows/test_on_windows.yml`
- Updated `.github/workflows/test_on_ubuntu.yml`
- Updated `.github/workflows/test_on_macos.yml`

The `bundler-cache` feature is built into `ruby/setup-ruby@v1` and automatically caches based on `Gemfile.lock`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI updated to enable Bundler dependency caching across macOS, Ubuntu, and Windows workflows, removing redundant explicit install steps—resulting in faster builds, reduced redundant work, and more stable automated test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->