### PR TITLE
refactor: rename C functions in column.c to follow HACKING.md conventions

### DIFF
--- a/ext/duckdb/column.c
+++ b/ext/duckdb/column.c
@@ -5,9 +5,9 @@ static VALUE cDuckDBColumn;
 static void deallocate(void *ctx);
 static VALUE allocate(VALUE klass);
 static size_t memsize(const void *p);
-static VALUE duckdb_column__type(VALUE oDuckDBColumn);
-static VALUE duckdb_column__logical_type(VALUE oDuckDBColumn);
-static VALUE duckdb_column_get_name(VALUE oDuckDBColumn);
+static VALUE column__type(VALUE oDuckDBColumn);
+static VALUE column_logical_type(VALUE oDuckDBColumn);
+static VALUE column_name(VALUE oDuckDBColumn);
 
 static const rb_data_type_t column_data_type = {
     "DuckDB/Column",
@@ -31,7 +31,7 @@ static size_t memsize(const void *p) {
 }
 
 /* :nodoc: */
-VALUE duckdb_column__type(VALUE oDuckDBColumn) {
+VALUE column__type(VALUE oDuckDBColumn) {
     rubyDuckDBColumn *ctx;
     rubyDuckDBResult *ctxresult;
     VALUE result;
@@ -53,7 +53,7 @@ VALUE duckdb_column__type(VALUE oDuckDBColumn) {
  *  Returns the logical type class.
  *
  */
-VALUE duckdb_column__logical_type(VALUE oDuckDBColumn) {
+VALUE column_logical_type(VALUE oDuckDBColumn) {
     rubyDuckDBColumn *ctx;
     rubyDuckDBResult *ctxresult;
     VALUE result;
@@ -80,7 +80,7 @@ VALUE duckdb_column__logical_type(VALUE oDuckDBColumn) {
  *  Returns the column name.
  *
  */
-VALUE duckdb_column_get_name(VALUE oDuckDBColumn) {
+VALUE column_name(VALUE oDuckDBColumn) {
     rubyDuckDBColumn *ctx;
     VALUE result;
     rubyDuckDBResult *ctxresult;
@@ -107,14 +107,14 @@ VALUE rbduckdb_create_column(VALUE oDuckDBResult, idx_t col) {
     return obj;
 }
 
-void rbduckdb_init_duckdb_column(void) {
+void rbduckdb_init_column(void) {
 #if 0
     VALUE mDuckDB = rb_define_module("DuckDB");
 #endif
     cDuckDBColumn = rb_define_class_under(mDuckDB, "Column", rb_cObject);
     rb_define_alloc_func(cDuckDBColumn, allocate);
 
-    rb_define_private_method(cDuckDBColumn, "_type", duckdb_column__type, 0);
-    rb_define_method(cDuckDBColumn, "logical_type", duckdb_column__logical_type, 0);
-    rb_define_method(cDuckDBColumn, "name", duckdb_column_get_name, 0);
+    rb_define_private_method(cDuckDBColumn, "_type", column__type, 0);
+    rb_define_method(cDuckDBColumn, "logical_type", column_logical_type, 0);
+    rb_define_method(cDuckDBColumn, "name", column_name, 0);
 }

--- a/ext/duckdb/column.h
+++ b/ext/duckdb/column.h
@@ -8,7 +8,7 @@ struct _rubyDuckDBColumn {
 
 typedef struct _rubyDuckDBColumn rubyDuckDBColumn;
 
-void rbduckdb_init_duckdb_column(void);
+void rbduckdb_init_column(void);
 VALUE rbduckdb_create_column(VALUE oDuckDBResult, idx_t col);
 
 #endif

--- a/ext/duckdb/duckdb.c
+++ b/ext/duckdb/duckdb.c
@@ -45,7 +45,7 @@ Init_duckdb_native(void) {
     rbduckdb_init_database();
     rbduckdb_init_duckdb_connection();
     rbduckdb_init_duckdb_result();
-    rbduckdb_init_duckdb_column();
+    rbduckdb_init_column();
     rbduckdb_init_logical_type();
     rbduckdb_init_duckdb_prepared_statement();
     rbduckdb_init_duckdb_pending_result();


### PR DESCRIPTION
## Summary

- Rename `duckdb_column__type` → `column__type` per Rule 2 (`rb_define_private_method` static function: `classname__methodname`)
- Rename `duckdb_column__logical_type` → `column_logical_type` per Rule 1 (`rb_define_method` static function: `classname_methodname`)
- Rename `duckdb_column_get_name` → `column_name` per Rule 1
- Rename `rbduckdb_init_duckdb_column` → `rbduckdb_init_column` per Rule 10 (no redundant `duckdb_` in init function names); updated call site in `duckdb.c`

## Test plan

- [x] `bundle exec rake test` — 1084 runs, 0 failures, 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)