### PR TITLE
ci: use DuckDB 1.5.2 instead of 1.5.1

### DIFF
--- a/.github/workflows/test_on_macos.yml
+++ b/.github/workflows/test_on_macos.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       matrix:
         ruby: ['3.2.11', '3.3.11', '3.4.9', '4.0.2', 'head']
-        duckdb: ['1.4.4', '1.5.1']
+        duckdb: ['1.4.4', '1.5.2']
 
     steps:
     - uses: actions/checkout@v4
@@ -49,7 +49,7 @@ jobs:
       run: |
         curl -OL https://github.com/duckdb/duckdb/releases/download/v${DUCKDB_VERSION}/libduckdb-osx-universal.zip
         case "${DUCKDB_VERSION}" in
-          "1.5.1") EXPECTED_SHA256="d9dd723c59f8571202b468f6bf71d4555238544553dd1445e6c9ecb39f54c0f3" ;;
+          "1.5.2") EXPECTED_SHA256="524f3537330a1b747556a0c98b62a46865a3f48c7ead2b2035c62f1ad3e5ca8b" ;;
           "1.4.4") EXPECTED_SHA256="5e6d79f5fb86bbd4f24d59cee3bc38f113d1433761df35337e3c01c62eeafe26" ;;
           *) echo "No known SHA256 for DuckDB v${DUCKDB_VERSION}"; exit 1 ;;
         esac

--- a/.github/workflows/test_on_ubuntu.yml
+++ b/.github/workflows/test_on_ubuntu.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         ruby: ['3.2.11', '3.3.11', '3.4.9', '4.0.2', 'head']
-        duckdb: ['1.4.4', '1.5.1']
+        duckdb: ['1.4.4', '1.5.2']
 
     services:
       mysql:
@@ -62,7 +62,7 @@ jobs:
       run: |
         curl -OL https://github.com/duckdb/duckdb/releases/download/v${DUCKDB_VERSION}/libduckdb-linux-amd64.zip
         case "${DUCKDB_VERSION}" in
-          "1.5.1") EXPECTED_SHA256="21aec66a60eae1696270ba715a481ab066a88d99a62718d0577579ac1a7a4834" ;;
+          "1.5.2") EXPECTED_SHA256="4711438f0fdb04f0441803409bec5430b763d4f2ac3482c1f97cfa6b5ecb4c15" ;;
           "1.4.4") EXPECTED_SHA256="09cc288295964d897b47665d1898e16e8ef176cae9ea615797fc136eae15bd5d" ;;
           *) echo "No known SHA256 for DuckDB v${DUCKDB_VERSION}"; exit 1 ;;
         esac

--- a/.github/workflows/test_on_windows.yml
+++ b/.github/workflows/test_on_windows.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       matrix:
         ruby: ['3.2.9', '3.3.10', '3.4.8', '4.0.1', 'ucrt', 'mingw', 'mswin', 'head']
-        duckdb: ['1.4.4', '1.5.1']
+        duckdb: ['1.4.4', '1.5.2']
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Update CI matrix to test against DuckDB 1.5.2.

- Update `duckdb` matrix version from `1.5.1` to `1.5.2` in Ubuntu, macOS, and Windows workflows
- Update `EXPECTED_SHA256` for Linux (`libduckdb-linux-amd64.zip`) and macOS (`libduckdb-osx-universal.zip`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated DuckDB test version from 1.5.1 to 1.5.2 across macOS, Ubuntu, and Windows CI workflows.
  * Updated verification checksums for artifact validation to match the new DuckDB version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->