### PR TITLE
prepare release ruby-duckdb 1.5.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,14 @@ All notable changes to this project will be documented in this file.
 
 # Unreleased
 
+# 1.5.2.1 - 2026-04-24
+
 - add `DuckDB::AggregateFunction.create`.
 - add `DuckDB::Appender#clear_columns`.
 - add `DuckDB::Appender#add_column`.
 - add `DuckDB::Appender#clear` to discard all unflushed data from the appender without writing it to the table (requires DuckDB >= 1.5.0).
 - add `DuckDB::Value.create_decimal`.
+- fix gemspec to use `git ls-files`, preventing precompiled x86_64 `.so` from being bundled into the gem and breaking non-x86 platforms.
 
 # 1.5.2.0 - 2026-04-16
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,20 +1,20 @@
 PATH
   remote: .
   specs:
-    duckdb (1.5.2.0)
+    duckdb (1.5.2.1)
       bigdecimal (>= 3.1.4)
 
 GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.3)
-    bigdecimal (4.1.1)
+    bigdecimal (4.1.2)
     csv (3.3.5)
     drb (2.2.3)
-    json (2.19.3)
+    json (2.19.4)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
-    minitest (6.0.4)
+    minitest (6.0.5)
       drb (~> 2.0)
       prism (~> 1.5)
     parallel (1.28.0)

--- a/lib/duckdb/version.rb
+++ b/lib/duckdb/version.rb
@@ -3,5 +3,5 @@
 module DuckDB
   # The version string of ruby-duckdb.
   # Currently, ruby-duckdb is NOT semantic versioning.
-  VERSION = '1.5.2.0'
+  VERSION = '1.5.2.1'
 end


### PR DESCRIPTION
## Release Notes - Version 1.5.2.1

* **New Features**
  * add `DuckDB::AggregateFunction.create`
  * add `DuckDB::Appender#clear_columns`
  * add `DuckDB::Appender#add_column`
  * add `DuckDB::Appender#clear` to discard all unflushed data from the appender without writing it to the table (requires DuckDB >= 1.5.0)
  * add `DuckDB::Value.create_decimal`

* **Bug Fixes**
  * fix gemspec to use `git ls-files`, preventing precompiled x86_64 `.so` from being bundled into the gem and breaking non-x86 platforms (fixes #1335)