### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -14,6 +14,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   rubocop:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/suketa/ruby-duckdb/security/code-scanning/4](https://github.com/suketa/ruby-duckdb/security/code-scanning/4)

Add an explicit `permissions` block to `.github/workflows/linter.yml` at the workflow root (top-level), so it applies to all jobs in this workflow.  
For this linter workflow, the minimal required permission is:

- `contents: read`

This preserves current functionality (`actions/checkout` can read code; no write scopes are required) while enforcing least privilege and satisfying CodeQL.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
