### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test_on_ubuntu.yml
+++ b/.github/workflows/test_on_ubuntu.yml
@@ -10,6 +10,10 @@ on:
       - synchronize
       - reopened
 
+permissions:
+  contents: read
+  packages: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/suketa/ruby-duckdb/security/code-scanning/7](https://github.com/suketa/ruby-duckdb/security/code-scanning/7)

Add an explicit `permissions` block at the workflow root (best single fix) so it applies to all jobs (`test` and `post-test`) without changing behavior.  
For this workflow, a minimal safe baseline is:

- `contents: read` (needed for `actions/checkout`)
- `packages: read` (common read-only baseline; harmless if unused)

Edit **`.github/workflows/test_on_ubuntu.yml`** by inserting the `permissions` section after the trigger (`on:` block) and before `concurrency:`.

No imports, methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
