### PR TITLE
refactor: fix extracted_statements.c naming to follow HACKING.md conventions

### DIFF
--- a/ext/duckdb/duckdb.c
+++ b/ext/duckdb/duckdb.c
@@ -53,7 +53,7 @@ Init_duckdb_native(void) {
     rbduckdb_init_appender();
     rbduckdb_init_duckdb_config();
     rbduckdb_init_converter();
-    rbduckdb_init_duckdb_extracted_statements();
+    rbduckdb_init_extracted_statements();
     rbduckdb_init_duckdb_instance_cache();
     rbduckdb_init_duckdb_value();
     rbduckdb_init_duckdb_scalar_function();

--- a/ext/duckdb/extracted_statements.c
+++ b/ext/duckdb/extracted_statements.c
@@ -16,10 +16,10 @@ static void deallocate(void *ctx);
 static VALUE allocate(VALUE klass);
 static size_t memsize(const void *p);
 
-static VALUE duckdb_extracted_statements__initialize(VALUE self, VALUE con, VALUE query);
-static VALUE duckdb_extracted_statements_destroy(VALUE self);
-static VALUE duckdb_extracted_statements_size(VALUE self);
-static VALUE duckdb_extracted_statements_prepared_statement(VALUE self, VALUE con, VALUE index);
+static VALUE extracted_statements__initialize(VALUE self, VALUE con, VALUE query);
+static VALUE extracted_statements_destroy(VALUE self);
+static VALUE extracted_statements_size(VALUE self);
+static VALUE extracted_statements_prepared_statement(VALUE self, VALUE con, VALUE index);
 
 static void deallocate(void *ctx) {
     rubyDuckDBExtractedStatements *p = (rubyDuckDBExtractedStatements *)ctx;
@@ -39,7 +39,7 @@ static size_t memsize(const void *p) {
     return sizeof(rubyDuckDBExtractedStatements);
 }
 
-static VALUE duckdb_extracted_statements__initialize(VALUE self, VALUE con, VALUE query) {
+static VALUE extracted_statements__initialize(VALUE self, VALUE con, VALUE query) {
     rubyDuckDBConnection *pcon;
     rubyDuckDBExtractedStatements *ctx;
     char *pquery;
@@ -63,7 +63,7 @@ static VALUE duckdb_extracted_statements__initialize(VALUE self, VALUE con, VALU
     return self;
 }
 
-static VALUE duckdb_extracted_statements_destroy(VALUE self) {
+static VALUE extracted_statements_destroy(VALUE self) {
     rubyDuckDBExtractedStatements *ctx;
 
     TypedData_Get_Struct(self, rubyDuckDBExtractedStatements, &extract_statements_data_type, ctx);
@@ -73,7 +73,7 @@ static VALUE duckdb_extracted_statements_destroy(VALUE self) {
     return Qnil;
 }
 
-static VALUE duckdb_extracted_statements_size(VALUE self) {
+static VALUE extracted_statements_size(VALUE self) {
     rubyDuckDBExtractedStatements *ctx;
 
     TypedData_Get_Struct(self, rubyDuckDBExtractedStatements, &extract_statements_data_type, ctx);
@@ -81,7 +81,7 @@ static VALUE duckdb_extracted_statements_size(VALUE self) {
     return ULL2NUM(ctx->num_statements);
 }
 
-static VALUE duckdb_extracted_statements_prepared_statement(VALUE self, VALUE con, VALUE index) {
+static VALUE extracted_statements_prepared_statement(VALUE self, VALUE con, VALUE index) {
     rubyDuckDBConnection *pcon;
     rubyDuckDBExtractedStatements *ctx;
 
@@ -94,15 +94,15 @@ static VALUE duckdb_extracted_statements_prepared_statement(VALUE self, VALUE co
     return rbduckdb_prepared_statement_new(pcon->con, ctx->extracted_statements, NUM2ULL(index));
 }
 
-void rbduckdb_init_duckdb_extracted_statements(void) {
+void rbduckdb_init_extracted_statements(void) {
 #if 0
     VALUE mDuckDB = rb_define_module("DuckDB");
 #endif
     cDuckDBExtractedStatements = rb_define_class_under(mDuckDB, "ExtractedStatements", rb_cObject);
 
     rb_define_alloc_func(cDuckDBExtractedStatements, allocate);
-    rb_define_private_method(cDuckDBExtractedStatements, "_initialize", duckdb_extracted_statements__initialize, 2);
-    rb_define_method(cDuckDBExtractedStatements, "destroy", duckdb_extracted_statements_destroy, 0);
-    rb_define_method(cDuckDBExtractedStatements, "size", duckdb_extracted_statements_size, 0);
-    rb_define_method(cDuckDBExtractedStatements, "prepared_statement", duckdb_extracted_statements_prepared_statement, 2);
+    rb_define_private_method(cDuckDBExtractedStatements, "_initialize", extracted_statements__initialize, 2);
+    rb_define_method(cDuckDBExtractedStatements, "destroy", extracted_statements_destroy, 0);
+    rb_define_method(cDuckDBExtractedStatements, "size", extracted_statements_size, 0);
+    rb_define_method(cDuckDBExtractedStatements, "prepared_statement", extracted_statements_prepared_statement, 2);
 }

--- a/ext/duckdb/extracted_statements.h
+++ b/ext/duckdb/extracted_statements.h
@@ -8,5 +8,5 @@ struct _rubyDuckDBExtractedStatements {
 
 typedef struct _rubyDuckDBExtractedStatements rubyDuckDBExtractedStatements;
 
-void rbduckdb_init_duckdb_extracted_statements(void);
+void rbduckdb_init_extracted_statements(void);
 #endif


### PR DESCRIPTION
## Summary

- Rename `duckdb_extracted_statements__initialize` → `extracted_statements__initialize` (Rule 2)
- Rename `duckdb_extracted_statements_destroy` → `extracted_statements_destroy` (Rule 1)
- Rename `duckdb_extracted_statements_size` → `extracted_statements_size` (Rule 1)
- Rename `duckdb_extracted_statements_prepared_statement` → `extracted_statements_prepared_statement` (Rule 1)
- Rename `rbduckdb_init_duckdb_extracted_statements` → `rbduckdb_init_extracted_statements` (Rule 10)
- Update `extracted_statements.h` and `duckdb.c` caller accordingly

## Test plan

- [x] `bundle exec rake test` — 1102 runs, 0 failures, 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal naming conventions for extracted statements handling to improve code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->