### PR TITLE
feat: add DuckDB::Value.create_decimal

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -27,6 +27,7 @@ Metrics/ClassLength:
     - 'lib/duckdb/prepared_statement.rb'
     - 'lib/duckdb/appender.rb'
     - 'lib/duckdb/connection.rb'
+    - 'lib/duckdb/value.rb'
 
 Metrics/MethodLength:
   Exclude:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 - add `DuckDB::Appender#clear_columns`.
 - add `DuckDB::Appender#add_column`.
 - add `DuckDB::Appender#clear` to discard all unflushed data from the appender without writing it to the table (requires DuckDB >= 1.5.0).
+- add `DuckDB::Value.create_decimal`.
 
 # 1.5.2.0 - 2026-04-16
 

--- a/ext/duckdb/value.c
+++ b/ext/duckdb/value.c
@@ -20,6 +20,7 @@ static VALUE duckdb_value_s__create_varchar(VALUE klass, VALUE str);
 static VALUE duckdb_value_s__create_blob(VALUE klass, VALUE str);
 static VALUE duckdb_value_s__create_hugeint(VALUE klass, VALUE lower, VALUE upper);
 static VALUE duckdb_value_s__create_uhugeint(VALUE klass, VALUE lower, VALUE upper);
+static VALUE duckdb_value_s__create_decimal(VALUE klass, VALUE lower, VALUE upper, VALUE width, VALUE scale);
 static VALUE duckdb_value_s_create_null(VALUE klass);
 
 static const rb_data_type_t value_data_type = {
@@ -126,6 +127,16 @@ static VALUE duckdb_value_s__create_uhugeint(VALUE klass, VALUE lower, VALUE upp
     uhugeint.lower = NUM2ULL(lower);
     uhugeint.upper = NUM2ULL(upper);
     duckdb_value value = duckdb_create_uhugeint(uhugeint);
+    return rbduckdb_value_new(value);
+}
+
+static VALUE duckdb_value_s__create_decimal(VALUE klass, VALUE lower, VALUE upper, VALUE width, VALUE scale) {
+    duckdb_decimal decimal;
+    decimal.value.lower = NUM2ULL(lower);
+    decimal.value.upper = NUM2LL(upper);
+    decimal.width = (uint8_t)NUM2UINT(width);
+    decimal.scale = (uint8_t)NUM2UINT(scale);
+    duckdb_value value = duckdb_create_decimal(decimal);
     return rbduckdb_value_new(value);
 }
 
@@ -274,6 +285,7 @@ void rbduckdb_init_duckdb_value(void) {
     rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_blob", duckdb_value_s__create_blob, 1);
     rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_hugeint", duckdb_value_s__create_hugeint, 2);
     rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_uhugeint", duckdb_value_s__create_uhugeint, 2);
+    rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_decimal", duckdb_value_s__create_decimal, 4);
     rb_define_singleton_method(cDuckDBValue, "create_null", duckdb_value_s_create_null, 0);
 }
 

--- a/lib/duckdb/converter.rb
+++ b/lib/duckdb/converter.rb
@@ -18,6 +18,7 @@ module DuckDB
     RANGE_UINT64 = 0..18_446_744_073_709_551_615
     RANGE_HUGEINT = (-(1 << 127)..((1 << 127) - 1))
     RANGE_UHUGEINT = (0..((1 << 128) - 1))
+    RANGE_DECIMAL_WIDTH = 1..38
 
     HALF_HUGEINT_BIT = 64
     HALF_HUGEINT = 1 << HALF_HUGEINT_BIT
@@ -120,6 +121,10 @@ module DuckDB
 
     def _hugeint_upper(value)
       value >> HALF_HUGEINT_BIT
+    end
+
+    def _decimal_width(value)
+      value.to_s('F').gsub(/[^0-9]/, '').length
     end
 
     def _to_decimal_from_hugeint(width, scale, upper, lower = nil)

--- a/lib/duckdb/logical_type.rb
+++ b/lib/duckdb/logical_type.rb
@@ -2,8 +2,6 @@
 
 module DuckDB
   class LogicalType # rubocop:disable Metrics/ClassLength
-    RANGE_DECIMAL_WIDTH = 1..38
-
     alias :alias get_alias
     alias :alias= set_alias
 
@@ -171,7 +169,7 @@ module DuckDB
       #   decimal_type.width #=> 18
       #   decimal_type.scale #=> 3
       def create_decimal(width, scale)
-        raise DuckDB::Error, 'width must be between 1 and 38' unless RANGE_DECIMAL_WIDTH.cover?(width)
+        raise DuckDB::Error, 'width must be between 1 and 38' unless Converter::RANGE_DECIMAL_WIDTH.cover?(width)
         raise DuckDB::Error, "scale must be between 0 and width(#{width})" unless (0..width).cover?(scale)
 
         _create_decimal_type(width, scale)

--- a/lib/duckdb/prepared_statement.rb
+++ b/lib/duckdb/prepared_statement.rb
@@ -281,7 +281,7 @@ module DuckDB
     def bind_decimal(index, value)
       decimal = _parse_deciaml(value)
       lower, upper = decimal_to_hugeint(decimal)
-      width = decimal.to_s('F').gsub(/[^0-9]/, '').length
+      width = _decimal_width(decimal)
       _bind_decimal(index, lower, upper, width, decimal.scale)
     end
 

--- a/lib/duckdb/value.rb
+++ b/lib/duckdb/value.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'bigdecimal'
+
 module DuckDB
   class Value
     class << self
@@ -217,6 +219,23 @@ module DuckDB
 
         lower, upper = integer_to_hugeint(value)
         _create_uhugeint(lower, upper)
+      end
+
+      # Creates a DuckDB::Value of DECIMAL type.
+      #
+      #   value = DuckDB::Value.create_decimal(BigDecimal('12345.678'))
+      #
+      # @param value [BigDecimal] the decimal value.
+      # @return [DuckDB::Value] the created Value object.
+      # @raise [ArgumentError] if +value+ is not a BigDecimal or its width is out of range (1..38).
+      def create_decimal(value)
+        check_type!(value, BigDecimal)
+
+        width = _decimal_width(value)
+        check_range!(width, RANGE_DECIMAL_WIDTH, 'DECIMAL width')
+
+        lower, upper = decimal_to_hugeint(value)
+        _create_decimal(lower, upper, width, value.scale)
       end
 
       private

--- a/test/duckdb_test/value_test.rb
+++ b/test/duckdb_test/value_test.rb
@@ -558,6 +558,60 @@ module DuckDBTest
       end
     end
 
+    def test_create_decimal_with_positive
+      value = DuckDB::Value.create_decimal(BigDecimal('12345.678'))
+
+      assert_instance_of(DuckDB::Value, value)
+    end
+
+    def test_create_decimal_with_negative
+      value = DuckDB::Value.create_decimal(BigDecimal('-12345.678'))
+
+      assert_instance_of(DuckDB::Value, value)
+    end
+
+    def test_create_decimal_with_zero
+      value = DuckDB::Value.create_decimal(BigDecimal('0'))
+
+      assert_instance_of(DuckDB::Value, value)
+    end
+
+    def test_create_decimal_with_leading_fractional_zeros
+      value = DuckDB::Value.create_decimal(BigDecimal('0.0012'))
+
+      assert_instance_of(DuckDB::Value, value)
+    end
+
+    def test_create_decimal_with_string_raises_argument_error
+      assert_raises(ArgumentError) do
+        DuckDB::Value.create_decimal('not decimal')
+      end
+    end
+
+    def test_create_decimal_with_integer_raises_argument_error
+      assert_raises(ArgumentError) do
+        DuckDB::Value.create_decimal(123)
+      end
+    end
+
+    def test_create_decimal_with_float_raises_argument_error
+      assert_raises(ArgumentError) do
+        DuckDB::Value.create_decimal(1.23)
+      end
+    end
+
+    def test_create_decimal_with_nil_raises_argument_error
+      assert_raises(ArgumentError) do
+        DuckDB::Value.create_decimal(nil)
+      end
+    end
+
+    def test_create_decimal_with_width_over_38_raises_argument_error
+      assert_raises(ArgumentError) do
+        DuckDB::Value.create_decimal(BigDecimal('1' * 39))
+      end
+    end
+
     def test_create_int32_bind_value
       @con.query('CREATE TABLE e2e_int32 (id INTEGER, val INTEGER)')
       stmt = DuckDB::PreparedStatement.new(@con, 'INSERT INTO e2e_int32 VALUES (1, ?)')
@@ -689,6 +743,36 @@ module DuckDBTest
       result = @con.query('SELECT val FROM e2e_uhugeint WHERE id = 1')
 
       assert_equal(340_282_366_920_938_463_463_374_607_431_768_211_455, result.first[0])
+    end
+
+    def test_create_decimal_bind_value
+      @con.query('CREATE TABLE e2e_decimal (id INTEGER, val DECIMAL(8, 3))')
+      stmt = DuckDB::PreparedStatement.new(@con, 'INSERT INTO e2e_decimal VALUES (1, ?)')
+      stmt.bind_value(1, DuckDB::Value.create_decimal(BigDecimal('12345.678')))
+      stmt.execute
+      result = @con.query('SELECT val FROM e2e_decimal WHERE id = 1')
+
+      assert_equal(BigDecimal('12345.678'), result.first[0])
+    end
+
+    def test_create_decimal_bind_value_negative
+      @con.query('CREATE TABLE e2e_decimal_neg (id INTEGER, val DECIMAL(6, 3))')
+      stmt = DuckDB::PreparedStatement.new(@con, 'INSERT INTO e2e_decimal_neg VALUES (1, ?)')
+      stmt.bind_value(1, DuckDB::Value.create_decimal(BigDecimal('-987.654')))
+      stmt.execute
+      result = @con.query('SELECT val FROM e2e_decimal_neg WHERE id = 1')
+
+      assert_equal(BigDecimal('-987.654'), result.first[0])
+    end
+
+    def test_create_decimal_bind_value_leading_fractional_zeros
+      @con.query('CREATE TABLE e2e_decimal_frac (id INTEGER, val DECIMAL(5, 4))')
+      stmt = DuckDB::PreparedStatement.new(@con, 'INSERT INTO e2e_decimal_frac VALUES (1, ?)')
+      stmt.bind_value(1, DuckDB::Value.create_decimal(BigDecimal('0.0012')))
+      stmt.execute
+      result = @con.query('SELECT val FROM e2e_decimal_frac WHERE id = 1')
+
+      assert_equal(BigDecimal('0.0012'), result.first[0])
     end
   end
 end


### PR DESCRIPTION
Wrap duckdb_create_decimal() C API to create DECIMAL type values. This enables binding decimal values via PreparedStatement#bind_value.

ref: https://duckdb.org/docs/stable/clients/c/api.html#duckdb_create_decimal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `DuckDB::Value.create_decimal` method for creating decimal values from BigDecimal objects, with validation for width and scale constraints.

* **Tests**
  * Comprehensive test coverage for decimal value creation, type validation, and prepared statement binding with various decimal inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->