### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test_on_macos.yml
+++ b/.github/workflows/test_on_macos.yml
@@ -1,5 +1,8 @@
 name: MacOS
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/suketa/ruby-duckdb/security/code-scanning/6](https://github.com/suketa/ruby-duckdb/security/code-scanning/6)

Add an explicit top-level `permissions` block in `.github/workflows/test_on_macos.yml` so all jobs inherit least-privilege defaults.

Best single fix without changing functionality:
- Insert at workflow root (after `name` is a good location):
  - `permissions:`
  - `  contents: read`

Why this works:
- `actions/checkout@v4` needs `contents: read`.
- The rest of the workflow (build/test/cache) does not require write scopes to repository resources.
- Applying at root covers both `test` and `post-test` jobs consistently.

No imports/dependencies/methods are needed (YAML config-only change).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration to include security permissions settings.

---

**Note:** This is an internal infrastructure change with no visible impact to end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->