### PR TITLE
refactor: rename functions in instance_cache.c per HACKING.md

### DIFF
--- a/ext/duckdb/duckdb.c
+++ b/ext/duckdb/duckdb.c
@@ -54,7 +54,7 @@ Init_duckdb_native(void) {
     rbduckdb_init_duckdb_config();
     rbduckdb_init_converter();
     rbduckdb_init_extracted_statements();
-    rbduckdb_init_duckdb_instance_cache();
+    rbduckdb_init_instance_cache();
     rbduckdb_init_value();
     rbduckdb_init_duckdb_scalar_function();
     rbduckdb_init_duckdb_scalar_function_set();

--- a/ext/duckdb/instance_cache.c
+++ b/ext/duckdb/instance_cache.c
@@ -5,9 +5,9 @@ VALUE cDuckDBInstanceCache;
 static void deallocate(void * ctx);
 static VALUE allocate(VALUE klass);
 static size_t memsize(const void *p);
-static VALUE duckdb_instance_cache_initialize(VALUE self);
-static VALUE duckdb_instance_cache_get_or_create(int argc, VALUE *argv, VALUE self);
-static VALUE duckdb_instance_cache_destroy(VALUE self);
+static VALUE instance_cache_initialize(VALUE self);
+static VALUE instance_cache_get_or_create(int argc, VALUE *argv, VALUE self);
+static VALUE instance_cache_destroy(VALUE self);
 
 static const rb_data_type_t instance_cache_data_type = {
     "DuckDB/InstanceCache",
@@ -33,7 +33,7 @@ static VALUE allocate(VALUE klass) {
     return TypedData_Wrap_Struct(klass, &instance_cache_data_type, ctx);
 }
 
-static VALUE duckdb_instance_cache_initialize(VALUE self) {
+static VALUE instance_cache_initialize(VALUE self) {
     rubyDuckDBInstanceCache *ctx;
 
     TypedData_Get_Struct(self, rubyDuckDBInstanceCache, &instance_cache_data_type, ctx);
@@ -47,7 +47,7 @@ static VALUE duckdb_instance_cache_initialize(VALUE self) {
 }
 
 /* :nodoc: */
-static VALUE duckdb_instance_cache_get_or_create(int argc, VALUE *argv, VALUE self) {
+static VALUE instance_cache_get_or_create(int argc, VALUE *argv, VALUE self) {
     VALUE vpath = Qnil;
     VALUE vconfig = Qnil;
     const char *path = NULL;
@@ -82,7 +82,7 @@ static VALUE duckdb_instance_cache_get_or_create(int argc, VALUE *argv, VALUE se
     return rbduckdb_create_database_obj(db);
 }
 
-static VALUE duckdb_instance_cache_destroy(VALUE self) {
+static VALUE instance_cache_destroy(VALUE self) {
     rubyDuckDBInstanceCache *ctx;
     TypedData_Get_Struct(self, rubyDuckDBInstanceCache, &instance_cache_data_type, ctx);
 
@@ -94,13 +94,13 @@ static VALUE duckdb_instance_cache_destroy(VALUE self) {
     return Qnil;
 }
 
-void rbduckdb_init_duckdb_instance_cache(void) {
+void rbduckdb_init_instance_cache(void) {
 #if 0
     VALUE mDuckDB = rb_define_module("DuckDB");
 #endif
     cDuckDBInstanceCache = rb_define_class_under(mDuckDB, "InstanceCache", rb_cObject);
-    rb_define_method(cDuckDBInstanceCache, "initialize", duckdb_instance_cache_initialize, 0);
-    rb_define_method(cDuckDBInstanceCache, "get_or_create", duckdb_instance_cache_get_or_create, -1);
-    rb_define_method(cDuckDBInstanceCache, "destroy", duckdb_instance_cache_destroy, 0);
+    rb_define_method(cDuckDBInstanceCache, "initialize", instance_cache_initialize, 0);
+    rb_define_method(cDuckDBInstanceCache, "get_or_create", instance_cache_get_or_create, -1);
+    rb_define_method(cDuckDBInstanceCache, "destroy", instance_cache_destroy, 0);
     rb_define_alloc_func(cDuckDBInstanceCache, allocate);
 }

--- a/ext/duckdb/instance_cache.h
+++ b/ext/duckdb/instance_cache.h
@@ -7,6 +7,6 @@ struct _rubyDuckDBInstanceCache {
 
 typedef struct _rubyDuckDBInstanceCache rubyDuckDBInstanceCache;
 
-void rbduckdb_init_duckdb_instance_cache(void);
+void rbduckdb_init_instance_cache(void);
 
 #endif


### PR DESCRIPTION
## Summary

- Rename static C functions per Rule 1: `duckdb_instance_cache_*` → `instance_cache_*` (`initialize`, `get_or_create`, `destroy`)
- Rename init function per Rule 10: `rbduckdb_init_duckdb_instance_cache` → `rbduckdb_init_instance_cache` (removes redundant `duckdb_` segment)
- Update declaration in `instance_cache.h` and call site in `duckdb.c` accordingly

## Test plan

- [x] Compiles cleanly with `bundle exec rake compile -- --with-opt-include=... --with-opt-lib=...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized internal function naming conventions for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->