### PR TITLE
refactor: fix result.c naming to follow HACKING.md conventions

### DIFF
--- a/ext/duckdb/column.c
+++ b/ext/duckdb/column.c
@@ -40,7 +40,7 @@ VALUE column__type(VALUE oDuckDBColumn) {
     TypedData_Get_Struct(oDuckDBColumn, rubyDuckDBColumn, &column_data_type, ctx);
 
     result = rb_ivar_get(oDuckDBColumn, rb_intern("result"));
-    ctxresult = get_struct_result(result);
+    ctxresult = rbduckdb_get_struct_result(result);
     type = duckdb_column_type(&(ctxresult->result), ctx->col);
 
     return INT2FIX(type);
@@ -63,7 +63,7 @@ VALUE column_logical_type(VALUE oDuckDBColumn) {
     TypedData_Get_Struct(oDuckDBColumn, rubyDuckDBColumn, &column_data_type, ctx);
 
     result = rb_ivar_get(oDuckDBColumn, rb_intern("result"));
-    ctxresult = get_struct_result(result);
+    ctxresult = rbduckdb_get_struct_result(result);
     _logical_type = duckdb_column_logical_type(&(ctxresult->result), ctx->col);
 
     if (_logical_type) {
@@ -89,7 +89,7 @@ VALUE column_name(VALUE oDuckDBColumn) {
 
     result = rb_ivar_get(oDuckDBColumn, rb_intern("result"));
 
-    ctxresult = get_struct_result(result);
+    ctxresult = rbduckdb_get_struct_result(result);
 
     return rb_utf8_str_new_cstr(duckdb_column_name(&(ctxresult->result), ctx->col));
 }

--- a/ext/duckdb/connection.c
+++ b/ext/duckdb/connection.c
@@ -176,7 +176,7 @@ static VALUE connection__query_sql(VALUE self, VALUE str) {
     VALUE result = rbduckdb_create_result();
 
     TypedData_Get_Struct(self, rubyDuckDBConnection, &connection_data_type, ctx);
-    ctxr = get_struct_result(result);
+    ctxr = rbduckdb_get_struct_result(result);
 
     if (!(ctx->con)) {
         rb_raise(eDuckDBError, "Database connection closed");

--- a/ext/duckdb/duckdb.c
+++ b/ext/duckdb/duckdb.c
@@ -44,7 +44,7 @@ Init_duckdb_native(void) {
     rbduckdb_init_duckdb_error();
     rbduckdb_init_database();
     rbduckdb_init_connection();
-    rbduckdb_init_duckdb_result();
+    rbduckdb_init_result();
     rbduckdb_init_column();
     rbduckdb_init_logical_type();
     rbduckdb_init_prepared_statement();

--- a/ext/duckdb/pending_result.c
+++ b/ext/duckdb/pending_result.c
@@ -100,7 +100,7 @@ static VALUE pending_result_execute_pending(VALUE self) {
     VALUE result = rbduckdb_create_result();
 
     TypedData_Get_Struct(self, rubyDuckDBPendingResult, &pending_result_data_type, ctx);
-    ctxr = get_struct_result(result);
+    ctxr = rbduckdb_get_struct_result(result);
     if (duckdb_execute_pending(ctx->pending_result, &(ctxr->result)) == DuckDBError) {
         rb_raise(eDuckDBError, "%s", duckdb_pending_error(ctx->pending_result));
     }

--- a/ext/duckdb/prepared_statement.c
+++ b/ext/duckdb/prepared_statement.c
@@ -130,7 +130,7 @@ static VALUE prepared_statement_execute(VALUE self) {
     VALUE msg;
 
     TypedData_Get_Struct(self, rubyDuckDBPreparedStatement, &prepared_statement_data_type, ctx);
-    ctxr = get_struct_result(result);
+    ctxr = rbduckdb_get_struct_result(result);
 
     prepared_statement_execute_nogvl_args args = {
         .prepared_statement = ctx->prepared_statement,

--- a/ext/duckdb/result.c
+++ b/ext/duckdb/result.c
@@ -10,19 +10,19 @@ static VALUE cDuckDBResult;
 static void deallocate(void *ctx);
 static VALUE allocate(VALUE klass);
 static size_t memsize(const void *p);
-static VALUE duckdb_result_column_count(VALUE oDuckDBResult);
-static VALUE duckdb_result_rows_changed(VALUE oDuckDBResult);
-static VALUE duckdb_result_columns(VALUE oDuckDBResult);
+static VALUE result_column_count(VALUE oDuckDBResult);
+static VALUE result_rows_changed(VALUE oDuckDBResult);
+static VALUE result_columns(VALUE oDuckDBResult);
 static VALUE destroy_data_chunk(VALUE arg);
 
-static VALUE duckdb_result__chunk_stream(VALUE oDuckDBResult);
+static VALUE result__chunk_stream(VALUE oDuckDBResult);
 static VALUE yield_rows(VALUE arg);
-static VALUE duckdb_result__column_type(VALUE oDuckDBResult, VALUE col_idx);
-static VALUE duckdb_result__return_type(VALUE oDuckDBResult);
-static VALUE duckdb_result__statement_type(VALUE oDuckDBResult);
-static VALUE duckdb_result__enum_internal_type(VALUE oDuckDBResult, VALUE col_idx);
-static VALUE duckdb_result__enum_dictionary_size(VALUE oDuckDBResult, VALUE col_idx);
-static VALUE duckdb_result__enum_dictionary_value(VALUE oDuckDBResult, VALUE col_idx, VALUE idx);
+static VALUE result__column_type(VALUE oDuckDBResult, VALUE col_idx);
+static VALUE result__return_type(VALUE oDuckDBResult);
+static VALUE result__statement_type(VALUE oDuckDBResult);
+static VALUE result__enum_internal_type(VALUE oDuckDBResult, VALUE col_idx);
+static VALUE result__enum_dictionary_size(VALUE oDuckDBResult, VALUE col_idx);
+static VALUE result__enum_dictionary_value(VALUE oDuckDBResult, VALUE col_idx, VALUE idx);
 
 static VALUE vector_date(void *vector_data, idx_t row_idx);
 static VALUE vector_timestamp(void* vector_data, idx_t row_idx);
@@ -72,7 +72,7 @@ static size_t memsize(const void *p) {
     return sizeof(rubyDuckDBResult);
 }
 
-rubyDuckDBResult *get_struct_result(VALUE obj) {
+rubyDuckDBResult *rbduckdb_get_struct_result(VALUE obj) {
     rubyDuckDBResult *ctx;
     TypedData_Get_Struct(obj, rubyDuckDBResult, &result_data_type, ctx);
     return ctx;
@@ -100,7 +100,7 @@ rubyDuckDBResult *get_struct_result(VALUE obj) {
  *    end
  *
  */
-static VALUE duckdb_result_rows_changed(VALUE oDuckDBResult) {
+static VALUE result_rows_changed(VALUE oDuckDBResult) {
     rubyDuckDBResult *ctx;
     TypedData_Get_Struct(oDuckDBResult, rubyDuckDBResult, &result_data_type, ctx);
     return LL2NUM(duckdb_rows_changed(&(ctx->result)));
@@ -124,7 +124,7 @@ static VALUE duckdb_result_rows_changed(VALUE oDuckDBResult) {
  *    end
  *
  */
-static VALUE duckdb_result_column_count(VALUE oDuckDBResult) {
+static VALUE result_column_count(VALUE oDuckDBResult) {
     rubyDuckDBResult *ctx;
     TypedData_Get_Struct(oDuckDBResult, rubyDuckDBResult, &result_data_type, ctx);
     return LL2NUM(duckdb_column_count(&(ctx->result)));
@@ -137,7 +137,7 @@ static VALUE duckdb_result_column_count(VALUE oDuckDBResult) {
  *  Returns the column class Lists.
  *
  */
-static VALUE duckdb_result_columns(VALUE oDuckDBResult) {
+static VALUE result_columns(VALUE oDuckDBResult) {
     rubyDuckDBResult *ctx;
     TypedData_Get_Struct(oDuckDBResult, rubyDuckDBResult, &result_data_type, ctx);
 
@@ -159,7 +159,7 @@ static VALUE destroy_data_chunk(VALUE arg) {
 }
 
 /* :nodoc: */
-static VALUE duckdb_result__chunk_stream(VALUE oDuckDBResult) {
+static VALUE result__chunk_stream(VALUE oDuckDBResult) {
     rubyDuckDBResult *ctx;
     struct chunk_arg arg;
 
@@ -199,28 +199,28 @@ static VALUE yield_rows(VALUE arg) {
 }
 
 /* :nodoc: */
-static VALUE duckdb_result__column_type(VALUE oDuckDBResult, VALUE col_idx) {
+static VALUE result__column_type(VALUE oDuckDBResult, VALUE col_idx) {
     rubyDuckDBResult *ctx;
     TypedData_Get_Struct(oDuckDBResult, rubyDuckDBResult, &result_data_type, ctx);
     return LL2NUM(duckdb_column_type(&(ctx->result), NUM2LL(col_idx)));
 }
 
 /* :nodoc: */
-static VALUE duckdb_result__return_type(VALUE oDuckDBResult) {
+static VALUE result__return_type(VALUE oDuckDBResult) {
     rubyDuckDBResult *ctx;
     TypedData_Get_Struct(oDuckDBResult, rubyDuckDBResult, &result_data_type, ctx);
     return INT2FIX(duckdb_result_return_type(ctx->result));
 }
 
 /* :nodoc: */
-static VALUE duckdb_result__statement_type(VALUE oDuckDBResult) {
+static VALUE result__statement_type(VALUE oDuckDBResult) {
     rubyDuckDBResult *ctx;
     TypedData_Get_Struct(oDuckDBResult, rubyDuckDBResult, &result_data_type, ctx);
     return INT2FIX(duckdb_result_statement_type(ctx->result));
 }
 
 /* :nodoc: */
-static VALUE duckdb_result__enum_internal_type(VALUE oDuckDBResult, VALUE col_idx) {
+static VALUE result__enum_internal_type(VALUE oDuckDBResult, VALUE col_idx) {
     rubyDuckDBResult *ctx;
     VALUE type = Qnil;
     duckdb_logical_type logical_type;
@@ -235,7 +235,7 @@ static VALUE duckdb_result__enum_internal_type(VALUE oDuckDBResult, VALUE col_id
 }
 
 /* :nodoc: */
-static VALUE duckdb_result__enum_dictionary_size(VALUE oDuckDBResult, VALUE col_idx) {
+static VALUE result__enum_dictionary_size(VALUE oDuckDBResult, VALUE col_idx) {
     rubyDuckDBResult *ctx;
     VALUE size = Qnil;
     duckdb_logical_type logical_type;
@@ -250,7 +250,7 @@ static VALUE duckdb_result__enum_dictionary_size(VALUE oDuckDBResult, VALUE col_
 }
 
 /* :nodoc: */
-static VALUE duckdb_result__enum_dictionary_value(VALUE oDuckDBResult, VALUE col_idx, VALUE idx) {
+static VALUE result__enum_dictionary_value(VALUE oDuckDBResult, VALUE col_idx, VALUE idx) {
     rubyDuckDBResult *ctx;
     VALUE value = Qnil;
     duckdb_logical_type logical_type;
@@ -706,7 +706,7 @@ static VALUE vector_value(duckdb_vector vector, idx_t row_idx) {
     return obj;
 }
 
-void rbduckdb_init_duckdb_result(void) {
+void rbduckdb_init_result(void) {
 #if 0
     VALUE mDuckDB = rb_define_module("DuckDB");
 #endif
@@ -714,15 +714,15 @@ void rbduckdb_init_duckdb_result(void) {
 
     rb_define_alloc_func(cDuckDBResult, allocate);
 
-    rb_define_method(cDuckDBResult, "column_count", duckdb_result_column_count, 0);
-    rb_define_method(cDuckDBResult, "rows_changed", duckdb_result_rows_changed, 0);
-    rb_define_method(cDuckDBResult, "columns", duckdb_result_columns, 0);
-    rb_define_private_method(cDuckDBResult, "_chunk_stream", duckdb_result__chunk_stream, 0);
-    rb_define_private_method(cDuckDBResult, "_column_type", duckdb_result__column_type, 1);
-    rb_define_private_method(cDuckDBResult, "_return_type", duckdb_result__return_type, 0);
-    rb_define_private_method(cDuckDBResult, "_statement_type", duckdb_result__statement_type, 0);
+    rb_define_method(cDuckDBResult, "column_count", result_column_count, 0);
+    rb_define_method(cDuckDBResult, "rows_changed", result_rows_changed, 0);
+    rb_define_method(cDuckDBResult, "columns", result_columns, 0);
+    rb_define_private_method(cDuckDBResult, "_chunk_stream", result__chunk_stream, 0);
+    rb_define_private_method(cDuckDBResult, "_column_type", result__column_type, 1);
+    rb_define_private_method(cDuckDBResult, "_return_type", result__return_type, 0);
+    rb_define_private_method(cDuckDBResult, "_statement_type", result__statement_type, 0);
 
-    rb_define_private_method(cDuckDBResult, "_enum_internal_type", duckdb_result__enum_internal_type, 1);
-    rb_define_private_method(cDuckDBResult, "_enum_dictionary_size", duckdb_result__enum_dictionary_size, 1);
-    rb_define_private_method(cDuckDBResult, "_enum_dictionary_value", duckdb_result__enum_dictionary_value, 2);
+    rb_define_private_method(cDuckDBResult, "_enum_internal_type", result__enum_internal_type, 1);
+    rb_define_private_method(cDuckDBResult, "_enum_dictionary_size", result__enum_dictionary_size, 1);
+    rb_define_private_method(cDuckDBResult, "_enum_dictionary_value", result__enum_dictionary_value, 2);
 }

--- a/ext/duckdb/result.h
+++ b/ext/duckdb/result.h
@@ -7,10 +7,9 @@ struct _rubyDuckDBResult {
 
 typedef struct _rubyDuckDBResult rubyDuckDBResult;
 
-rubyDuckDBResult *get_struct_result(VALUE obj);
-void rbduckdb_init_duckdb_result(void);
+rubyDuckDBResult *rbduckdb_get_struct_result(VALUE obj);
+void rbduckdb_init_result(void);
 VALUE rbduckdb_create_result(void);
 VALUE rbduckdb_vector_value_at(duckdb_vector vector, duckdb_logical_type element_type, idx_t index);
 
 #endif
-


### PR DESCRIPTION
## Summary

- Rename public method static functions from `duckdb_result_*` to `result_*` (rule 1)
- Rename private method static functions from `duckdb_result__*` to `result__*` (rule 2)
- Rename extern `get_struct_result` to `rbduckdb_get_struct_result` (rule 11)
- Rename init from `rbduckdb_init_duckdb_result` to `rbduckdb_init_result` (rule 10)
- Update all callers: `duckdb.c`, `column.c`, `connection.c`, `prepared_statement.c`, `pending_result.c`

## Test plan

- [x] Compiled successfully with no warnings
- [x] All 1102 tests pass, 0 failures, 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)