### PR TITLE
Add DuckDB::TableDescription and DuckDB::ColumnDescription

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,8 +31,8 @@ All notable changes to this project will be documented in this file.
 - add `DuckDB::Appender#append_data_chunk` to append a `DuckDB::DataChunk` in one call.
 - add `DuckDB::DataChunk.new(types)` to create an owned data chunk from Ruby logical types.
 - add `DuckDB::AggregateFunction`.
-- add `DuckDB::TableDescription` to retrieve metadata about a table.
-- add `DuckDB::ColumnDescription` to describe a column's name, logical type, and whether it has a default value.
+- add `DuckDB::TableDescription` to retrieve metadata about a table (with DuckDB >= 1.5.0).
+- add `DuckDB::ColumnDescription` to describe a column's name, logical type, and whether it has a default value (with DuckDB >= 1.5.0).
 
 ## Breaking Changes
 - rename `DuckDB::ValueImpl` to `DuckDB::Value`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ All notable changes to this project will be documented in this file.
 - add `DuckDB::Appender#append_data_chunk` to append a `DuckDB::DataChunk` in one call.
 - add `DuckDB::DataChunk.new(types)` to create an owned data chunk from Ruby logical types.
 - add `DuckDB::AggregateFunction`.
+- add `DuckDB::TableDescription` to retrieve metadata about a table.
+- add `DuckDB::ColumnDescription` to describe a column's name, logical type, and whether it has a default value.
 
 ## Breaking Changes
 - rename `DuckDB::ValueImpl` to `DuckDB::Value`

--- a/ext/duckdb/duckdb.c
+++ b/ext/duckdb/duckdb.c
@@ -69,4 +69,5 @@ Init_duckdb_native(void) {
     rbduckdb_init_duckdb_table_function_bind_info();
     rbduckdb_init_duckdb_table_function_init_info();
     rbduckdb_init_duckdb_table_function_function_info();
+    rbduckdb_init_duckdb_table_description();
 }

--- a/ext/duckdb/duckdb.c
+++ b/ext/duckdb/duckdb.c
@@ -69,5 +69,7 @@ Init_duckdb_native(void) {
     rbduckdb_init_duckdb_table_function_bind_info();
     rbduckdb_init_duckdb_table_function_init_info();
     rbduckdb_init_duckdb_table_function_function_info();
+#ifdef HAVE_DUCKDB_H_GE_V1_5_0
     rbduckdb_init_duckdb_table_description();
+#endif
 }

--- a/ext/duckdb/ruby-duckdb.h
+++ b/ext/duckdb/ruby-duckdb.h
@@ -44,6 +44,7 @@
 #include "./data_chunk.h"
 #include "./memory_helper.h"
 #include "./table_function.h"
+#include "./table_description.h"
 
 extern VALUE mDuckDB;
 extern VALUE cDuckDBDatabase;

--- a/ext/duckdb/table_description.c
+++ b/ext/duckdb/table_description.c
@@ -1,0 +1,141 @@
+#include "ruby-duckdb.h"
+
+VALUE cDuckDBTableDescription;
+
+static void deallocate(void *ctx);
+static VALUE allocate(VALUE klass);
+static size_t memsize(const void *p);
+static rubyDuckDBTableDescription *get_struct_table_description(VALUE obj);
+static VALUE rbduckdb_table_description_error_message(VALUE self);
+static VALUE duckdb_table_description__initialize(VALUE self, VALUE conn, VALUE catalog, VALUE schema, VALUE table);
+static VALUE duckdb_table_description__column_count(VALUE self);
+static VALUE duckdb_table_description__column_name(VALUE self, VALUE idx);
+static VALUE duckdb_table_description__column_logical_type(VALUE self, VALUE idx);
+static VALUE duckdb_table_description__column_has_default(VALUE self, VALUE idx);
+
+static const rb_data_type_t table_description_data_type = {
+    "DuckDB/TableDescription",
+    {NULL, deallocate, memsize,},
+    0, 0, RUBY_TYPED_FREE_IMMEDIATELY
+};
+
+static void deallocate(void *ctx) {
+    rubyDuckDBTableDescription *p = (rubyDuckDBTableDescription *)ctx;
+
+    if (p->table_description) {
+        duckdb_table_description_destroy(&(p->table_description));
+    }
+    xfree(p);
+}
+
+static VALUE allocate(VALUE klass) {
+    rubyDuckDBTableDescription *ctx = xcalloc((size_t)1, sizeof(rubyDuckDBTableDescription));
+    return TypedData_Wrap_Struct(klass, &table_description_data_type, ctx);
+}
+
+static size_t memsize(const void *p) {
+    return sizeof(rubyDuckDBTableDescription);
+}
+
+static rubyDuckDBTableDescription *get_struct_table_description(VALUE obj) {
+    rubyDuckDBTableDescription *ctx;
+    TypedData_Get_Struct(obj, rubyDuckDBTableDescription, &table_description_data_type, ctx);
+    return ctx;
+}
+
+static VALUE rbduckdb_table_description_error_message(VALUE self) {
+    rubyDuckDBTableDescription *ctx = get_struct_table_description(self);
+    const char *p = duckdb_table_description_error(ctx->table_description);
+    return p ? rb_str_new2(p) : Qnil;
+}
+
+/* nodoc */
+static VALUE duckdb_table_description__initialize(VALUE self, VALUE con, VALUE catalog, VALUE schema, VALUE table) {
+    char *pcatalog = NULL;
+    char *pschema = NULL;
+    char *ptable = NULL;
+    duckdb_state state;
+    rubyDuckDBTableDescription *ctx;
+    rubyDuckDBConnection *ctxcon;
+
+    if (!NIL_P(catalog)) {
+        pcatalog = StringValuePtr(catalog);
+    }
+    if (!NIL_P(schema)) {
+        pschema = StringValuePtr(schema);
+    }
+    if (!NIL_P(table)) {
+        ptable = StringValuePtr(table);
+    }
+    ctxcon = get_struct_connection(con);
+    ctx = get_struct_table_description(self);
+
+    if (ctx->table_description) {
+        duckdb_table_description_destroy(&ctx->table_description);
+    }
+
+    if (pcatalog) {
+        state = duckdb_table_description_create_ext(ctxcon->con, pcatalog, pschema, ptable, &ctx->table_description);
+    } else {
+        state = duckdb_table_description_create(ctxcon->con, pschema, ptable, &ctx->table_description);
+    }
+    if (state == DuckDBError) {
+        return Qfalse;
+    }
+    return Qtrue;
+}
+
+/* nodoc */
+static VALUE duckdb_table_description__column_count(VALUE self) {
+    rubyDuckDBTableDescription *ctx;
+    ctx = get_struct_table_description(self);
+    return ULL2NUM(duckdb_table_description_get_column_count(ctx->table_description));
+}
+
+/* nodoc */
+static VALUE duckdb_table_description__column_name(VALUE self, VALUE idx) {
+    VALUE name = Qnil;
+    rubyDuckDBTableDescription *ctx;
+    ctx = get_struct_table_description(self);
+    char *p = duckdb_table_description_get_column_name(ctx->table_description, NUM2ULL(idx));
+    if (p) {
+        name = rb_utf8_str_new_cstr(p);
+        duckdb_free(p);
+    }
+    return name;
+}
+
+/* nodoc */
+static VALUE duckdb_table_description__column_logical_type(VALUE self, VALUE idx) {
+    rubyDuckDBTableDescription *ctx;
+    duckdb_logical_type lt;
+    ctx = get_struct_table_description(self);
+    lt = duckdb_table_description_get_column_type(ctx->table_description, NUM2ULL(idx));
+    return rbduckdb_create_logical_type(lt);
+}
+
+static VALUE duckdb_table_description__column_has_default(VALUE self, VALUE idx) {
+    rubyDuckDBTableDescription *ctx;
+    bool has_default;
+    ctx = get_struct_table_description(self);
+    duckdb_state state = duckdb_column_has_default(ctx->table_description, NUM2ULL(idx), &has_default);
+    if (state == DuckDBError) {
+        return Qnil;
+    }
+    return has_default ? Qtrue : Qfalse;
+}
+
+void rbduckdb_init_duckdb_table_description(void) {
+#if 0
+    VALUE mDuckDB = rb_define_module("DuckDB");
+#endif
+    cDuckDBTableDescription = rb_define_class_under(mDuckDB, "TableDescription", rb_cObject);
+    rb_define_alloc_func(cDuckDBTableDescription, allocate);
+    rb_define_method(cDuckDBTableDescription, "error_message", rbduckdb_table_description_error_message, 0);
+    rb_define_private_method(cDuckDBTableDescription, "_initialize", duckdb_table_description__initialize, 4);
+    rb_define_private_method(cDuckDBTableDescription, "_column_count", duckdb_table_description__column_count, 0);
+    rb_define_private_method(cDuckDBTableDescription, "_column_name", duckdb_table_description__column_name, 1);
+    rb_define_private_method(cDuckDBTableDescription, "_column_logical_type", duckdb_table_description__column_logical_type, 1);
+    rb_define_private_method(cDuckDBTableDescription, "_column_has_default", duckdb_table_description__column_has_default, 1);
+}
+

--- a/ext/duckdb/table_description.c
+++ b/ext/duckdb/table_description.c
@@ -1,5 +1,7 @@
 #include "ruby-duckdb.h"
 
+#ifdef HAVE_DUCKDB_H_GE_V1_5_0
+
 VALUE cDuckDBTableDescription;
 
 static void deallocate(void *ctx);
@@ -8,6 +10,7 @@ static size_t memsize(const void *p);
 static rubyDuckDBTableDescription *get_struct_table_description(VALUE obj);
 static VALUE rbduckdb_table_description_error_message(VALUE self);
 static VALUE duckdb_table_description__initialize(VALUE self, VALUE conn, VALUE catalog, VALUE schema, VALUE table);
+
 static VALUE duckdb_table_description__column_count(VALUE self);
 static VALUE duckdb_table_description__column_name(VALUE self, VALUE idx);
 static VALUE duckdb_table_description__column_logical_type(VALUE self, VALUE idx);
@@ -138,4 +141,4 @@ void rbduckdb_init_duckdb_table_description(void) {
     rb_define_private_method(cDuckDBTableDescription, "_column_logical_type", duckdb_table_description__column_logical_type, 1);
     rb_define_private_method(cDuckDBTableDescription, "_column_has_default", duckdb_table_description__column_has_default, 1);
 }
-
+#endif

--- a/ext/duckdb/table_description.h
+++ b/ext/duckdb/table_description.h
@@ -1,6 +1,8 @@
 #ifndef RUBY_DUCKDB_TABLE_DESCRIPTION_H
 #define RUBY_DUCKDB_TABLE_DESCRIPTION_H
 
+#ifdef HAVE_DUCKDB_H_GE_V1_5_0
+
 struct _rubyDuckDBTableDescription {
     duckdb_table_description table_description;
 };
@@ -8,5 +10,7 @@ struct _rubyDuckDBTableDescription {
 typedef struct _rubyDuckDBTableDescription rubyDuckDBTableDescription;
 
 void rbduckdb_init_duckdb_table_description(void);
+
+#endif /* HAVE_DUCKDB_H_GE_V1_5_0 */
 
 #endif

--- a/ext/duckdb/table_description.h
+++ b/ext/duckdb/table_description.h
@@ -1,0 +1,12 @@
+#ifndef RUBY_DUCKDB_TABLE_DESCRIPTION_H
+#define RUBY_DUCKDB_TABLE_DESCRIPTION_H
+
+struct _rubyDuckDBTableDescription {
+    duckdb_table_description table_description;
+};
+
+typedef struct _rubyDuckDBTableDescription rubyDuckDBTableDescription;
+
+void rbduckdb_init_duckdb_table_description(void);
+
+#endif

--- a/lib/duckdb.rb
+++ b/lib/duckdb.rb
@@ -31,6 +31,8 @@ require 'duckdb/infinity'
 require 'duckdb/instance_cache'
 require 'duckdb/casting'
 require 'duckdb/value'
+require 'duckdb/table_description'
+require 'duckdb/column_description'
 
 # DuckDB provides Ruby interface of DuckDB.
 module DuckDB

--- a/lib/duckdb/column_description.rb
+++ b/lib/duckdb/column_description.rb
@@ -1,28 +1,32 @@
 # frozen_string_literal: true
 
 module DuckDB
-  # DuckDB::ColumnDescription is an immutable value object describing a single
-  # column returned by DuckDB::TableDescription#column_descriptions.
-  #
-  # It is defined using +Data.define+ and exposes three attributes:
-  #
-  # - +name+ — the column name as a String
-  # - +logical_type+ — a DuckDB::LogicalType representing the column's type
-  # - +has_default+ — +true+ if the column has a DEFAULT value, +false+ otherwise
-  #
-  # A predicate alias +has_default?+ is provided for idiomatic Ruby usage.
-  #
-  #   require 'duckdb'
-  #   db = DuckDB::Database.open
-  #   con = db.connect
-  #   con.query("CREATE TABLE t (id INTEGER, name VARCHAR DEFAULT 'anon')")
-  #
-  #   td = DuckDB::TableDescription.new(con, 't')
-  #   cd = td.column_descriptions.last
-  #   cd.name          #=> "name"
-  #   cd.logical_type.type  #=> :varchar
-  #   cd.has_default?  #=> true
-  ColumnDescription = Data.define(:name, :logical_type, :has_default) do
-    alias_method :has_default?, :has_default
+  if defined?(DuckDB::TableDescription)
+    # DuckDB::ColumnDescription is an immutable value object describing a single
+    # column returned by DuckDB::TableDescription#column_descriptions.
+    #
+    # It is defined using +Data.define+ and exposes three attributes:
+    #
+    # - +name+ — the column name as a String
+    # - +logical_type+ — a DuckDB::LogicalType representing the column's type
+    # - +has_default+ — +true+ if the column has a DEFAULT value, +false+ otherwise
+    #
+    # A predicate alias +has_default?+ is provided for idiomatic Ruby usage.
+    #
+    # Requires DuckDB >= 1.5.0.
+    #
+    #   require 'duckdb'
+    #   db = DuckDB::Database.open
+    #   con = db.connect
+    #   con.query("CREATE TABLE t (id INTEGER, name VARCHAR DEFAULT 'anon')")
+    #
+    #   td = DuckDB::TableDescription.new(con, 't')
+    #   cd = td.column_descriptions.last
+    #   cd.name               #=> "name"
+    #   cd.logical_type.type  #=> :varchar
+    #   cd.has_default?       #=> true
+    ColumnDescription = Data.define(:name, :logical_type, :has_default) do
+      alias_method :has_default?, :has_default
+    end
   end
 end

--- a/lib/duckdb/column_description.rb
+++ b/lib/duckdb/column_description.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module DuckDB
+  # DuckDB::ColumnDescription is an immutable value object describing a single
+  # column returned by DuckDB::TableDescription#column_descriptions.
+  #
+  # It is defined using +Data.define+ and exposes three attributes:
+  #
+  # - +name+ — the column name as a String
+  # - +logical_type+ — a DuckDB::LogicalType representing the column's type
+  # - +has_default+ — +true+ if the column has a DEFAULT value, +false+ otherwise
+  #
+  # A predicate alias +has_default?+ is provided for idiomatic Ruby usage.
+  #
+  #   require 'duckdb'
+  #   db = DuckDB::Database.open
+  #   con = db.connect
+  #   con.query("CREATE TABLE t (id INTEGER, name VARCHAR DEFAULT 'anon')")
+  #
+  #   td = DuckDB::TableDescription.new(con, 't')
+  #   cd = td.column_descriptions.last
+  #   cd.name          #=> "name"
+  #   cd.logical_type.type  #=> :varchar
+  #   cd.has_default?  #=> true
+  ColumnDescription = Data.define(:name, :logical_type, :has_default) do
+    alias_method :has_default?, :has_default
+  end
+end

--- a/lib/duckdb/table_description.rb
+++ b/lib/duckdb/table_description.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+module DuckDB
+  # DuckDB::TableDescription provides metadata about a table in DuckDB.
+  #
+  # Use it to retrieve column descriptions — including name, logical type, and
+  # whether a column has a default value — for any accessible table.
+  #
+  #   require 'duckdb'
+  #   db = DuckDB::Database.open
+  #   con = db.connect
+  #   con.query('CREATE TABLE users (id INTEGER, name VARCHAR DEFAULT \'anonymous\')')
+  #
+  #   td = DuckDB::TableDescription.new(con, 'users')
+  #   td.column_descriptions.each do |cd|
+  #     puts "#{cd.name}: #{cd.logical_type.type}, default=#{cd.has_default?}"
+  #   end
+  #   # id: integer, default=false
+  #   # name: varchar, default=true
+  class TableDescription
+    # Creates a new TableDescription for the given table.
+    #
+    # +con+ must be a DuckDB::Connection. +table+ is the table name (String).
+    # Optionally pass +schema:+ and/or +catalog:+ to qualify the table.
+    #
+    # Raises DuckDB::Error if the connection is invalid, the table name is nil,
+    # or the table (or schema/catalog) does not exist.
+    #
+    #   require 'duckdb'
+    #   db = DuckDB::Database.open
+    #   con = db.connect
+    #   con.query('CREATE TABLE t (i INTEGER)')
+    #
+    #   DuckDB::TableDescription.new(con, 't')
+    #   DuckDB::TableDescription.new(con, 't', schema: 'main')
+    def initialize(con, table, schema: nil, catalog: nil)
+      raise DuckDB::Error, '1st argument must be DuckDB::Connection object.' unless con.is_a?(DuckDB::Connection)
+      raise DuckDB::Error, '2nd argument must be table name.' if table.nil?
+
+      raise DuckDB::Error, error_message unless _initialize(con, catalog, schema, table)
+    end
+
+    # Returns an array of DuckDB::ColumnDescription objects, one per column.
+    #
+    # Each element describes a single column's name, logical type, and whether
+    # it has a default value defined.
+    #
+    #   require 'duckdb'
+    #   db = DuckDB::Database.open
+    #   con = db.connect
+    #   con.query("CREATE TABLE t (i INTEGER, j INTEGER DEFAULT 5)")
+    #
+    #   td = DuckDB::TableDescription.new(con, 't')
+    #   td.column_descriptions
+    #   #=> [#<data DuckDB::ColumnDescription name="i" ...>, ...]
+    def column_descriptions
+      Array.new(_column_count) do |i|
+        ColumnDescription.new(
+          name: _column_name(i),
+          logical_type: _column_logical_type(i),
+          has_default: _column_has_default?(i)
+        )
+      end
+    end
+
+    private
+
+    def _column_has_default?(idx)
+      ret = _column_has_default(idx)
+      raise DuckDB::Error, error_message || 'failed to determine column has default' if ret.nil?
+
+      ret
+    end
+  end
+end

--- a/lib/duckdb/table_description.rb
+++ b/lib/duckdb/table_description.rb
@@ -1,75 +1,79 @@
 # frozen_string_literal: true
 
 module DuckDB
-  # DuckDB::TableDescription provides metadata about a table in DuckDB.
-  #
-  # Use it to retrieve column descriptions — including name, logical type, and
-  # whether a column has a default value — for any accessible table.
-  #
-  #   require 'duckdb'
-  #   db = DuckDB::Database.open
-  #   con = db.connect
-  #   con.query('CREATE TABLE users (id INTEGER, name VARCHAR DEFAULT \'anonymous\')')
-  #
-  #   td = DuckDB::TableDescription.new(con, 'users')
-  #   td.column_descriptions.each do |cd|
-  #     puts "#{cd.name}: #{cd.logical_type.type}, default=#{cd.has_default?}"
-  #   end
-  #   # id: integer, default=false
-  #   # name: varchar, default=true
-  class TableDescription
-    # Creates a new TableDescription for the given table.
+  if defined?(DuckDB::TableDescription)
+    # DuckDB::TableDescription provides metadata about a table in DuckDB.
     #
-    # +con+ must be a DuckDB::Connection. +table+ is the table name (String).
-    # Optionally pass +schema:+ and/or +catalog:+ to qualify the table.
+    # Use it to retrieve column descriptions — including name, logical type, and
+    # whether a column has a default value — for any accessible table.
     #
-    # Raises DuckDB::Error if the connection is invalid, the table name is nil,
-    # or the table (or schema/catalog) does not exist.
+    # Requires DuckDB >= 1.5.0.
     #
     #   require 'duckdb'
     #   db = DuckDB::Database.open
     #   con = db.connect
-    #   con.query('CREATE TABLE t (i INTEGER)')
+    #   con.query('CREATE TABLE users (id INTEGER, name VARCHAR DEFAULT \'anonymous\')')
     #
-    #   DuckDB::TableDescription.new(con, 't')
-    #   DuckDB::TableDescription.new(con, 't', schema: 'main')
-    def initialize(con, table, schema: nil, catalog: nil)
-      raise DuckDB::Error, '1st argument must be DuckDB::Connection object.' unless con.is_a?(DuckDB::Connection)
-      raise DuckDB::Error, '2nd argument must be table name.' if table.nil?
+    #   td = DuckDB::TableDescription.new(con, 'users')
+    #   td.column_descriptions.each do |cd|
+    #     puts "#{cd.name}: #{cd.logical_type.type}, default=#{cd.has_default?}"
+    #   end
+    #   # id: integer, default=false
+    #   # name: varchar, default=true
+    class TableDescription
+      # Creates a new TableDescription for the given table.
+      #
+      # +con+ must be a DuckDB::Connection. +table+ is the table name (String).
+      # Optionally pass +schema:+ and/or +catalog:+ to qualify the table.
+      #
+      # Raises DuckDB::Error if the connection is invalid, the table name is nil,
+      # or the table (or schema/catalog) does not exist.
+      #
+      #   require 'duckdb'
+      #   db = DuckDB::Database.open
+      #   con = db.connect
+      #   con.query('CREATE TABLE t (i INTEGER)')
+      #
+      #   DuckDB::TableDescription.new(con, 't')
+      #   DuckDB::TableDescription.new(con, 't', schema: 'main')
+      def initialize(con, table, schema: nil, catalog: nil)
+        raise DuckDB::Error, '1st argument must be DuckDB::Connection object.' unless con.is_a?(DuckDB::Connection)
+        raise DuckDB::Error, '2nd argument must be table name.' if table.nil?
 
-      raise DuckDB::Error, error_message unless _initialize(con, catalog, schema, table)
-    end
-
-    # Returns an array of DuckDB::ColumnDescription objects, one per column.
-    #
-    # Each element describes a single column's name, logical type, and whether
-    # it has a default value defined.
-    #
-    #   require 'duckdb'
-    #   db = DuckDB::Database.open
-    #   con = db.connect
-    #   con.query("CREATE TABLE t (i INTEGER, j INTEGER DEFAULT 5)")
-    #
-    #   td = DuckDB::TableDescription.new(con, 't')
-    #   td.column_descriptions
-    #   #=> [#<data DuckDB::ColumnDescription name="i" ...>, ...]
-    def column_descriptions
-      Array.new(_column_count) do |i|
-        ColumnDescription.new(
-          name: _column_name(i),
-          logical_type: _column_logical_type(i),
-          has_default: _column_has_default?(i)
-        )
+        raise DuckDB::Error, error_message unless _initialize(con, catalog, schema, table)
       end
-    end
 
-    private
+      # Returns an array of DuckDB::ColumnDescription objects, one per column.
+      #
+      # Each element describes a single column's name, logical type, and whether
+      # it has a default value defined.
+      #
+      #   require 'duckdb'
+      #   db = DuckDB::Database.open
+      #   con = db.connect
+      #   con.query("CREATE TABLE t (i INTEGER, j INTEGER DEFAULT 5)")
+      #
+      #   td = DuckDB::TableDescription.new(con, 't')
+      #   td.column_descriptions
+      #   #=> [#<data DuckDB::ColumnDescription name="i" ...>, ...]
+      def column_descriptions
+        Array.new(_column_count) do |i|
+          ColumnDescription.new(
+            name: _column_name(i),
+            logical_type: _column_logical_type(i),
+            has_default: _column_has_default?(i)
+          )
+        end
+      end
 
-    def _column_has_default?(idx)
-      ret = _column_has_default(idx)
-      raise DuckDB::Error, error_message || 'failed to determine column has default' if ret.nil?
+      private
 
-      ret
+      def _column_has_default?(idx)
+        ret = _column_has_default(idx)
+        raise DuckDB::Error, error_message || 'failed to determine column has default' if ret.nil?
+
+        ret
+      end
     end
   end
 end

--- a/test/duckdb_test/column_description_test.rb
+++ b/test/duckdb_test/column_description_test.rb
@@ -3,7 +3,8 @@
 require 'test_helper'
 
 module DuckDBTest
-  class ColumnDescriptionTest < Minitest::Test
+  if defined?(DuckDB::TableDescription)
+  class ColumnDescriptionTest < Minitest::Test # rubocop:disable Layout/IndentationWidth
     def setup
       @db = DuckDB::Database.open
       @con = @db.connect
@@ -40,5 +41,6 @@ module DuckDBTest
       refute_predicate(cds[0], :has_default?)
       assert_predicate(cds[1], :has_default?)
     end
+  end
   end
 end

--- a/test/duckdb_test/column_description_test.rb
+++ b/test/duckdb_test/column_description_test.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module DuckDBTest
+  class ColumnDescriptionTest < Minitest::Test
+    def setup
+      @db = DuckDB::Database.open
+      @con = @db.connect
+    end
+
+    def teardown
+      @con&.close
+      @db&.close
+    end
+
+    def test_name
+      @con.query("CREATE TABLE t (i INTEGER, j VARCHAR DEFAULT 'foo')")
+      td = DuckDB::TableDescription.new(@con, 't')
+      cds = td.column_descriptions
+
+      assert_equal('i', cds[0].name)
+      assert_equal('j', cds[1].name)
+    end
+
+    def test_logical_type
+      @con.query("CREATE TABLE t (i INTEGER, j VARCHAR DEFAULT 'foo')")
+      td = DuckDB::TableDescription.new(@con, 't')
+      cds = td.column_descriptions
+
+      assert_equal(:integer, cds[0].logical_type.type)
+      assert_equal(:varchar, cds[1].logical_type.type)
+    end
+
+    def test_has_default
+      @con.query("CREATE TABLE t (i INTEGER, j VARCHAR DEFAULT 'foo')")
+      td = DuckDB::TableDescription.new(@con, 't')
+      cds = td.column_descriptions
+
+      refute_predicate(cds[0], :has_default?)
+      assert_predicate(cds[1], :has_default?)
+    end
+  end
+end

--- a/test/duckdb_test/table_description_test.rb
+++ b/test/duckdb_test/table_description_test.rb
@@ -3,7 +3,8 @@
 require 'test_helper'
 
 module DuckDBTest
-  class TableDescriptionTest < Minitest::Test
+  if defined?(DuckDB::TableDescription)
+  class TableDescriptionTest < Minitest::Test # rubocop:disable Layout/IndentationWidth
     def setup
       @db = DuckDB::Database.open
       @con = @db.connect
@@ -96,5 +97,6 @@ module DuckDBTest
       assert_instance_of(DuckDB::ColumnDescription, cds[0])
       assert_instance_of(DuckDB::ColumnDescription, cds[1])
     end
+  end
   end
 end

--- a/test/duckdb_test/table_description_test.rb
+++ b/test/duckdb_test/table_description_test.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module DuckDBTest
+  class TableDescriptionTest < Minitest::Test
+    def setup
+      @db = DuckDB::Database.open
+      @con = @db.connect
+      @con.query('CREATE TABLE t (i INTEGER, j INTEGER DEFAULT 5)')
+    end
+
+    def teardown
+      @con.close
+      @db.close
+    end
+
+    def test_s_new
+      assert_instance_of DuckDB::TableDescription, DuckDB::TableDescription.new(@con, 't')
+    end
+
+    def test_s_new_with_schema
+      @con.query('CREATE SCHEMA s')
+      @con.query('CREATE TABLE s.u (x INTEGER)')
+
+      assert_instance_of DuckDB::TableDescription, DuckDB::TableDescription.new(@con, 'u', schema: 's')
+    end
+
+    def test_s_new_with_catalog
+      @con.query("ATTACH ':memory:' AS ext")
+      @con.query('CREATE TABLE ext.v (x INTEGER)')
+
+      assert_instance_of DuckDB::TableDescription, DuckDB::TableDescription.new(@con, 'v', catalog: 'ext')
+    end
+
+    def test_s_new_with_schema_and_catalog
+      @con.query("ATTACH ':memory:' AS ext")
+      @con.query('CREATE SCHEMA ext.s')
+      @con.query('CREATE TABLE ext.s.w (x INTEGER)')
+
+      assert_instance_of DuckDB::TableDescription,
+                         DuckDB::TableDescription.new(@con, 'w', schema: 's', catalog: 'ext')
+    end
+
+    def test_s_new_with_invalid_connection
+      assert_raises DuckDB::Error do
+        DuckDB::TableDescription.new('not_a_connection', 't')
+      end
+    end
+
+    def test_s_new_with_nil_table
+      assert_raises DuckDB::Error do
+        DuckDB::TableDescription.new(@con, nil)
+      end
+    end
+
+    def test_s_new_with_nonexistent_table
+      ex = assert_raises DuckDB::Error do
+        DuckDB::TableDescription.new(@con, 'nope')
+      end
+      refute_empty ex.message
+    end
+
+    def test_s_new_with_nonexistent_schema
+      ex = assert_raises DuckDB::Error do
+        DuckDB::TableDescription.new(@con, 't', schema: 'no_such_schema')
+      end
+      refute_empty ex.message
+    end
+
+    def test_s_new_with_nonexistent_catalog
+      ex = assert_raises DuckDB::Error do
+        DuckDB::TableDescription.new(@con, 't', catalog: 'no_such_catalog')
+      end
+      refute_empty ex.message
+    end
+
+    def test_error_message_returns_nil_on_success
+      td = DuckDB::TableDescription.new(@con, 't')
+
+      assert_nil td.error_message
+    end
+
+    def test_column_descriptions_return_array
+      td = DuckDB::TableDescription.new(@con, 't')
+      cds = td.column_descriptions
+
+      assert_instance_of(Array, cds)
+      assert_equal(2, cds.length)
+    end
+
+    def test_column_descriptions_return_array_of_column_description
+      td = DuckDB::TableDescription.new(@con, 't')
+      cds = td.column_descriptions
+
+      assert_instance_of(DuckDB::ColumnDescription, cds[0])
+      assert_instance_of(DuckDB::ColumnDescription, cds[1])
+    end
+  end
+end


### PR DESCRIPTION
refs #1268 

## Summary

- Add `DuckDB::TableDescription` to retrieve metadata about a table (column count, names, logical types, and default presence)
- Add `DuckDB::ColumnDescription` as an immutable value object describing a column's name, logical type, and whether it has a default value
- Add document comments to both classes with usage examples
- Add tests for both classes

## Usage

```ruby
require 'duckdb'
db = DuckDB::Database.open
con = db.connect
con.query("CREATE TABLE users (id INTEGER, name VARCHAR DEFAULT 'anon')")

td = DuckDB::TableDescription.new(con, 'users')
td.column_descriptions.each do |cd|
  puts "\#{cd.name}: \#{cd.logical_type.type}, default=\#{cd.has_default?}"
end
# id: integer, default=false
# name: varchar, default=true
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Retrieve table metadata with `DuckDB::TableDescription`—access column names, logical types, and default-value information for any table
  * Access column details via `DuckDB::ColumnDescription`—an immutable structure containing name, type, and default presence for each column

<!-- end of auto-generated comment: release notes by coderabbit.ai -->