### PR TITLE
refactor: fix data_chunk.c naming to follow HACKING.md conventions

### DIFF
--- a/ext/duckdb/appender.c
+++ b/ext/duckdb/appender.c
@@ -442,7 +442,7 @@ static VALUE appender__append_data_chunk(VALUE self, VALUE chunk) {
     rubyDuckDBDataChunk *chunk_ctx;
 
     TypedData_Get_Struct(self, rubyDuckDBAppender, &appender_data_type, ctx);
-    chunk_ctx = get_struct_data_chunk(chunk);
+    chunk_ctx = rbduckdb_get_struct_data_chunk(chunk);
 
     return state_to_rbool(duckdb_append_data_chunk(ctx->appender, chunk_ctx->data_chunk));
 }

--- a/ext/duckdb/data_chunk.c
+++ b/ext/duckdb/data_chunk.c
@@ -6,12 +6,12 @@ extern VALUE cDuckDBVector;
 static void deallocate(void *ctx);
 static VALUE allocate(VALUE klass);
 static size_t memsize(const void *p);
-static VALUE initialize(int argc, VALUE *argv, VALUE self);
-static VALUE rbduckdb_data_chunk_column_count(VALUE self);
-static VALUE rbduckdb_data_chunk_get_size(VALUE self);
-static VALUE rbduckdb_data_chunk_set_size(VALUE self, VALUE size);
-static VALUE rbduckdb_data_chunk_get_vector(VALUE self, VALUE col_idx);
-static VALUE rbduckdb_data_chunk__reset(VALUE self);
+static VALUE data_chunk_initialize(int argc, VALUE *argv, VALUE self);
+static VALUE data_chunk_column_count(VALUE self);
+static VALUE data_chunk_size(VALUE self);
+static VALUE data_chunk_set_size(VALUE self, VALUE size);
+static VALUE data_chunk_get_vector(VALUE self, VALUE col_idx);
+static VALUE data_chunk__reset(VALUE self);
 
 static const rb_data_type_t data_chunk_data_type = {
     "DuckDB/DataChunk",
@@ -38,13 +38,13 @@ static size_t memsize(const void *p) {
     return sizeof(rubyDuckDBDataChunk);
 }
 
-rubyDuckDBDataChunk *get_struct_data_chunk(VALUE obj) {
+rubyDuckDBDataChunk *rbduckdb_get_struct_data_chunk(VALUE obj) {
     rubyDuckDBDataChunk *ctx;
     TypedData_Get_Struct(obj, rubyDuckDBDataChunk, &data_chunk_data_type, ctx);
     return ctx;
 }
 
-static VALUE initialize(int argc, VALUE *argv, VALUE self) {
+static VALUE data_chunk_initialize(int argc, VALUE *argv, VALUE self) {
     rubyDuckDBDataChunk *ctx;
     VALUE logical_types;
     idx_t column_count;
@@ -94,7 +94,7 @@ static VALUE initialize(int argc, VALUE *argv, VALUE self) {
  *
  *   data_chunk.column_count  # => 2
  */
-static VALUE rbduckdb_data_chunk_column_count(VALUE self) {
+static VALUE data_chunk_column_count(VALUE self) {
     rubyDuckDBDataChunk *ctx;
     idx_t count;
 
@@ -113,7 +113,7 @@ static VALUE rbduckdb_data_chunk_column_count(VALUE self) {
  *
  *   data_chunk.size  # => 100
  */
-static VALUE rbduckdb_data_chunk_get_size(VALUE self) {
+static VALUE data_chunk_size(VALUE self) {
     rubyDuckDBDataChunk *ctx;
     idx_t size;
 
@@ -132,7 +132,7 @@ static VALUE rbduckdb_data_chunk_get_size(VALUE self) {
  *
  *   data_chunk.size = 50
  */
-static VALUE rbduckdb_data_chunk_set_size(VALUE self, VALUE size) {
+static VALUE data_chunk_set_size(VALUE self, VALUE size) {
     rubyDuckDBDataChunk *ctx;
     idx_t sz;
 
@@ -152,7 +152,7 @@ static VALUE rbduckdb_data_chunk_set_size(VALUE self, VALUE size) {
  *
  *   vector = data_chunk.get_vector(0)
  */
-static VALUE rbduckdb_data_chunk_get_vector(VALUE self, VALUE col_idx) {
+static VALUE data_chunk_get_vector(VALUE self, VALUE col_idx) {
     rubyDuckDBDataChunk *ctx;
     idx_t idx;
     duckdb_vector vector;
@@ -180,7 +180,7 @@ static VALUE rbduckdb_data_chunk_get_vector(VALUE self, VALUE col_idx) {
  *
  *   data_chunk._reset
  */
-static VALUE rbduckdb_data_chunk__reset(VALUE self) {
+static VALUE data_chunk__reset(VALUE self) {
     rubyDuckDBDataChunk *ctx;
 
     TypedData_Get_Struct(self, rubyDuckDBDataChunk, &data_chunk_data_type, ctx);
@@ -190,17 +190,17 @@ static VALUE rbduckdb_data_chunk__reset(VALUE self) {
     return self;
 }
 
-void rbduckdb_init_duckdb_data_chunk(void) {
+void rbduckdb_init_data_chunk(void) {
 #if 0
     VALUE mDuckDB = rb_define_module("DuckDB");
 #endif
     cDuckDBDataChunk = rb_define_class_under(mDuckDB, "DataChunk", rb_cObject);
     rb_define_alloc_func(cDuckDBDataChunk, allocate);
 
-    rb_define_method(cDuckDBDataChunk, "initialize", initialize, -1);
-    rb_define_method(cDuckDBDataChunk, "column_count", rbduckdb_data_chunk_column_count, 0);
-    rb_define_method(cDuckDBDataChunk, "size", rbduckdb_data_chunk_get_size, 0);
-    rb_define_method(cDuckDBDataChunk, "size=", rbduckdb_data_chunk_set_size, 1);
-    rb_define_method(cDuckDBDataChunk, "get_vector", rbduckdb_data_chunk_get_vector, 1);
-    rb_define_private_method(cDuckDBDataChunk, "_reset", rbduckdb_data_chunk__reset, 0);
+    rb_define_method(cDuckDBDataChunk, "initialize", data_chunk_initialize, -1);
+    rb_define_method(cDuckDBDataChunk, "column_count", data_chunk_column_count, 0);
+    rb_define_method(cDuckDBDataChunk, "size", data_chunk_size, 0);
+    rb_define_method(cDuckDBDataChunk, "size=", data_chunk_set_size, 1);
+    rb_define_method(cDuckDBDataChunk, "get_vector", data_chunk_get_vector, 1);
+    rb_define_private_method(cDuckDBDataChunk, "_reset", data_chunk__reset, 0);
 }

--- a/ext/duckdb/data_chunk.h
+++ b/ext/duckdb/data_chunk.h
@@ -8,7 +8,7 @@ struct _rubyDuckDBDataChunk {
 
 typedef struct _rubyDuckDBDataChunk rubyDuckDBDataChunk;
 
-rubyDuckDBDataChunk *get_struct_data_chunk(VALUE obj);
-void rbduckdb_init_duckdb_data_chunk(void);
+rubyDuckDBDataChunk *rbduckdb_get_struct_data_chunk(VALUE obj);
+void rbduckdb_init_data_chunk(void);
 
 #endif

--- a/ext/duckdb/duckdb.c
+++ b/ext/duckdb/duckdb.c
@@ -63,7 +63,7 @@ Init_duckdb_native(void) {
     rbduckdb_init_client_context();
     rbduckdb_init_duckdb_scalar_function_bind_info();
     rbduckdb_init_duckdb_vector();
-    rbduckdb_init_duckdb_data_chunk();
+    rbduckdb_init_data_chunk();
     rbduckdb_init_memory_helper();
     rbduckdb_init_duckdb_table_function();
     rbduckdb_init_duckdb_table_function_bind_info();

--- a/ext/duckdb/table_function.c
+++ b/ext/duckdb/table_function.c
@@ -388,7 +388,7 @@ static void execute_execute_callback_protected(void *user_data) {
     func_info_ctx->info = darg->info;
 
     data_chunk_obj = rb_class_new_instance(0, NULL, cDuckDBDataChunk);
-    data_chunk_ctx = get_struct_data_chunk(data_chunk_obj);
+    data_chunk_ctx = rbduckdb_get_struct_data_chunk(data_chunk_obj);
     data_chunk_ctx->data_chunk = darg->output;
 
     VALUE call_args[3] = { darg->ctx->execute_proc, func_info_obj, data_chunk_obj };


### PR DESCRIPTION
## Summary

- Rename static functions to `data_chunk_<methodname>` pattern (Rule 1, 2)
- Rename extern `get_struct_data_chunk` → `rbduckdb_get_struct_data_chunk` (Rule 11)
- Rename `rbduckdb_init_duckdb_data_chunk` → `rbduckdb_init_data_chunk` (Rule 10)
- Update all callers in `appender.c`, `table_function.c`, `duckdb.c`, and `data_chunk.h`

## Test plan

- [x] `bundle exec rake test` — 1102 runs, 0 failures, 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)