### PR TITLE
refactor: rename C functions in aggregate_function.c to follow HACKING.md conventions

### DIFF
--- a/ext/duckdb/aggregate_function.c
+++ b/ext/duckdb/aggregate_function.c
@@ -569,21 +569,18 @@ static void execute_finalize_callback_protected(void *user_data) {
 
     for (i = 0; i < arg->count; i++) {
         ruby_aggregate_state *state = states[i];
+        struct finalize_one_arg one;
         struct vector_set_arg vsa;
         int exception_state;
         VALUE ret;
 
-        if (arg->ctx->finalize_proc != Qnil) {
-            struct finalize_one_arg one;
-            one.finalize_proc = arg->ctx->finalize_proc;
-            one.ruby_state = state->ruby_state;
-            ret = rb_protect(call_finalize_proc, (VALUE)&one, &exception_state);
-            if (exception_state) {
-                report_ruby_error_to_duckdb(arg->info);
-                goto cleanup;
-            }
-        } else {
-            ret = state->ruby_state;
+        one.finalize_proc = arg->ctx->finalize_proc;
+        one.ruby_state = state->ruby_state;
+
+        ret = rb_protect(call_finalize_proc, (VALUE)&one, &exception_state);
+        if (exception_state) {
+            report_ruby_error_to_duckdb(arg->info);
+            goto cleanup;
         }
 
         vsa.vector = arg->result;
@@ -619,7 +616,7 @@ static void finalize_callback(duckdb_function_info info,
     struct finalize_callback_arg arg;
 
     ctx = (rubyDuckDBAggregateFunction *)duckdb_aggregate_function_get_extra_info(info);
-    if (ctx == NULL) {
+    if (ctx == NULL || ctx->finalize_proc == Qnil) {
         return;
     }
 
@@ -670,11 +667,10 @@ static void destroy_callback(duckdb_aggregate_state *states, idx_t count) {
 
 /*
  * Wire up all 5 DuckDB aggregate callbacks on the underlying aggregate_function.
- * Called once init_proc has been supplied.  finalize_proc is optional; when
- * absent the finalize callback uses the identity (returns the state as-is).
+ * Called once both init_proc and finalize_proc have been supplied.
  */
 static void maybe_set_functions(rubyDuckDBAggregateFunction *p) {
-    if (p->init_proc == Qnil) {
+    if (p->init_proc == Qnil || p->finalize_proc == Qnil) {
         return;
     }
     duckdb_aggregate_function_set_extra_info(p->aggregate_function, p, NULL);

--- a/ext/duckdb/aggregate_function.c
+++ b/ext/duckdb/aggregate_function.c
@@ -32,15 +32,15 @@ static void deallocate(void *);
 static VALUE allocate(VALUE klass);
 static size_t memsize(const void *p);
 static void compact(void *);
-static VALUE duckdb_aggregate_function_initialize(VALUE self);
-static VALUE rbduckdb_aggregate_function_set_name(VALUE self, VALUE name);
-static VALUE rbduckdb_aggregate_function__set_return_type(VALUE self, VALUE logical_type);
-static VALUE rbduckdb_aggregate_function_add_parameter(VALUE self, VALUE logical_type);
-static VALUE rbduckdb_aggregate_function_set_init(VALUE self);
-static VALUE rbduckdb_aggregate_function_set_update(VALUE self);
-static VALUE rbduckdb_aggregate_function_set_combine(VALUE self);
-static VALUE rbduckdb_aggregate_function_set_finalize(VALUE self);
-static VALUE rbduckdb_aggregate_function__set_special_handling(VALUE self);
+static VALUE aggregate_function_initialize(VALUE self);
+static VALUE aggregate_function_set_name(VALUE self, VALUE name);
+static VALUE aggregate_function__set_return_type(VALUE self, VALUE logical_type);
+static VALUE aggregate_function__add_parameter(VALUE self, VALUE logical_type);
+static VALUE aggregate_function_set_init(VALUE self);
+static VALUE aggregate_function_set_update(VALUE self);
+static VALUE aggregate_function_set_combine(VALUE self);
+static VALUE aggregate_function_set_finalize(VALUE self);
+static VALUE aggregate_function__set_special_handling(VALUE self);
 
 static const rb_data_type_t aggregate_function_data_type = {
     "DuckDB/AggregateFunction",
@@ -87,13 +87,13 @@ static size_t memsize(const void *p) {
     return sizeof(rubyDuckDBAggregateFunction);
 }
 
-rubyDuckDBAggregateFunction *get_struct_aggregate_function(VALUE obj) {
+rubyDuckDBAggregateFunction *rbduckdb_get_struct_aggregate_function(VALUE obj) {
     rubyDuckDBAggregateFunction *ctx;
     TypedData_Get_Struct(obj, rubyDuckDBAggregateFunction, &aggregate_function_data_type, ctx);
     return ctx;
 }
 
-static VALUE duckdb_aggregate_function_initialize(VALUE self) {
+static VALUE aggregate_function_initialize(VALUE self) {
     rubyDuckDBAggregateFunction *p;
     TypedData_Get_Struct(self, rubyDuckDBAggregateFunction, &aggregate_function_data_type, p);
     p->aggregate_function = duckdb_create_aggregate_function();
@@ -105,7 +105,7 @@ static VALUE duckdb_aggregate_function_initialize(VALUE self) {
     return self;
 }
 
-static VALUE rbduckdb_aggregate_function_set_name(VALUE self, VALUE name) {
+static VALUE aggregate_function_set_name(VALUE self, VALUE name) {
     rubyDuckDBAggregateFunction *p;
     TypedData_Get_Struct(self, rubyDuckDBAggregateFunction, &aggregate_function_data_type, p);
 
@@ -115,7 +115,7 @@ static VALUE rbduckdb_aggregate_function_set_name(VALUE self, VALUE name) {
     return self;
 }
 
-static VALUE rbduckdb_aggregate_function__set_return_type(VALUE self, VALUE logical_type) {
+static VALUE aggregate_function__set_return_type(VALUE self, VALUE logical_type) {
     rubyDuckDBAggregateFunction *p;
     rubyDuckDBLogicalType *lt;
 
@@ -127,7 +127,7 @@ static VALUE rbduckdb_aggregate_function__set_return_type(VALUE self, VALUE logi
     return self;
 }
 
-static VALUE rbduckdb_aggregate_function_add_parameter(VALUE self, VALUE logical_type) {
+static VALUE aggregate_function__add_parameter(VALUE self, VALUE logical_type) {
     rubyDuckDBAggregateFunction *p;
     rubyDuckDBLogicalType *lt;
 
@@ -690,7 +690,7 @@ static void maybe_set_functions(rubyDuckDBAggregateFunction *p) {
 }
 
 /* :nodoc: */
-static VALUE rbduckdb_aggregate_function_set_init(VALUE self) {
+static VALUE aggregate_function_set_init(VALUE self) {
     rubyDuckDBAggregateFunction *p;
 
     if (!rb_block_given_p()) {
@@ -706,7 +706,7 @@ static VALUE rbduckdb_aggregate_function_set_init(VALUE self) {
 }
 
 /* :nodoc: */
-static VALUE rbduckdb_aggregate_function_set_update(VALUE self) {
+static VALUE aggregate_function_set_update(VALUE self) {
     rubyDuckDBAggregateFunction *p;
 
     if (!rb_block_given_p()) {
@@ -722,7 +722,7 @@ static VALUE rbduckdb_aggregate_function_set_update(VALUE self) {
 }
 
 /* :nodoc: */
-static VALUE rbduckdb_aggregate_function_set_combine(VALUE self) {
+static VALUE aggregate_function_set_combine(VALUE self) {
     rubyDuckDBAggregateFunction *p;
 
     if (!rb_block_given_p()) {
@@ -738,7 +738,7 @@ static VALUE rbduckdb_aggregate_function_set_combine(VALUE self) {
 }
 
 /* :nodoc: */
-static VALUE rbduckdb_aggregate_function_set_finalize(VALUE self) {
+static VALUE aggregate_function_set_finalize(VALUE self) {
     rubyDuckDBAggregateFunction *p;
 
     if (!rb_block_given_p()) {
@@ -754,7 +754,7 @@ static VALUE rbduckdb_aggregate_function_set_finalize(VALUE self) {
 }
 
 /* :nodoc: */
-static VALUE rbduckdb_aggregate_function__set_special_handling(VALUE self) {
+static VALUE aggregate_function__set_special_handling(VALUE self) {
     rubyDuckDBAggregateFunction *p;
     TypedData_Get_Struct(self, rubyDuckDBAggregateFunction, &aggregate_function_data_type, p);
     p->special_handling = true;
@@ -763,28 +763,28 @@ static VALUE rbduckdb_aggregate_function__set_special_handling(VALUE self) {
 }
 
 /* Returns the number of Ruby states currently tracked in the registry. */
-static VALUE aggregate_function_state_registry_size(VALUE klass) {
+static VALUE aggregate_function_s__state_registry_size(VALUE klass) {
     (void)klass;
     return LONG2NUM((long)RHASH_SIZE(g_aggregate_state_registry));
 }
 
-void rbduckdb_init_duckdb_aggregate_function(void) {
+void rbduckdb_init_aggregate_function(void) {
 #if 0
     VALUE mDuckDB = rb_define_module("DuckDB");
 #endif
     cDuckDBAggregateFunction = rb_define_class_under(mDuckDB, "AggregateFunction", rb_cObject);
     rb_define_alloc_func(cDuckDBAggregateFunction, allocate);
-    rb_define_method(cDuckDBAggregateFunction, "initialize", duckdb_aggregate_function_initialize, 0);
-    rb_define_method(cDuckDBAggregateFunction, "name=", rbduckdb_aggregate_function_set_name, 1);
-    rb_define_private_method(cDuckDBAggregateFunction, "_set_return_type", rbduckdb_aggregate_function__set_return_type, 1);
-    rb_define_private_method(cDuckDBAggregateFunction, "_add_parameter", rbduckdb_aggregate_function_add_parameter, 1);
-    rb_define_method(cDuckDBAggregateFunction, "set_init", rbduckdb_aggregate_function_set_init, 0);
-    rb_define_method(cDuckDBAggregateFunction, "set_update", rbduckdb_aggregate_function_set_update, 0);
-    rb_define_method(cDuckDBAggregateFunction, "set_combine", rbduckdb_aggregate_function_set_combine, 0);
-    rb_define_method(cDuckDBAggregateFunction, "set_finalize", rbduckdb_aggregate_function_set_finalize, 0);
-    rb_define_private_method(cDuckDBAggregateFunction, "_set_special_handling", rbduckdb_aggregate_function__set_special_handling, 0);
+    rb_define_method(cDuckDBAggregateFunction, "initialize", aggregate_function_initialize, 0);
+    rb_define_method(cDuckDBAggregateFunction, "name=", aggregate_function_set_name, 1);
+    rb_define_private_method(cDuckDBAggregateFunction, "_set_return_type", aggregate_function__set_return_type, 1);
+    rb_define_private_method(cDuckDBAggregateFunction, "_add_parameter", aggregate_function__add_parameter, 1);
+    rb_define_method(cDuckDBAggregateFunction, "set_init", aggregate_function_set_init, 0);
+    rb_define_method(cDuckDBAggregateFunction, "set_update", aggregate_function_set_update, 0);
+    rb_define_method(cDuckDBAggregateFunction, "set_combine", aggregate_function_set_combine, 0);
+    rb_define_method(cDuckDBAggregateFunction, "set_finalize", aggregate_function_set_finalize, 0);
+    rb_define_private_method(cDuckDBAggregateFunction, "_set_special_handling", aggregate_function__set_special_handling, 0);
     rb_define_singleton_method(cDuckDBAggregateFunction, "_state_registry_size",
-                               aggregate_function_state_registry_size, 0);
+                               aggregate_function_s__state_registry_size, 0);
 
     g_aggregate_state_registry = rb_hash_new();
     rb_gc_register_mark_object(g_aggregate_state_registry);

--- a/ext/duckdb/aggregate_function.c
+++ b/ext/duckdb/aggregate_function.c
@@ -569,18 +569,21 @@ static void execute_finalize_callback_protected(void *user_data) {
 
     for (i = 0; i < arg->count; i++) {
         ruby_aggregate_state *state = states[i];
-        struct finalize_one_arg one;
         struct vector_set_arg vsa;
         int exception_state;
         VALUE ret;
 
-        one.finalize_proc = arg->ctx->finalize_proc;
-        one.ruby_state = state->ruby_state;
-
-        ret = rb_protect(call_finalize_proc, (VALUE)&one, &exception_state);
-        if (exception_state) {
-            report_ruby_error_to_duckdb(arg->info);
-            goto cleanup;
+        if (arg->ctx->finalize_proc != Qnil) {
+            struct finalize_one_arg one;
+            one.finalize_proc = arg->ctx->finalize_proc;
+            one.ruby_state = state->ruby_state;
+            ret = rb_protect(call_finalize_proc, (VALUE)&one, &exception_state);
+            if (exception_state) {
+                report_ruby_error_to_duckdb(arg->info);
+                goto cleanup;
+            }
+        } else {
+            ret = state->ruby_state;
         }
 
         vsa.vector = arg->result;
@@ -616,7 +619,7 @@ static void finalize_callback(duckdb_function_info info,
     struct finalize_callback_arg arg;
 
     ctx = (rubyDuckDBAggregateFunction *)duckdb_aggregate_function_get_extra_info(info);
-    if (ctx == NULL || ctx->finalize_proc == Qnil) {
+    if (ctx == NULL) {
         return;
     }
 
@@ -667,10 +670,11 @@ static void destroy_callback(duckdb_aggregate_state *states, idx_t count) {
 
 /*
  * Wire up all 5 DuckDB aggregate callbacks on the underlying aggregate_function.
- * Called once both init_proc and finalize_proc have been supplied.
+ * Called once init_proc has been supplied.  finalize_proc is optional; when
+ * absent the finalize callback uses the identity (returns the state as-is).
  */
 static void maybe_set_functions(rubyDuckDBAggregateFunction *p) {
-    if (p->init_proc == Qnil || p->finalize_proc == Qnil) {
+    if (p->init_proc == Qnil) {
         return;
     }
     duckdb_aggregate_function_set_extra_info(p->aggregate_function, p, NULL);

--- a/ext/duckdb/aggregate_function.h
+++ b/ext/duckdb/aggregate_function.h
@@ -12,7 +12,7 @@ struct _rubyDuckDBAggregateFunction {
 
 typedef struct _rubyDuckDBAggregateFunction rubyDuckDBAggregateFunction;
 
-void rbduckdb_init_duckdb_aggregate_function(void);
-rubyDuckDBAggregateFunction *get_struct_aggregate_function(VALUE obj);
+void rbduckdb_init_aggregate_function(void);
+rubyDuckDBAggregateFunction *rbduckdb_get_struct_aggregate_function(VALUE obj);
 
 #endif

--- a/ext/duckdb/connection.c
+++ b/ext/duckdb/connection.c
@@ -272,7 +272,7 @@ static VALUE duckdb_connection_register_aggregate_function(VALUE self, VALUE agg
     duckdb_state state;
 
     ctxcon = get_struct_connection(self);
-    ctxaf = get_struct_aggregate_function(aggregate_function);
+    ctxaf = rbduckdb_get_struct_aggregate_function(aggregate_function);
 
     state = duckdb_register_aggregate_function(ctxcon->con, ctxaf->aggregate_function);
 

--- a/ext/duckdb/duckdb.c
+++ b/ext/duckdb/duckdb.c
@@ -58,7 +58,7 @@ Init_duckdb_native(void) {
     rbduckdb_init_duckdb_value();
     rbduckdb_init_duckdb_scalar_function();
     rbduckdb_init_duckdb_scalar_function_set();
-    rbduckdb_init_duckdb_aggregate_function();
+    rbduckdb_init_aggregate_function();
     rbduckdb_init_duckdb_expression();
     rbduckdb_init_client_context();
     rbduckdb_init_duckdb_scalar_function_bind_info();

--- a/test/duckdb_test/aggregate_function_test.rb
+++ b/test/duckdb_test/aggregate_function_test.rb
@@ -24,6 +24,15 @@ module DuckDBTest
       assert_equal 42, result.first.first
     end
 
+    def test_default_finalize_returns_state_as_is
+      register_aggregate('my_agg_no_finalize',
+                         init: -> { 42 })
+
+      result = @con.query('SELECT my_agg_no_finalize(i) FROM range(100) t(i)')
+
+      assert_equal 42, result.first.first
+    end
+
     def test_aggregate_update_sums_values
       register_aggregate('my_sum',
                          init: -> { 0 },
@@ -310,7 +319,7 @@ module DuckDBTest
       func.set_init(&callbacks[:init])
       func.set_update(&callbacks[:update]) if callbacks[:update]
       func.set_combine(&callbacks[:combine]) if callbacks[:combine]
-      func.set_finalize(&callbacks[:finalize])
+      func.set_finalize(&callbacks[:finalize]) if callbacks[:finalize]
     end
   end
 end

--- a/test/duckdb_test/aggregate_function_test.rb
+++ b/test/duckdb_test/aggregate_function_test.rb
@@ -24,15 +24,6 @@ module DuckDBTest
       assert_equal 42, result.first.first
     end
 
-    def test_default_finalize_returns_state_as_is
-      register_aggregate('my_agg_no_finalize',
-                         init: -> { 42 })
-
-      result = @con.query('SELECT my_agg_no_finalize(i) FROM range(100) t(i)')
-
-      assert_equal 42, result.first.first
-    end
-
     def test_aggregate_update_sums_values
       register_aggregate('my_sum',
                          init: -> { 0 },
@@ -319,7 +310,7 @@ module DuckDBTest
       func.set_init(&callbacks[:init])
       func.set_update(&callbacks[:update]) if callbacks[:update]
       func.set_combine(&callbacks[:combine]) if callbacks[:combine]
-      func.set_finalize(&callbacks[:finalize]) if callbacks[:finalize]
+      func.set_finalize(&callbacks[:finalize])
     end
   end
 end


### PR DESCRIPTION
## Summary

- Rename `rb_define_method` callbacks to `aggregate_function_<methodname>` (Rule 1)
- Rename `rb_define_private_method` callbacks to `aggregate_function__<methodname>` (Rule 2)
- Rename singleton method callback to `aggregate_function_s__state_registry_size` (Rule 8)
- Rename extern `get_struct_aggregate_function` → `rbduckdb_get_struct_aggregate_function` (Rule 11)
- Rename init function `rbduckdb_init_duckdb_aggregate_function` → `rbduckdb_init_aggregate_function` (Rule 10)
- Update callers in `connection.c` and `duckdb.c`

## Test plan

- [x] `bundle exec rake test` — 1084 runs, 0 failures, 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)