### PR TITLE
make DuckDB::TableFunction work when `SET threads > 0`

### DIFF
--- a/lib/duckdb/connection.rb
+++ b/lib/duckdb/connection.rb
@@ -276,7 +276,6 @@ module DuckDB
     def register_table_function(table_function)
       raise ArgumentError, 'table_function must be a TableFunction' unless table_function.is_a?(TableFunction)
 
-      check_threads
       _register_table_function(table_function)
     end
 
@@ -291,12 +290,10 @@ module DuckDB
     # @param columns [Hash{String => DuckDB::LogicalType}, nil] optional column schema override;
     #   if omitted, the adapter determines the columns (e.g. from headers or inference)
     # @raise [ArgumentError] if no adapter is registered for the object's class
-    # @raise [DuckDB::Error] if threads setting is not 1
     # @return [void]
     #
     # @example Expose a CSV as a table
     #   require 'csv'
-    #   con.execute('SET threads=1')
     #   DuckDB::TableFunction.add_table_adapter(CSV, CSVTableAdapter.new)
     #   csv = CSV.new(File.read('data.csv'), headers: true)
     #   con.expose_as_table(csv, 'csv_table')
@@ -317,18 +314,6 @@ module DuckDB
     end
 
     private
-
-    def check_threads
-      result = execute("SELECT current_setting('threads')")
-      thread_count = result.first.first.to_i
-
-      return unless thread_count > 1
-
-      raise DuckDB::Error,
-            'Functions with Ruby callbacks require single-threaded execution. ' \
-            "Current threads setting: #{thread_count}. " \
-            "Execute 'SET threads=1' before registering functions."
-    end
 
     def run_appender_block(appender, &)
       return appender unless block_given?

--- a/lib/duckdb/table_function.rb
+++ b/lib/duckdb/table_function.rb
@@ -163,7 +163,6 @@ module DuckDB
       #
       #   # Register and use:
       #   DuckDB::TableFunction.add_table_adapter(CSV, CSVTableAdapter.new)
-      #   con.execute('SET threads=1')
       #   con.expose_as_table(csv, 'csv_table')
       #   con.query('SELECT * FROM csv_table()').to_a
       #

--- a/test/duckdb_test/data_chunk_test.rb
+++ b/test/duckdb_test/data_chunk_test.rb
@@ -56,8 +56,6 @@ module DuckDBTest
 
     # Test 4: Vector#logical_type returns LogicalType
     def test_vector_logical_type # rubocop:disable Minitest/MultipleAssertions
-      @conn.execute('SET threads=1')
-
       table_function = DuckDB::TableFunction.new
       table_function.name = 'test_vector_type'
 
@@ -98,8 +96,6 @@ module DuckDBTest
 
     # Test 5: DataChunk#set_value with INTEGER
     def test_data_chunk_set_value_integer
-      @conn.execute('SET threads=1')
-
       done = false
       table_function = DuckDB::TableFunction.new
       table_function.name = 'test_set_value_int'
@@ -133,8 +129,6 @@ module DuckDBTest
 
     # Test 6: DataChunk#set_value with BIGINT
     def test_data_chunk_set_value_bigint
-      @conn.execute('SET threads=1')
-
       done = false
       table_function = DuckDB::TableFunction.new
       table_function.name = 'test_set_value_bigint'
@@ -165,8 +159,6 @@ module DuckDBTest
 
     # Test 7: DataChunk#set_value with VARCHAR
     def test_data_chunk_set_value_varchar
-      @conn.execute('SET threads=1')
-
       done = false
       table_function = DuckDB::TableFunction.new
       table_function.name = 'test_set_value_varchar'
@@ -199,8 +191,6 @@ module DuckDBTest
 
     # Test 8: DataChunk#set_value with DOUBLE
     def test_data_chunk_set_value_double
-      @conn.execute('SET threads=1')
-
       done = false
       table_function = DuckDB::TableFunction.new
       table_function.name = 'test_set_value_double'
@@ -233,8 +223,6 @@ module DuckDBTest
 
     # Test 9: DataChunk#set_value with NULL
     def test_data_chunk_set_value_null # rubocop:disable Minitest/MultipleAssertions
-      @conn.execute('SET threads=1')
-
       done = false
       table_function = DuckDB::TableFunction.new
       table_function.name = 'test_set_value_null'
@@ -269,8 +257,6 @@ module DuckDBTest
 
     # Test 10: DataChunk#set_value with BLOB
     def test_data_chunk_set_value_blob
-      @conn.execute('SET threads=1')
-
       done = false
       table_function = DuckDB::TableFunction.new
       table_function.name = 'test_set_value_blob'
@@ -306,8 +292,6 @@ module DuckDBTest
     # Test 11: DataChunk#set_value with multiple columns
     # rubocop:disable Minitest/MultipleAssertions
     def test_data_chunk_set_value_multiple_columns
-      @conn.execute('SET threads=1')
-
       done = false
       table_function = DuckDB::TableFunction.new
       table_function.name = 'test_set_value_multi'
@@ -361,8 +345,6 @@ module DuckDBTest
 
     # Test 12: DataChunk#set_value with TIMESTAMP
     def test_data_chunk_set_value_timestamp
-      @conn.execute('SET threads=1')
-
       done = false
       table_function = DuckDB::TableFunction.new
       table_function.name = 'test_set_value_timestamp'
@@ -398,8 +380,6 @@ module DuckDBTest
 
     # Test 13: DataChunk#set_value with TIMESTAMP_TZ
     def test_data_chunk_set_value_timestamp_tz # rubocop:disable Minitest/MultipleAssertions
-      @conn.execute('SET threads=1')
-
       done = false
       table_function = DuckDB::TableFunction.new
       table_function.name = 'test_set_value_timestamp_tz'

--- a/test/duckdb_test/gc_stress_test.rb
+++ b/test/duckdb_test/gc_stress_test.rb
@@ -82,8 +82,6 @@ module DuckDBTest
       skip 'GC.compact not available' unless GC.respond_to?(:compact)
       skip 'GC.compact hangs on Windows in parallel test execution' if Gem.win_platform?
 
-      @con.execute('SET threads=1') # Table functions still require single-threaded execution
-
       # Capture local variables
       multiplier = 3
       done = false
@@ -134,8 +132,6 @@ module DuckDBTest
     def test_mixed_functions_gc_stress
       skip 'GC.compact not available' unless GC.respond_to?(:compact)
       skip 'GC.compact hangs on Windows in parallel test execution' if Gem.win_platform?
-
-      @con.execute('SET threads=1') # Table functions still require single-threaded execution
 
       # Register both scalar and table functions
       @con.register_scalar_function(DuckDB::ScalarFunction.new.tap do |sf|

--- a/test/duckdb_test/table_function_csv_test.rb
+++ b/test/duckdb_test/table_function_csv_test.rb
@@ -50,7 +50,6 @@ module DuckDBTest
     def setup
       @db = DuckDB::Database.open
       @con = @db.connect
-      @con.execute('SET threads=1') # Required for Ruby callbacks
     end
 
     def teardown

--- a/test/duckdb_test/table_function_integration_test.rb
+++ b/test/duckdb_test/table_function_integration_test.rb
@@ -7,7 +7,6 @@ module DuckDBTest
     def setup
       @database = DuckDB::Database.open
       @connection = @database.connect
-      @connection.execute('SET threads=1') # Required for Ruby callbacks
     end
 
     def teardown
@@ -48,6 +47,70 @@ module DuckDBTest
       assert_equal ['test'], rows[2]
     end
     # rubocop:enable Minitest/MultipleAssertions
+
+    # Verifies that register_table_function works with threads > 1.
+    # Callbacks are dispatched to the shared executor thread so correctness
+    # is preserved even when DuckDB invokes them from worker threads.
+    def test_register_table_function_under_multi_thread_setting
+      @connection.execute('SET threads=4')
+      table_function = create_simple_function
+
+      @connection.register_table_function(table_function)
+      rows = @connection.query('SELECT * FROM simple_function()').each.to_a
+
+      assert_equal [[1, 'Alice'], [2, 'Bob'], [3, 'Charlie']], rows
+    end
+
+    # An exception raised inside the execute callback must surface as
+    # DuckDB::Error — even when DuckDB invokes the callback from a worker
+    # thread. Guards against longjmp escaping through native frames.
+    def test_execute_callback_error_propagation_under_multi_thread_setting
+      @connection.execute('SET threads=4')
+
+      tf = DuckDB::TableFunction.new
+      tf.name = 'raising_function'
+      tf.bind { |bind_info| bind_info.add_result_column('id', DuckDB::LogicalType::BIGINT) }
+      tf.init { |_init_info| } # rubocop:disable Lint/EmptyBlock
+      tf.execute { |_func_info, _output| raise 'boom from execute' }
+
+      @connection.register_table_function(tf)
+
+      error = assert_raises(DuckDB::Error) do
+        @connection.query('SELECT * FROM raising_function()').each.to_a
+      end
+      assert_match(/boom from execute/, error.message)
+    end
+
+    # When the total row count spans multiple chunks, execute is invoked
+    # repeatedly until size=0 is returned. Exercises the executor dispatch
+    # across many invocations under threads > 1.
+    def test_execute_callback_multi_chunk_under_multi_thread_setting
+      @connection.execute('SET threads=4')
+      target_rows = 5000
+      emitted = 0
+
+      tf = DuckDB::TableFunction.new
+      tf.name = 'multi_chunk_function'
+      tf.bind { |bind_info| bind_info.add_result_column('n', DuckDB::LogicalType::BIGINT) }
+      tf.init { |_init_info| emitted = 0 }
+      tf.execute do |_func_info, output|
+        remaining = target_rows - emitted
+        if remaining <= 0
+          output.size = 0
+        else
+          batch = [remaining, 1000].min
+          batch.times { |i| output.set_value(0, i, emitted + i) }
+          output.size = batch
+          emitted += batch
+        end
+      end
+
+      @connection.register_table_function(tf)
+      result = @connection.query('SELECT COUNT(*) AS c, SUM(n) AS s FROM multi_chunk_function()').each.to_a
+
+      assert_equal target_rows, result[0][0]
+      assert_equal (0...target_rows).sum, result[0][1]
+    end
 
     private
 

--- a/test/duckdb_test/table_function_integration_test.rb
+++ b/test/duckdb_test/table_function_integration_test.rb
@@ -52,7 +52,7 @@ module DuckDBTest
     # Callbacks are dispatched to the shared executor thread so correctness
     # is preserved even when DuckDB invokes them from worker threads.
     def test_register_table_function_under_multi_thread_setting
-      @connection.execute('SET threads=4')
+      set_multi_thread
       table_function = create_simple_function
 
       @connection.register_table_function(table_function)
@@ -65,7 +65,7 @@ module DuckDBTest
     # DuckDB::Error — even when DuckDB invokes the callback from a worker
     # thread. Guards against longjmp escaping through native frames.
     def test_execute_callback_error_propagation_under_multi_thread_setting
-      @connection.execute('SET threads=4')
+      set_multi_thread
 
       tf = DuckDB::TableFunction.new
       tf.name = 'raising_function'
@@ -85,15 +85,17 @@ module DuckDBTest
     # repeatedly until size=0 is returned. Exercises the executor dispatch
     # across many invocations under threads > 1.
     def test_execute_callback_multi_chunk_under_multi_thread_setting
-      @connection.execute('SET threads=4')
+      set_multi_thread
       target_rows = 5000
       emitted = 0
+      execute_calls = 0
 
       tf = DuckDB::TableFunction.new
       tf.name = 'multi_chunk_function'
       tf.bind { |bind_info| bind_info.add_result_column('n', DuckDB::LogicalType::BIGINT) }
       tf.init { |_init_info| emitted = 0 }
       tf.execute do |_func_info, output|
+        execute_calls += 1
         remaining = target_rows - emitted
         if remaining <= 0
           output.size = 0
@@ -110,9 +112,14 @@ module DuckDBTest
 
       assert_equal target_rows, result[0][0]
       assert_equal (0...target_rows).sum, result[0][1]
+      assert_operator execute_calls, :>, 1, 'expected execute to be invoked across multiple chunks'
     end
 
     private
+
+    def set_multi_thread
+      @connection.execute('SET threads=4')
+    end
 
     def create_simple_function
       done = false # Track state with closure variable

--- a/test/duckdb_test/table_function_test.rb
+++ b/test/duckdb_test/table_function_test.rb
@@ -16,7 +16,6 @@ module DuckDBTest
     def test_create_with_set_value
       db = DuckDB::Database.open
       conn = db.connect
-      conn.query('SET threads=1')
 
       called = 0
 
@@ -91,7 +90,6 @@ module DuckDBTest
 
       db = DuckDB::Database.open
       conn = db.connect
-      conn.query('SET threads=1')
 
       # Capture local variable in callbacks
       row_multiplier = 2
@@ -155,7 +153,6 @@ module DuckDBTest
     def test_symbol_columns
       db = DuckDB::Database.open
       conn = db.connect
-      conn.query('SET threads=1')
 
       # Capture local variable in callbacks
       row_multiplier = 2


### PR DESCRIPTION
## Summary

Related to #1136.

Remove the `threads=1` restriction from `DuckDB::TableFunction`.

Previously, `register_table_function` raised an error if DuckDB's thread count was greater than 1, requiring users to execute `SET threads=1` before registering functions. This was a workaround because DuckDB worker threads are not Ruby threads and cannot safely acquire the GVL.

The `function_executor` infrastructure (introduced in a prior commit) already solves this correctly by dispatching callbacks to a global Ruby executor thread when called from non-Ruby threads. This PR removes the now-unnecessary restriction.

## Changes

- Remove `check_threads` method from `Connection`
- Remove `SET threads=1` from docs and test setup
- Add integration tests verifying table functions work with `threads=4`

## How it works

All table function callbacks (bind, init, execute) go through `rbduckdb_function_executor_dispatch`, which handles three cases:

1. Called from a Ruby thread **with** GVL → invoke directly
2. Called from a Ruby thread **without** GVL → `rb_thread_call_with_gvl`
3. Called from a DuckDB worker thread (non-Ruby thread) → enqueue to global executor Ruby thread

DuckDB worker threads block until the executor processes their callback, making it safe for any thread count.

## What is not yet implemented

This PR uses a **single global executor thread** — all DuckDB worker threads serialize their callbacks through one Ruby thread. Per-worker proxy threads (one dedicated Ruby thread per DuckDB worker) are **not** implemented yet.

Per-worker proxies would allow callbacks from different workers to compete for the GVL in round-robin fashion rather than queuing strictly serially, which could improve throughput for workloads where callbacks release the GVL (e.g., I/O). That approach is tracked in #1136 and requires DuckDB >= 1.5.0 (with a fallback for 1.4.x LTS).