### PR TITLE
refactor: rename connection.c functions to follow HACKING.md conventions

### DIFF
--- a/ext/duckdb/appender.c
+++ b/ext/duckdb/appender.c
@@ -120,7 +120,7 @@ static VALUE appender_s_create_query(VALUE klass, VALUE con, VALUE query, VALUE 
             column_names[i] = StringValuePtr(col_name_val);
         }
     }
-    ctxcon = get_struct_connection(con);
+    ctxcon = rbduckdb_get_struct_connection(con);
     appender = allocate(klass);
     TypedData_Get_Struct(appender, rubyDuckDBAppender, &appender_data_type, ctx);
     if (duckdb_appender_create_query(ctxcon->con, query_str, column_count, type_array, table_name, column_names, &ctx->appender) == DuckDBError) {
@@ -141,7 +141,7 @@ static VALUE appender_initialize(VALUE self, VALUE con, VALUE schema, VALUE tabl
     }
 
     TypedData_Get_Struct(self, rubyDuckDBAppender, &appender_data_type, ctx);
-    ctxcon = get_struct_connection(con);
+    ctxcon = rbduckdb_get_struct_connection(con);
 
     if (schema != Qnil) {
         pschema = StringValuePtr(schema);

--- a/ext/duckdb/connection.c
+++ b/ext/duckdb/connection.c
@@ -6,16 +6,16 @@ static void deallocate(void *ctx);
 static void mark(void *ctx);
 static VALUE allocate(VALUE klass);
 static size_t memsize(const void *p);
-static VALUE duckdb_connection_disconnect(VALUE self);
-static VALUE duckdb_connection_interrupt(VALUE self);
-static VALUE duckdb_connection_query_progress(VALUE self);
-static VALUE duckdb_connection_connect(VALUE self, VALUE oDuckDBDatabase);
-static VALUE duckdb_connection_query_sql(VALUE self, VALUE str);
-static VALUE duckdb_connection_register_logical_type(VALUE self, VALUE logical_type);
-static VALUE duckdb_connection_register_scalar_function(VALUE self, VALUE scalar_function);
-static VALUE duckdb_connection_register_scalar_function_set(VALUE self, VALUE scalar_function_set);
-static VALUE duckdb_connection_register_aggregate_function(VALUE self, VALUE aggregate_function);
-static VALUE duckdb_connection_register_table_function(VALUE self, VALUE table_function);
+static VALUE connection_disconnect(VALUE self);
+static VALUE connection_interrupt(VALUE self);
+static VALUE connection_query_progress(VALUE self);
+static VALUE connection__connect(VALUE self, VALUE oDuckDBDatabase);
+static VALUE connection__query_sql(VALUE self, VALUE str);
+static VALUE connection__register_logical_type(VALUE self, VALUE logical_type);
+static VALUE connection__register_scalar_function(VALUE self, VALUE scalar_function);
+static VALUE connection__register_scalar_function_set(VALUE self, VALUE scalar_function_set);
+static VALUE connection__register_aggregate_function(VALUE self, VALUE aggregate_function);
+static VALUE connection__register_table_function(VALUE self, VALUE table_function);
 
 static const rb_data_type_t connection_data_type = {
     "DuckDB/Connection",
@@ -48,7 +48,7 @@ static size_t memsize(const void *p) {
     return sizeof(rubyDuckDBConnection);
 }
 
-rubyDuckDBConnection *get_struct_connection(VALUE obj) {
+rubyDuckDBConnection *rbduckdb_get_struct_connection(VALUE obj) {
     rubyDuckDBConnection *ctx;
     TypedData_Get_Struct(obj, rubyDuckDBConnection, &connection_data_type, ctx);
     return ctx;
@@ -71,7 +71,7 @@ VALUE rbduckdb_create_connection(VALUE oDuckDBDatabase) {
     return obj;
 }
 
-static VALUE duckdb_connection_disconnect(VALUE self) {
+static VALUE connection_disconnect(VALUE self) {
     rubyDuckDBConnection *ctx;
 
     TypedData_Get_Struct(self, rubyDuckDBConnection, &connection_data_type, ctx);
@@ -98,7 +98,7 @@ static VALUE duckdb_connection_disconnect(VALUE self) {
  *  pending_result.execute_task
  *  con.interrupt # => nil
  */
-static VALUE duckdb_connection_interrupt(VALUE self) {
+static VALUE connection_interrupt(VALUE self) {
     rubyDuckDBConnection *ctx;
 
     TypedData_Get_Struct(self, rubyDuckDBConnection, &connection_data_type, ctx);
@@ -122,7 +122,7 @@ static VALUE duckdb_connection_interrupt(VALUE self) {
  *  pending_result.execute_task
  *  con.query_progress # => Float
  */
-static VALUE duckdb_connection_query_progress(VALUE self) {
+static VALUE connection_query_progress(VALUE self) {
     rubyDuckDBConnection *ctx;
     duckdb_query_progress_type progress;
 
@@ -133,7 +133,7 @@ static VALUE duckdb_connection_query_progress(VALUE self) {
 }
 
 /* :nodoc: */
-static VALUE duckdb_connection_connect(VALUE self, VALUE oDuckDBDatabase) {
+static VALUE connection__connect(VALUE self, VALUE oDuckDBDatabase) {
     rubyDuckDBConnection *ctx;
     rubyDuckDB *ctxdb;
 
@@ -169,7 +169,7 @@ static void *duckdb_query_nogvl(void *arg) {
 }
 
 /* :nodoc: */
-static VALUE duckdb_connection_query_sql(VALUE self, VALUE str) {
+static VALUE connection__query_sql(VALUE self, VALUE str) {
     rubyDuckDBConnection *ctx;
     rubyDuckDBResult *ctxr;
 
@@ -203,12 +203,12 @@ static VALUE duckdb_connection_query_sql(VALUE self, VALUE str) {
 }
 
 /* :nodoc: */
-static VALUE duckdb_connection_register_logical_type(VALUE self, VALUE logical_type) {
+static VALUE connection__register_logical_type(VALUE self, VALUE logical_type) {
     rubyDuckDBConnection *ctxcon;
     rubyDuckDBLogicalType *ctxlt;
     duckdb_state state;
 
-    ctxcon = get_struct_connection(self);
+    ctxcon = rbduckdb_get_struct_connection(self);
     ctxlt = rbduckdb_get_struct_logical_type(logical_type);
 
     state = duckdb_register_logical_type(ctxcon->con, ctxlt->logical_type, NULL);
@@ -224,12 +224,12 @@ static VALUE duckdb_connection_register_logical_type(VALUE self, VALUE logical_t
 }
 
 /* :nodoc: */
-static VALUE duckdb_connection_register_scalar_function(VALUE self, VALUE scalar_function) {
+static VALUE connection__register_scalar_function(VALUE self, VALUE scalar_function) {
     rubyDuckDBConnection *ctxcon;
     rubyDuckDBScalarFunction *ctxsf;
     duckdb_state state;
 
-    ctxcon = get_struct_connection(self);
+    ctxcon = rbduckdb_get_struct_connection(self);
     ctxsf = get_struct_scalar_function(scalar_function);
 
     state = duckdb_register_scalar_function(ctxcon->con, ctxsf->scalar_function);
@@ -245,12 +245,12 @@ static VALUE duckdb_connection_register_scalar_function(VALUE self, VALUE scalar
 }
 
 /* :nodoc: */
-static VALUE duckdb_connection_register_scalar_function_set(VALUE self, VALUE scalar_function_set) {
+static VALUE connection__register_scalar_function_set(VALUE self, VALUE scalar_function_set) {
     rubyDuckDBConnection *ctxcon;
     rubyDuckDBScalarFunctionSet *ctxsfs;
     duckdb_state state;
 
-    ctxcon = get_struct_connection(self);
+    ctxcon = rbduckdb_get_struct_connection(self);
     ctxsfs = get_struct_scalar_function_set(scalar_function_set);
 
     state = duckdb_register_scalar_function_set(ctxcon->con, ctxsfs->scalar_function_set);
@@ -266,12 +266,12 @@ static VALUE duckdb_connection_register_scalar_function_set(VALUE self, VALUE sc
 }
 
 /* :nodoc: */
-static VALUE duckdb_connection_register_aggregate_function(VALUE self, VALUE aggregate_function) {
+static VALUE connection__register_aggregate_function(VALUE self, VALUE aggregate_function) {
     rubyDuckDBConnection *ctxcon;
     rubyDuckDBAggregateFunction *ctxaf;
     duckdb_state state;
 
-    ctxcon = get_struct_connection(self);
+    ctxcon = rbduckdb_get_struct_connection(self);
     ctxaf = rbduckdb_get_struct_aggregate_function(aggregate_function);
 
     state = duckdb_register_aggregate_function(ctxcon->con, ctxaf->aggregate_function);
@@ -286,12 +286,12 @@ static VALUE duckdb_connection_register_aggregate_function(VALUE self, VALUE agg
     return self;
 }
 
-static VALUE duckdb_connection_register_table_function(VALUE self, VALUE table_function) {
+static VALUE connection__register_table_function(VALUE self, VALUE table_function) {
     rubyDuckDBConnection *ctxcon;
     rubyDuckDBTableFunction *ctxtf;
     duckdb_state state;
 
-    ctxcon = get_struct_connection(self);
+    ctxcon = rbduckdb_get_struct_connection(self);
     ctxtf = get_struct_table_function(table_function);
 
     state = duckdb_register_table_function(ctxcon->con, ctxtf->table_function);
@@ -306,22 +306,21 @@ static VALUE duckdb_connection_register_table_function(VALUE self, VALUE table_f
     return self;
 }
 
-void rbduckdb_init_duckdb_connection(void) {
+void rbduckdb_init_connection(void) {
 #if 0
     VALUE mDuckDB = rb_define_module("DuckDB");
 #endif
     cDuckDBConnection = rb_define_class_under(mDuckDB, "Connection", rb_cObject);
     rb_define_alloc_func(cDuckDBConnection, allocate);
 
-    rb_define_method(cDuckDBConnection, "disconnect", duckdb_connection_disconnect, 0);
-    rb_define_method(cDuckDBConnection, "interrupt", duckdb_connection_interrupt, 0);
-    rb_define_method(cDuckDBConnection, "query_progress", duckdb_connection_query_progress, 0);
-    rb_define_private_method(cDuckDBConnection, "_register_logical_type", duckdb_connection_register_logical_type, 1);
-    rb_define_private_method(cDuckDBConnection, "_register_scalar_function", duckdb_connection_register_scalar_function, 1);
-    rb_define_private_method(cDuckDBConnection, "_register_scalar_function_set", duckdb_connection_register_scalar_function_set, 1);
-    rb_define_private_method(cDuckDBConnection, "_register_aggregate_function", duckdb_connection_register_aggregate_function, 1);
-    rb_define_private_method(cDuckDBConnection, "_register_table_function", duckdb_connection_register_table_function, 1);
-    rb_define_private_method(cDuckDBConnection, "_connect", duckdb_connection_connect, 1);
-    /* TODO: query_sql => _query_sql */
-    rb_define_private_method(cDuckDBConnection, "query_sql", duckdb_connection_query_sql, 1);
+    rb_define_method(cDuckDBConnection, "disconnect", connection_disconnect, 0);
+    rb_define_method(cDuckDBConnection, "interrupt", connection_interrupt, 0);
+    rb_define_method(cDuckDBConnection, "query_progress", connection_query_progress, 0);
+    rb_define_private_method(cDuckDBConnection, "_register_logical_type", connection__register_logical_type, 1);
+    rb_define_private_method(cDuckDBConnection, "_register_scalar_function", connection__register_scalar_function, 1);
+    rb_define_private_method(cDuckDBConnection, "_register_scalar_function_set", connection__register_scalar_function_set, 1);
+    rb_define_private_method(cDuckDBConnection, "_register_aggregate_function", connection__register_aggregate_function, 1);
+    rb_define_private_method(cDuckDBConnection, "_register_table_function", connection__register_table_function, 1);
+    rb_define_private_method(cDuckDBConnection, "_connect", connection__connect, 1);
+    rb_define_private_method(cDuckDBConnection, "_query_sql", connection__query_sql, 1);
 }

--- a/ext/duckdb/connection.h
+++ b/ext/duckdb/connection.h
@@ -8,8 +8,8 @@ struct _rubyDuckDBConnection {
 
 typedef struct _rubyDuckDBConnection rubyDuckDBConnection;
 
-rubyDuckDBConnection *get_struct_connection(VALUE obj);
-void rbduckdb_init_duckdb_connection(void);
+rubyDuckDBConnection *rbduckdb_get_struct_connection(VALUE obj);
+void rbduckdb_init_connection(void);
 VALUE rbduckdb_create_connection(VALUE oDuckDBDatabase);
 
 #endif

--- a/ext/duckdb/duckdb.c
+++ b/ext/duckdb/duckdb.c
@@ -43,7 +43,7 @@ Init_duckdb_native(void) {
 
     rbduckdb_init_duckdb_error();
     rbduckdb_init_database();
-    rbduckdb_init_duckdb_connection();
+    rbduckdb_init_connection();
     rbduckdb_init_duckdb_result();
     rbduckdb_init_column();
     rbduckdb_init_logical_type();

--- a/ext/duckdb/extracted_statements.c
+++ b/ext/duckdb/extracted_statements.c
@@ -50,7 +50,7 @@ static VALUE duckdb_extracted_statements__initialize(VALUE self, VALUE con, VALU
     }
 
     pquery = StringValuePtr(query);
-    pcon = get_struct_connection(con);
+    pcon = rbduckdb_get_struct_connection(con);
     TypedData_Get_Struct(self, rubyDuckDBExtractedStatements, &extract_statements_data_type, ctx);
 
     ctx->num_statements = duckdb_extract_statements(pcon->con, pquery, &(ctx->extracted_statements));
@@ -88,7 +88,7 @@ static VALUE duckdb_extracted_statements_prepared_statement(VALUE self, VALUE co
     if (rb_obj_is_kind_of(con, cDuckDBConnection) != Qtrue) {
         rb_raise(rb_eTypeError, "1st argument must be DuckDB::Connection");
     }
-    pcon = get_struct_connection(con);
+    pcon = rbduckdb_get_struct_connection(con);
     TypedData_Get_Struct(self, rubyDuckDBExtractedStatements, &extract_statements_data_type, ctx);
 
     return rbduckdb_prepared_statement_new(pcon->con, ctx->extracted_statements, NUM2ULL(index));

--- a/ext/duckdb/prepared_statement.c
+++ b/ext/duckdb/prepared_statement.c
@@ -93,7 +93,7 @@ static VALUE duckdb_prepared_statement_initialize(VALUE self, VALUE con, VALUE q
     }
 
     TypedData_Get_Struct(self, rubyDuckDBPreparedStatement, &prepared_statement_data_type, ctx);
-    ctxcon = get_struct_connection(con);
+    ctxcon = rbduckdb_get_struct_connection(con);
 
     if (duckdb_prepare(ctxcon->con, StringValuePtr(query), &(ctx->prepared_statement)) == DuckDBError) {
         const char *error = duckdb_prepare_error(ctx->prepared_statement);

--- a/ext/duckdb/table_description.c
+++ b/ext/duckdb/table_description.c
@@ -70,7 +70,7 @@ static VALUE duckdb_table_description__initialize(VALUE self, VALUE con, VALUE c
     if (!NIL_P(table)) {
         ptable = StringValuePtr(table);
     }
-    ctxcon = get_struct_connection(con);
+    ctxcon = rbduckdb_get_struct_connection(con);
     ctx = get_struct_table_description(self);
 
     if (ctx->table_description) {

--- a/lib/duckdb/connection.rb
+++ b/lib/duckdb/connection.rb
@@ -34,7 +34,7 @@ module DuckDB
 
     def query_multi_sql(sql)
       stmts = ExtractedStatements.new(self, sql)
-      return query_sql(sql) if stmts.size == 1
+      return _query_sql(sql) if stmts.size == 1
 
       result = nil
       stmts.each do |stmt|


### PR DESCRIPTION
## Summary

- **Rule 1/2**: Static functions renamed from `duckdb_connection_*` to `connection_*` (public) and `connection__*` (private with double underscore)
- **Rule 10**: `rbduckdb_init_duckdb_connection` → `rbduckdb_init_connection` (removed redundant `duckdb_` segment)
- **Rule 11**: `get_struct_connection` → `rbduckdb_get_struct_connection` (added `rbduckdb_` prefix); updated callers in `appender.c`, `extracted_statements.c`, `prepared_statement.c`, `table_description.c`
- **TODO resolved**: Ruby method `query_sql` renamed to `_query_sql` to match the private-via-wrapper pattern; updated caller in `lib/duckdb/connection.rb`

## Test plan

- [x] `bundle exec rake compile` — clean build, no warnings
- [x] `bundle exec rake test` — 1102 runs, 0 failures, 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)