### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test_on_ubuntu.yml
+++ b/.github/workflows/test_on_ubuntu.yml
@@ -14,6 +14,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/suketa/ruby-duckdb/security/code-scanning/2](https://github.com/suketa/ruby-duckdb/security/code-scanning/2)

Add an explicit `permissions` block at the workflow root so it applies to all jobs (`test` and `post-test`) unless overridden. The minimal safe permission for this workflow is:

- `contents: read`

This preserves existing functionality while documenting and enforcing least privilege.  
Edit **`.github/workflows/test_on_ubuntu.yml`** by inserting the block after the `concurrency` section and before `jobs:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
