### PR TITLE
refactor: fix converter naming to follow HACKING.md conventions

### DIFF
--- a/ext/duckdb/converter.h
+++ b/ext/duckdb/converter.h
@@ -32,12 +32,6 @@ VALUE rbduckdb_time_to_ruby(duckdb_time t);
 VALUE rbduckdb_date_to_ruby(duckdb_date date);
 VALUE rbduckdb_timestamp_to_ruby(duckdb_timestamp ts);
 
-VALUE infinite_date_value(duckdb_date date);
-VALUE infinite_timestamp_value(duckdb_timestamp timestamp);
-VALUE infinite_timestamp_s_value(duckdb_timestamp_s timestamp_s);
-VALUE infinite_timestamp_ms_value(duckdb_timestamp_ms timestamp_ms);
-VALUE infinite_timestamp_ns_value(duckdb_timestamp_ns timestamp_ns);
-
-void rbduckdb_init_duckdb_converter(void);
+void rbduckdb_init_converter(void);
 
 #endif

--- a/ext/duckdb/conveter.c
+++ b/ext/duckdb/conveter.c
@@ -17,7 +17,7 @@ ID id__to_time_from_duckdb_timestamp_tz;
 ID id__to_infinity;
 ID id__decimal_to_unscaled;
 
-VALUE infinite_date_value(duckdb_date date) {
+static VALUE infinite_date_value(duckdb_date date) {
     if (duckdb_is_finite_date(date) == false) {
         return rb_funcall(mDuckDBConverter, id__to_infinity, 1,
                           INT2NUM(date.days)
@@ -26,7 +26,7 @@ VALUE infinite_date_value(duckdb_date date) {
     return Qnil;
 }
 
-VALUE infinite_timestamp_value(duckdb_timestamp timestamp) {
+static VALUE infinite_timestamp_value(duckdb_timestamp timestamp) {
     if (duckdb_is_finite_timestamp(timestamp) == false) {
         return rb_funcall(mDuckDBConverter, id__to_infinity, 1,
                           LL2NUM(timestamp.micros)
@@ -35,7 +35,7 @@ VALUE infinite_timestamp_value(duckdb_timestamp timestamp) {
     return Qnil;
 }
 
-VALUE infinite_timestamp_s_value(duckdb_timestamp_s timestamp_s) {
+static VALUE infinite_timestamp_s_value(duckdb_timestamp_s timestamp_s) {
     if (duckdb_is_finite_timestamp_s(timestamp_s) == false) {
         return rb_funcall(mDuckDBConverter, id__to_infinity, 1,
                           LL2NUM(timestamp_s.seconds)
@@ -44,7 +44,7 @@ VALUE infinite_timestamp_s_value(duckdb_timestamp_s timestamp_s) {
     return Qnil;
 }
 
-VALUE infinite_timestamp_ms_value(duckdb_timestamp_ms timestamp_ms) {
+static VALUE infinite_timestamp_ms_value(duckdb_timestamp_ms timestamp_ms) {
     if (duckdb_is_finite_timestamp_ms(timestamp_ms) == false) {
         return rb_funcall(mDuckDBConverter, id__to_infinity, 1,
                           LL2NUM(timestamp_ms.millis)
@@ -53,7 +53,7 @@ VALUE infinite_timestamp_ms_value(duckdb_timestamp_ms timestamp_ms) {
     return Qnil;
 }
 
-VALUE infinite_timestamp_ns_value(duckdb_timestamp_ns timestamp_ns) {
+static VALUE infinite_timestamp_ns_value(duckdb_timestamp_ns timestamp_ns) {
     if (duckdb_is_finite_timestamp_ns(timestamp_ns) == false) {
         return rb_funcall(mDuckDBConverter, id__to_infinity, 1,
                           LL2NUM(timestamp_ns.nanos)
@@ -320,7 +320,7 @@ VALUE rbduckdb_timestamp_to_ruby(duckdb_timestamp ts) {
     return obj;
 }
 
-void rbduckdb_init_duckdb_converter(void) {
+void rbduckdb_init_converter(void) {
     mDuckDBConverter = rb_define_module_under(mDuckDB, "Converter");
 
     id__to_date = rb_intern("_to_date");

--- a/ext/duckdb/duckdb.c
+++ b/ext/duckdb/duckdb.c
@@ -52,7 +52,7 @@ Init_duckdb_native(void) {
     rbduckdb_init_duckdb_blob();
     rbduckdb_init_appender();
     rbduckdb_init_duckdb_config();
-    rbduckdb_init_duckdb_converter();
+    rbduckdb_init_converter();
     rbduckdb_init_duckdb_extracted_statements();
     rbduckdb_init_duckdb_instance_cache();
     rbduckdb_init_duckdb_value();


### PR DESCRIPTION
## Summary

- Make `infinite_*_value` helpers `static` in `conveter.c` and remove their declarations from `converter.h` — they are only used internally, so external linkage is unnecessary (HACKING.md rule 11)
- Rename `rbduckdb_init_duckdb_converter` → `rbduckdb_init_converter` — removes the redundant `duckdb_` segment (HACKING.md rule 10)

## Test plan

- [x] `bundle exec rake compile` — builds cleanly
- [x] `bundle exec rake test` — 1102 runs, 2257 assertions, 0 failures, 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restricted visibility of converter helper functions to internal module operations, removing external access points for internal-only functionality
  * Renamed converter module initialization function to improve naming consistency and clarity across the initialization subsystem

<!-- end of auto-generated comment: release notes by coderabbit.ai -->