### PR TITLE
ruby-duckdb uses only DuckDB no-deprecated C-API

### DIFF
--- a/.github/workflows/test_on_macos.yml
+++ b/.github/workflows/test_on_macos.yml
@@ -57,11 +57,6 @@ jobs:
         mkdir libduckdb-osx-universal
         unzip libduckdb-osx-universal.zip -d libduckdb-osx-universal
 
-    - name: Build test with DUCKDB_API_NO_DEPRECATED and Ruby ${{ matrix.ruby }}
-      run: |
-        env DUCKDB_API_NO_DEPRECATED=1 bundle exec rake build -- --with-duckdb-include=${GITHUB_WORKSPACE}/libduckdb-osx-universal --with-duckdb-lib=${GITHUB_WORKSPACE}/libduckdb-osx-universal
-        bundle exec rake clean
-
     - name: Build with Ruby ${{ matrix.ruby }}
       run: |
         bundle exec rake build -- --with-duckdb-include=${GITHUB_WORKSPACE}/libduckdb-osx-universal --with-duckdb-lib=${GITHUB_WORKSPACE}/libduckdb-osx-universal

--- a/.github/workflows/test_on_ubuntu.yml
+++ b/.github/workflows/test_on_ubuntu.yml
@@ -75,11 +75,6 @@ jobs:
         sudo cp libduckdb-linux-amd64/libduckdb.so /usr/local/lib/
         sudo ldconfig
 
-    - name: Build test with DUCKDB_API_NO_DEPRECATED and Ruby ${{ matrix.ruby }}
-      run: |
-        env DUCKDB_API_NO_DEPRECATED=1 bundle exec rake build -- --with-duckdb-include=${GITHUB_WORKSPACE}/libduckdb-linux-amd64 --with-duckdb-lib=${GITHUB_WORKSPACE}/libduckdb-linux-amd64
-        bundle exec rake clean
-
     - name: Build with Ruby ${{ matrix.ruby }}
       run: |
         bundle exec rake build -- --with-duckdb-include=${GITHUB_WORKSPACE}/libduckdb-linux-amd64 --with-duckdb-lib=${GITHUB_WORKSPACE}/libduckdb-linux-amd64

--- a/ext/duckdb/extconf.rb
+++ b/ext/duckdb/extconf.rb
@@ -63,6 +63,4 @@ have_func('duckdb_appender_create_query', 'duckdb.h')
 
 have_func('duckdb_unsafe_vector_assign_string_element_len', 'duckdb.h')
 
-$CFLAGS << ' -DDUCKDB_API_NO_DEPRECATED' if ENV['DUCKDB_API_NO_DEPRECATED']
-
 create_makefile('duckdb/duckdb_native')

--- a/ext/duckdb/ruby-duckdb.h
+++ b/ext/duckdb/ruby-duckdb.h
@@ -1,7 +1,7 @@
 #ifndef RUBY_DUCKDB_H
 #define RUBY_DUCKDB_H
 
-// #define DUCKDB_API_NO_DEPRECATED
+#define DUCKDB_API_NO_DEPRECATED // ruby-duckdb uses no-deprecated DuckDB C-API only.
 #define DUCKDB_NO_EXTENSION_FUNCTIONS // disable extension C-functions
 
 #include "ruby.h"


### PR DESCRIPTION
ruby-duckdb uses only DuckDB no-deprecated C-API.
So, DUCKDB_API_NO_DEPRECATED is always enabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified build configuration to consistently use the non-deprecated DuckDB C-API across all builds, removing environment-variable-dependent compiler flag handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->