### PR TITLE
Add DuckDB::Appender#clear

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 # Unreleased
 
+- add `DuckDB::Appender#clear` to discard all unflushed data from the appender without writing it to the table (requires DuckDB >= 1.5.0).
+
 # 1.5.2.0 - 2026-04-16
 
 - add `DuckDB::DataChunk#reset` to clear a chunk's contents so it can be reused across multiple `Appender#append_data_chunk` calls without reallocation.

--- a/ext/duckdb/appender.c
+++ b/ext/duckdb/appender.c
@@ -37,6 +37,11 @@ static VALUE appender__append_uhugeint(VALUE self, VALUE lower, VALUE upper);
 static VALUE appender__append_value(VALUE self, VALUE val);
 static VALUE appender__append_data_chunk(VALUE self, VALUE chunk);
 static VALUE appender__flush(VALUE self);
+
+#ifdef HAVE_DUCKDB_H_GE_V1_5_0
+static VALUE appender__clear(VALUE self);
+#endif
+
 static VALUE appender__close(VALUE self);
 static VALUE duckdb_state_to_bool_value(duckdb_state state);
 
@@ -448,6 +453,16 @@ static VALUE appender__flush(VALUE self) {
     return duckdb_state_to_bool_value(duckdb_appender_flush(ctx->appender));
 }
 
+#ifdef HAVE_DUCKDB_H_GE_V1_5_0
+/* :nodoc: */
+static VALUE appender__clear(VALUE self) {
+    rubyDuckDBAppender *ctx;
+    TypedData_Get_Struct(self, rubyDuckDBAppender, &appender_data_type, ctx);
+
+    return duckdb_state_to_bool_value(duckdb_appender_clear(ctx->appender));
+}
+#endif
+
 /* :nodoc: */
 static VALUE appender__close(VALUE self) {
     rubyDuckDBAppender *ctx;
@@ -474,6 +489,11 @@ void rbduckdb_init_duckdb_appender(void) {
     rb_define_method(cDuckDBAppender, "error_message", appender_error_message, 0);
     rb_define_private_method(cDuckDBAppender, "_end_row", appender__end_row, 0);
     rb_define_private_method(cDuckDBAppender, "_flush", appender__flush, 0);
+
+#ifdef HAVE_DUCKDB_H_GE_V1_5_0
+    rb_define_private_method(cDuckDBAppender, "_clear", appender__clear, 0);
+#endif
+
     rb_define_private_method(cDuckDBAppender, "_close", appender__close, 0);
     rb_define_private_method(cDuckDBAppender, "_append_bool", appender__append_bool, 1);
     rb_define_private_method(cDuckDBAppender, "_append_int8", appender__append_int8, 1);

--- a/lib/duckdb/appender.rb
+++ b/lib/duckdb/appender.rb
@@ -93,6 +93,9 @@ module DuckDB
       raise_appender_error('failed to close')
     end
 
+    def clear
+    end
+
     # call-seq:
     #   appender.append_bool(val) -> self
     #

--- a/lib/duckdb/appender.rb
+++ b/lib/duckdb/appender.rb
@@ -93,8 +93,28 @@ module DuckDB
       raise_appender_error('failed to close')
     end
 
-    def clear
-      self
+    if DuckDB::Appender.private_method_defined?(:_clear)
+      # :call-seq:
+      #   appender.clear -> self
+      #
+      # Clears all unflushed data from the appender, discarding any appended rows
+      # that have not yet been flushed to the table.
+      #
+      #   require 'duckdb'
+      #   db = DuckDB::Database.open
+      #   con = db.connect
+      #   con.query('CREATE TABLE users (id INTEGER, name VARCHAR)')
+      #   appender = con.appender('users')
+      #   appender
+      #     .append_int32(1)
+      #     .append_varchar('Alice')
+      #     .end_row
+      #     .clear # discards the row above without flushing to the table
+      def clear
+        return self if _clear
+
+        raise_appender_error('failed to clear')
+      end
     end
 
     # call-seq:

--- a/lib/duckdb/appender.rb
+++ b/lib/duckdb/appender.rb
@@ -94,6 +94,7 @@ module DuckDB
     end
 
     def clear
+      self
     end
 
     # call-seq:

--- a/test/duckdb_test/appender_test.rb
+++ b/test/duckdb_test/appender_test.rb
@@ -996,5 +996,25 @@ module DuckDBTest
 
       assert_equal([1, 'foo'], r.first)
     end
+
+    def test_appender_clear
+      skip 'DuckDB::Appender#clear is not available' unless DuckDB::Appender.method_defined?(:clear)
+
+      @con.query('CREATE TABLE t (col1 INTEGER, col2 VARCHAR)')
+      appender = @con.appender('t')
+
+      data = [[1, 2], [3, -4], [5, 6]]
+      data.each do |(col1, col2)|
+        appender.append(col1).append(col2).end_row
+        if col1.positive? && col2.positive?
+          appender.flush
+        else
+          appender.clear
+        end
+      end
+      r = @con.query('SELECT * FROM t ORDER BY col1')
+
+      assert_equal([[1, 2], [5, 6]], r.each.to_a)
+    end
   end
 end

--- a/test/duckdb_test/appender_test.rb
+++ b/test/duckdb_test/appender_test.rb
@@ -1000,21 +1000,22 @@ module DuckDBTest
     def test_appender_clear
       skip 'DuckDB::Appender#clear is not available' unless DuckDB::Appender.method_defined?(:clear)
 
-      @con.query('CREATE TABLE t (col1 INTEGER, col2 VARCHAR)')
+      @con.query('CREATE TABLE t (id INTEGER, name VARCHAR)')
       appender = @con.appender('t')
 
-      data = [[1, 2], [3, -4], [5, 6]]
-      data.each do |(col1, col2)|
-        appender.append(col1).append(col2).end_row
-        if col1.positive? && col2.positive?
-          appender.flush
-        else
+      data = [[1, 'John'], [-2, 'Bob'], [3, 'Jane']]
+      data.each do |(id, name)|
+        appender.append(id).append(name).end_row
+        if id.negative?
           appender.clear
+          next
         end
+        appender.flush
       end
-      r = @con.query('SELECT * FROM t ORDER BY col1')
 
-      assert_equal([[1, 2], [5, 6]], r.each.to_a)
+      r = @con.query('SELECT * FROM t ORDER BY id')
+
+      assert_equal([[1, 'John'], [3, 'Jane']], r.each.to_a)
     end
   end
 end


### PR DESCRIPTION
## Summary

Add `DuckDB::Appender#clear` to discard all unflushed data from the appender without writing it to the table.

## Changes

- `ext/duckdb/appender.c` — wraps `duckdb_appender_clear` C API behind `#ifdef HAVE_DUCKDB_H_GE_V1_5_0`
- `lib/duckdb/appender.rb` — public `#clear` method with YARD docs, conditionally defined when C method is available
- `test/duckdb_test/appender_test.rb` — tests verifying rows are discarded without being flushed
- `CHANGELOG.md` — Unreleased entry

## Requirements

Requires DuckDB >= 1.5.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `Appender#clear` method (requires DuckDB >= 1.5.0).

* **Bug Fixes**
  * Improved UUID value handling and validation.

* **Tests**
  * Added comprehensive test coverage for appender operations and UUID handling.

* **Chores**
  * Updated DuckDB to version 1.5.2.
  * Updated gem version to 1.5.2.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->