### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test_on_windows.yml
+++ b/.github/workflows/test_on_windows.yml
@@ -10,6 +10,9 @@ on:
       - synchronize
       - reopened
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/suketa/ruby-duckdb/security/code-scanning/5](https://github.com/suketa/ruby-duckdb/security/code-scanning/5)

Add an explicit workflow-level `permissions` block so all jobs inherit minimal token access.  
Best fix for this file is to add:

```yml
permissions:
  contents: read
```

at the top level (e.g., after `on:` block and before `concurrency:`). This preserves current behavior for checkout and avoids granting unnecessary write privileges. No imports, methods, or dependencies are needed since this is YAML configuration only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
