### PR TITLE
fix security alert 9

### DIFF
--- a/lib/duckdb/interval.rb
+++ b/lib/duckdb/interval.rb
@@ -41,6 +41,8 @@ module DuckDB
       Regexp::EXTENDED
     )
     private_constant :ISO8601_REGEXP
+
+    ISO8601_STRING_LENGTH = 1_000
     # :startdoc:
 
     class << self
@@ -49,7 +51,9 @@ module DuckDB
       #   DuckDB::Interval.iso8601_parse('P1Y2M3DT4H5M6.123456S')
       #   => #<DuckDB::Interval:0x00007f9b9c0b3b60 @interval_months=14, @interval_days=3, @interval_micros=14706123456>
       def iso8601_parse(value)
-        raise ArgumentError, "input #{value} too long." if value.length > 1000
+        if value.length > ISO8601_STRING_LENGTH
+          raise ArgumentError, "Argument of iso8601_parse is too long. It must be less than #{ISO8601_STRING_LENGTH}."
+        end
 
         m = ISO8601_REGEXP.match(value)
         raise ArgumentError, "The argument `#{value}` can't be parse." if m.nil?

--- a/lib/duckdb/interval.rb
+++ b/lib/duckdb/interval.rb
@@ -30,19 +30,20 @@ module DuckDB
   class Interval
     # :stopdoc:
     ISO8601_REGEXP = Regexp.compile(
-      '\A(?<negativ>-{0,1})P
-      (?<year>-{0,1}\d+Y){0,1}
-      (?<month>-{0,1}\d+M){0,1}
-      (?<day>-{0,1}\d+D){0,1}
-      T{0,1}
-      (?<hour>-{0,1}\d+H){0,1}
-      (?<min>-{0,1}\d+M){0,1}
-      ((?<sec>-{0,1}\d+)\.{0,1}(?<usec>\d*)S){0,1}\z',
+      '\A(?<negativ>-?+)P
+      (?<year>-?+\d++Y)?+
+        (?<month>-?+\d++M)?+
+        (?<day>-?+\d++D)?+
+        T?+
+        (?<hour>-?+\d++H)?+
+        (?<min>-?+\d++M)?+
+        ((?<sec>-?+\d++)\.?+(?<usec>\d*+)S)?+\z',
       Regexp::EXTENDED
     )
     private_constant :ISO8601_REGEXP
 
     ISO8601_STRING_LENGTH = 1_000
+    private_constant :ISO8601_STRING_LENGTH
     # :startdoc:
 
     class << self

--- a/lib/duckdb/interval.rb
+++ b/lib/duckdb/interval.rb
@@ -30,14 +30,14 @@ module DuckDB
   class Interval
     # :stopdoc:
     ISO8601_REGEXP = Regexp.compile(
-      '(?<negativ>-{0,1})P
+      '\A(?<negativ>-{0,1})P
       (?<year>-{0,1}\d+Y){0,1}
       (?<month>-{0,1}\d+M){0,1}
       (?<day>-{0,1}\d+D){0,1}
       T{0,1}
       (?<hour>-{0,1}\d+H){0,1}
       (?<min>-{0,1}\d+M){0,1}
-      ((?<sec>-{0,1}\d+)\.{0,1}(?<usec>\d*)S){0,1}',
+      ((?<sec>-{0,1}\d+)\.{0,1}(?<usec>\d*)S){0,1}\z',
       Regexp::EXTENDED
     )
     private_constant :ISO8601_REGEXP

--- a/lib/duckdb/interval.rb
+++ b/lib/duckdb/interval.rb
@@ -49,8 +49,9 @@ module DuckDB
       #   DuckDB::Interval.iso8601_parse('P1Y2M3DT4H5M6.123456S')
       #   => #<DuckDB::Interval:0x00007f9b9c0b3b60 @interval_months=14, @interval_days=3, @interval_micros=14706123456>
       def iso8601_parse(value)
-        m = ISO8601_REGEXP.match(value)
+        raise ArgumentError, "input #{value} too long." if value.length > 1000
 
+        m = ISO8601_REGEXP.match(value)
         raise ArgumentError, "The argument `#{value}` can't be parse." if m.nil?
 
         year, month, day, hour, min, sec, usec = matched_to_i(m)

--- a/test/duckdb_test/interval_test.rb
+++ b/test/duckdb_test/interval_test.rb
@@ -57,6 +57,10 @@ module DuckDBTest
       assert_raises(ArgumentError) { DuckDB::Interval.iso8601_parse('1Y2M3DT4H5M6.7') }
     end
 
+    def test_s_iso8601_parse_value_having_more_1000chars
+      assert_raises(ArgumentError) { DuckDB::Interval.iso8601_parse("P#{'1' * 1_000}Y") }
+    end
+
     def test_s_mk_interval_positive_full
       assert_equal(
         DuckDB::Interval.new(interval_months: 14, interval_days: 3, interval_micros: 14_706_700_000),


### PR DESCRIPTION
refs https://github.com/suketa/ruby-duckdb/security/code-scanning/9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to reject excessively long input strings (>1000 characters) in interval parsing, raising an error earlier in the process.

* **Tests**
  * Added test case to verify error handling for extremely long input strings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->