### PR TITLE
refactoring. simplify Gc.verify_compaction_references

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,13 +5,7 @@ require 'duckdb'
 
 require_relative 'duckdb_test/duckdb_version'
 
-if defined?(GC.verify_compaction_references) == 'method'
-  if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.2.0')
-    GC.verify_compaction_references(expand_heap: true, toward: :empty)
-  else
-    GC.verify_compaction_references(double_heap: true, toward: :empty) unless /3.0/ =~ RUBY_VERSION
-  end
-end
+GC.verify_compaction_references(expand_heap: true, toward: :empty)
 
 module DuckDBTest
   def duckdb_library_version


### PR DESCRIPTION
We can write Ruby >= 3.2.0 style now.