### PR TITLE
bump ruby 4.0.3 on Ubuntu, MacOS

### DIFF
--- a/.github/workflows/test_on_macos.yml
+++ b/.github/workflows/test_on_macos.yml
@@ -23,7 +23,7 @@ jobs:
     timeout-minutes: 120
     strategy:
       matrix:
-        ruby: ['3.2.11', '3.3.11', '3.4.9', '4.0.2', 'head']
+        ruby: ['3.2.11', '3.3.11', '3.4.9', '4.0.3', 'head']
         duckdb: ['1.4.4', '1.5.2']
 
     steps:

--- a/.github/workflows/test_on_ubuntu.yml
+++ b/.github/workflows/test_on_ubuntu.yml
@@ -24,7 +24,7 @@ jobs:
     timeout-minutes: 120
     strategy:
       matrix:
-        ruby: ['3.2.11', '3.3.11', '3.4.9', '4.0.2', 'head']
+        ruby: ['3.2.11', '3.3.11', '3.4.9', '4.0.3', 'head']
         duckdb: ['1.4.4', '1.5.2']
 
     services:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Ruby version to 4.0.3 in CI test workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->