### PR TITLE
add DuckDB::Appender#add_column, clear_columns.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 # Unreleased
 
+- add `DuckDB::Appender#clear_columns`.
+- add `DuckDB::Appender#add_column`.
 - add `DuckDB::Appender#clear` to discard all unflushed data from the appender without writing it to the table (requires DuckDB >= 1.5.0).
 
 # 1.5.2.0 - 2026-04-16

--- a/ext/duckdb/appender.c
+++ b/ext/duckdb/appender.c
@@ -42,6 +42,8 @@ static VALUE appender__flush(VALUE self);
 static VALUE appender__clear(VALUE self);
 #endif
 
+static VALUE appender__add_column(VALUE self, VALUE name);
+static VALUE appender__clear_columns(VALUE self);
 static VALUE appender__close(VALUE self);
 static VALUE duckdb_state_to_bool_value(duckdb_state state);
 
@@ -464,6 +466,23 @@ static VALUE appender__clear(VALUE self) {
 #endif
 
 /* :nodoc: */
+static VALUE appender__add_column(VALUE self, VALUE name) {
+    char *p = StringValuePtr(name);
+    rubyDuckDBAppender *ctx;
+    TypedData_Get_Struct(self, rubyDuckDBAppender, &appender_data_type, ctx);
+
+    return duckdb_state_to_bool_value(duckdb_appender_add_column(ctx->appender, p));
+}
+
+/* :nodoc: */
+static VALUE appender__clear_columns(VALUE self) {
+    rubyDuckDBAppender *ctx;
+    TypedData_Get_Struct(self, rubyDuckDBAppender, &appender_data_type, ctx);
+
+    return duckdb_state_to_bool_value(duckdb_appender_clear_columns(ctx->appender));
+}
+
+/* :nodoc: */
 static VALUE appender__close(VALUE self) {
     rubyDuckDBAppender *ctx;
     TypedData_Get_Struct(self, rubyDuckDBAppender, &appender_data_type, ctx);
@@ -494,6 +513,8 @@ void rbduckdb_init_duckdb_appender(void) {
     rb_define_private_method(cDuckDBAppender, "_clear", appender__clear, 0);
 #endif
 
+    rb_define_private_method(cDuckDBAppender, "_add_column", appender__add_column, 1);
+    rb_define_private_method(cDuckDBAppender, "_clear_columns", appender__clear_columns, 0);
     rb_define_private_method(cDuckDBAppender, "_close", appender__close, 0);
     rb_define_private_method(cDuckDBAppender, "_append_bool", appender__append_bool, 1);
     rb_define_private_method(cDuckDBAppender, "_append_int8", appender__append_int8, 1);

--- a/lib/duckdb/appender.rb
+++ b/lib/duckdb/appender.rb
@@ -93,6 +93,56 @@ module DuckDB
       raise_appender_error('failed to close')
     end
 
+    # :call-seq:
+    #   appender.add_column(column_name) -> self
+    #
+    # Specifies a column to append to, allowing selective column insertion.
+    # Columns not added will use their default values or be computed from
+    # generated column expressions.
+    # Raises DuckDB::Error if the column does not exist in the table.
+    #
+    #   require 'duckdb'
+    #   db = DuckDB::Database.open
+    #   con = db.connect
+    #   con.query('CREATE TABLE t (id UUID PRIMARY KEY DEFAULT uuidv4(), name VARCHAR)')
+    #   appender = con.appender('t')
+    #   appender.add_column('name')
+    #   appender
+    #     .append_varchar('Alice')
+    #     .end_row
+    #     .flush
+    def add_column(column)
+      return self if _add_column(column)
+
+      raise_appender_error('failed to add_column')
+    end
+
+    # :call-seq:
+    #   appender.clear_columns -> self
+    #
+    # Clears the list of columns previously set by #add_column, so that all
+    # columns of the table become active again. Any previously appended rows
+    # are flushed before the column list is reset; if the flush fails (e.g.
+    # a constraint violation), this method raises DuckDB::Error.
+    #
+    #   require 'duckdb'
+    #   db = DuckDB::Database.open
+    #   con = db.connect
+    #   con.query('CREATE TABLE t (id UUID PRIMARY KEY DEFAULT uuidv4(), name VARCHAR)')
+    #   appender = con.appender('t')
+    #   appender.add_column('name')
+    #   appender
+    #     .append_varchar('Alice')
+    #     .end_row
+    #     .flush
+    #   appender.clear_columns
+    #   # all table columns are active again
+    def clear_columns
+      return self if _clear_columns
+
+      raise_appender_error('failed to clear_columns')
+    end
+
     if DuckDB::Appender.private_method_defined?(:_clear)
       # :call-seq:
       #   appender.clear -> self

--- a/test/duckdb_test/appender_test.rb
+++ b/test/duckdb_test/appender_test.rb
@@ -997,7 +997,7 @@ module DuckDBTest
       assert_equal([1, 'foo'], r.first)
     end
 
-    def test_appender_clear
+    def test_clear
       skip 'DuckDB::Appender#clear is not available' unless DuckDB::Appender.method_defined?(:clear)
 
       @con.query('CREATE TABLE t (id INTEGER, name VARCHAR)')
@@ -1016,6 +1016,155 @@ module DuckDBTest
       r = @con.query('SELECT * FROM t ORDER BY id')
 
       assert_equal([[1, 'John'], [3, 'Jane']], r.each.to_a)
+    end
+
+    def test_add_column
+      @con.query('CREATE TABLE t (id UUID PRIMARY KEY DEFAULT uuidv4(), name VARCHAR)')
+
+      appender = @con.appender('t')
+      appender.add_column('name')
+
+      data = %w[John Bob Jane]
+
+      data.each do |name|
+        appender.append(name).end_row
+      end
+      appender.flush
+
+      r = @con.query('SELECT name FROM t ORDER BY name')
+
+      assert_equal([['Bob'], ['Jane'], ['John']], r.each.to_a)
+    end
+
+    def test_add_column_with_invalid_column
+      @con.query('CREATE TABLE t (id UUID PRIMARY KEY DEFAULT uuidv4(), name VARCHAR)')
+
+      appender = @con.appender('t')
+
+      assert_raises(DuckDB::Error) do
+        appender.add_column('invalid_column_name')
+      end
+    end
+
+    def test_add_column_returns_self
+      @con.query('CREATE TABLE t (id UUID PRIMARY KEY DEFAULT uuidv4(), name VARCHAR)')
+
+      appender = @con.appender('t')
+
+      assert_same appender, appender.add_column('name')
+    end
+
+    def test_add_column_with_multiple_default_columns
+      @con.query('CREATE TABLE t (i INTEGER DEFAULT 4, j INTEGER, k INTEGER DEFAULT 30)')
+
+      appender = @con.appender('t')
+      appender.add_column('j')
+
+      appender.append_int32(15).end_row
+      appender.flush
+
+      r = @con.query('SELECT i, j, k FROM t')
+
+      assert_equal([[4, 15, 30]], r.each.to_a)
+    end
+
+    def test_add_column_with_multiple_columns
+      @con.query('CREATE TABLE t (i INTEGER DEFAULT 4, j INTEGER, k INTEGER DEFAULT 30)')
+
+      appender = @con.appender('t')
+      appender.add_column('j')
+      appender.add_column('k')
+
+      appender.append_int32(10).append_int32(20).end_row
+      appender.flush
+
+      r = @con.query('SELECT i, j, k FROM t')
+
+      assert_equal([[4, 10, 20]], r.each.to_a)
+    end
+
+    def test_add_column_with_generated_column
+      @con.query('CREATE TABLE t (i INTEGER DEFAULT 4, j INTEGER, k INTEGER DEFAULT 30, l AS (i + k))')
+
+      appender = @con.appender('t')
+      appender.add_column('j')
+
+      appender.append_int32(15).end_row
+      appender.flush
+
+      r = @con.query('SELECT i, j, k, l FROM t')
+
+      assert_equal([[4, 15, 30, 34]], r.each.to_a)
+    end
+
+    def test_add_column_with_non_string_argument
+      @con.query('CREATE TABLE t (id UUID PRIMARY KEY DEFAULT uuidv4(), name VARCHAR)')
+
+      appender = @con.appender('t')
+
+      assert_raises(TypeError) do
+        appender.add_column(123)
+      end
+    end
+
+    def test_clear_columns
+      @con.query('CREATE TABLE t (name VARCHAR, created_at TIMESTAMP DEFAULT NULL)')
+      appender = @con.appender('t')
+      appender.add_column('name')
+      appender.append('John').end_row
+      appender.clear_columns
+      appender.append('Bob').append(Time.local(2026, 4, 17, 12, 34, 56)).end_row.flush
+      r = @con.query('SELECT * FROM t ORDER BY name')
+
+      assert_equal([['Bob', Time.local(2026, 4, 17, 12, 34, 56)], ['John', nil]], r.each.to_a)
+    end
+
+    def test_clear_columns_with_flushing_error
+      @con.query('CREATE TABLE t (name VARCHAR NOT NULL, created_at TIMESTAMP DEFAULT NULL)')
+      appender = @con.appender('t')
+      appender.add_column('name')
+      appender.append_null
+
+      assert_raises(DuckDB::Error) do
+        appender.clear_columns
+      end
+    end
+
+    def test_clear_columns_returns_self
+      @con.query('CREATE TABLE t (id UUID PRIMARY KEY DEFAULT uuidv4(), name VARCHAR)')
+
+      appender = @con.appender('t')
+      appender.add_column('name')
+
+      assert_same appender, appender.clear_columns
+    end
+
+    def test_clear_columns_without_add_column
+      @con.query('CREATE TABLE t (id INTEGER, name VARCHAR)')
+      appender = @con.appender('t')
+
+      appender.clear_columns
+      appender.append_int32(1).append_varchar('Alice').end_row.flush
+
+      r = @con.query('SELECT * FROM t')
+
+      assert_equal([[1, 'Alice']], r.each.to_a)
+    end
+
+    def test_add_column_after_clear_columns
+      @con.query('CREATE TABLE t (i INTEGER DEFAULT 4, j INTEGER, k INTEGER DEFAULT 30)')
+      appender = @con.appender('t')
+
+      appender.add_column('j')
+      appender.append_int32(15).end_row.flush
+
+      appender.clear_columns
+      appender.add_column('k')
+      appender.append_int32(50).end_row.flush
+
+      r = @con.query('SELECT i, j, k FROM t ORDER BY k')
+
+      assert_equal([[4, 15, 30], [4, nil, 50]], r.each.to_a)
     end
   end
 end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `add_column(column)` method to DuckDB::Appender for dynamic column selection during append operations.
  * Added `clear_columns` method to DuckDB::Appender to reset target columns between appends.
  * Both methods support method chaining and raise errors on invalid operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->