### PR TITLE
refactor: rename C functions in client_context.c to follow HACKING.md conventions

### DIFF
--- a/ext/duckdb/client_context.c
+++ b/ext/duckdb/client_context.c
@@ -5,7 +5,7 @@ VALUE cDuckDBClientContext;
 static void deallocate(void *ctx);
 static VALUE allocate(VALUE klass);
 static size_t memsize(const void *p);
-static VALUE rbduckdb_client_context_connection_id(VALUE self);
+static VALUE client_context_connection_id(VALUE self);
 
 static const rb_data_type_t client_context_data_type = {
     "DuckDB/ClientContext",
@@ -42,7 +42,7 @@ VALUE rbduckdb_client_context_new(duckdb_client_context client_context) {
     return obj;
 }
 
-rubyDuckDBClientContext *get_struct_client_context(VALUE obj) {
+rubyDuckDBClientContext *rbduckdb_get_struct_client_context(VALUE obj) {
     rubyDuckDBClientContext *ctx;
     TypedData_Get_Struct(obj, rubyDuckDBClientContext, &client_context_data_type, ctx);
     return ctx;
@@ -54,17 +54,17 @@ rubyDuckDBClientContext *get_struct_client_context(VALUE obj) {
  *
  * Returns the connection id of the client context.
  */
-static VALUE rbduckdb_client_context_connection_id(VALUE self) {
+static VALUE client_context_connection_id(VALUE self) {
     rubyDuckDBClientContext *ctx;
     TypedData_Get_Struct(self, rubyDuckDBClientContext, &client_context_data_type, ctx);
     return ULL2NUM(duckdb_client_context_get_connection_id(ctx->client_context));
 }
 
-void rbduckdb_init_duckdb_client_context(void) {
+void rbduckdb_init_client_context(void) {
 #if 0
     VALUE mDuckDB = rb_define_module("DuckDB");
 #endif
     cDuckDBClientContext = rb_define_class_under(mDuckDB, "ClientContext", rb_cObject);
     rb_define_alloc_func(cDuckDBClientContext, allocate);
-    rb_define_method(cDuckDBClientContext, "connection_id", rbduckdb_client_context_connection_id, 0);
+    rb_define_method(cDuckDBClientContext, "connection_id", client_context_connection_id, 0);
 }

--- a/ext/duckdb/client_context.h
+++ b/ext/duckdb/client_context.h
@@ -7,8 +7,8 @@ struct _rubyDuckDBClientContext {
 
 typedef struct _rubyDuckDBClientContext rubyDuckDBClientContext;
 
-void rbduckdb_init_duckdb_client_context(void);
+void rbduckdb_init_client_context(void);
 VALUE rbduckdb_client_context_new(duckdb_client_context client_context);
-rubyDuckDBClientContext *get_struct_client_context(VALUE obj);
+rubyDuckDBClientContext *rbduckdb_get_struct_client_context(VALUE obj);
 
 #endif

--- a/ext/duckdb/duckdb.c
+++ b/ext/duckdb/duckdb.c
@@ -60,7 +60,7 @@ Init_duckdb_native(void) {
     rbduckdb_init_duckdb_scalar_function_set();
     rbduckdb_init_duckdb_aggregate_function();
     rbduckdb_init_duckdb_expression();
-    rbduckdb_init_duckdb_client_context();
+    rbduckdb_init_client_context();
     rbduckdb_init_duckdb_scalar_function_bind_info();
     rbduckdb_init_duckdb_vector();
     rbduckdb_init_duckdb_data_chunk();

--- a/ext/duckdb/expression.c
+++ b/ext/duckdb/expression.c
@@ -74,7 +74,7 @@ static VALUE rbduckdb_expression_fold(VALUE self, VALUE client_context) {
     VALUE result;
 
     TypedData_Get_Struct(self, rubyDuckDBExpression, &expression_data_type, expr_ctx);
-    cc_ctx = get_struct_client_context(client_context);
+    cc_ctx = rbduckdb_get_struct_client_context(client_context);
 
     error_data = duckdb_expression_fold(cc_ctx->client_context, expr_ctx->expression, &out_value);
 


### PR DESCRIPTION
## Summary

- Rename `rbduckdb_client_context_connection_id` → `client_context_connection_id` per Rule 1 (`rb_define_method` static function: `classname_methodname`)
- Rename `get_struct_client_context` → `rbduckdb_get_struct_client_context` per Rule 11 (extern functions must have `rbduckdb_` prefix); updated call site in `expression.c`
- Rename `rbduckdb_init_duckdb_client_context` → `rbduckdb_init_client_context` per Rule 10 (no redundant `duckdb_` in init function names); updated call site in `duckdb.c`

## Test plan

- [x] `bundle exec rake test` — 1084 runs, 0 failures, 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code refactoring to standardize naming conventions. No user-visible changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->