### PR TITLE
fix gemspec to use git ls-files, excluding dev-only files

### DIFF
--- a/duckdb.gemspec
+++ b/duckdb.gemspec
@@ -22,16 +22,13 @@ Gem::Specification.new do |spec|
   spec.metadata['changelog_uri'] = "#{spec.homepage}/blob/main/CHANGELOG.md"
 
   # Specify which files should be added to the gem when it is released.
-  spec.files = Dir[
-    'bin/*',
-    'ext/**/*',
-    'lib/**/*',
-    '.rdoc_options',
-    'CHANGELOG.md',
-    'LICENSE',
-    'Rakefile',
-    'README.md'
-  ]
+  spec.files = Dir.chdir(File.expand_path(__dir__)) do
+    `git ls-files -z`.split("\x0").reject do |f|
+      f.match(%r{^(test|spec|features|sample|benchmark)/|^\.(?!rdoc_options)|
+                 ^(HACKING|CONTRIBUTION)\.md$|
+                 ^(Dockerfile|docker-compose\.yml|getduckdb\.sh|Gemfile(\.lock)?)$}x)
+    end
+  end
 
   spec.require_paths = ['lib']
   spec.extensions = ['ext/duckdb/extconf.rb']


### PR DESCRIPTION
## Summary

- Switch `spec.files` from `Dir[]` glob to `git ls-files`, fixing [#1335] where a precompiled x86_64 `duckdb_native.so` was bundled into the gem and shadowed the correctly-compiled native extension on non-x86 platforms (aarch64, ARM macOS)
- Exclude dev-only files from the published gem: `sample/`, `benchmark/`, `.github/`, dotfiles (except `.rdoc_options`), `HACKING.md`, `CONTRIBUTION.md`, `Dockerfile`, `docker-compose.yml`, `getduckdb.sh`, `Gemfile`, `Gemfile.lock`

## Why `git ls-files`

The `Dir[]` approach introduced in #1233 requires manual exclusion of build artifacts. Using `git ls-files` is simpler and self-maintaining — compiled `.so` files are already gitignored so they are never included. This matches the approach used by other native gems (pg, ffi).

## Test plan

- [ ] Build the gem and verify contents with `gem unpack`
- [ ] Confirm no `.so` files are included
- [ ] Confirm `bundle install` compiles correctly on aarch64 Linux

Fixes #1335

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated gem packaging configuration to improve accuracy of release artifact selection by refining which files are included in distributions, excluding unnecessary build and configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->