### PR TITLE
deprecate Result#_column_type private method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to this project will be documented in this file.
 
 # Unreleased
+## Breaking Changes
+- deprecate `DuckDB::Result#_column_type(i)` private method. use `columns[i].send(:_type)` instead.
 
 # 1.5.2.1 - 2026-04-24
 

--- a/ext/duckdb/result.c
+++ b/ext/duckdb/result.c
@@ -17,7 +17,6 @@ static VALUE destroy_data_chunk(VALUE arg);
 
 static VALUE result__chunk_stream(VALUE oDuckDBResult);
 static VALUE yield_rows(VALUE arg);
-static VALUE result__column_type(VALUE oDuckDBResult, VALUE col_idx);
 static VALUE result__return_type(VALUE oDuckDBResult);
 static VALUE result__statement_type(VALUE oDuckDBResult);
 static VALUE result__enum_internal_type(VALUE oDuckDBResult, VALUE col_idx);
@@ -196,13 +195,6 @@ static VALUE yield_rows(VALUE arg) {
         rb_yield(row);
     }
     return Qnil;
-}
-
-/* :nodoc: */
-static VALUE result__column_type(VALUE oDuckDBResult, VALUE col_idx) {
-    rubyDuckDBResult *ctx;
-    TypedData_Get_Struct(oDuckDBResult, rubyDuckDBResult, &result_data_type, ctx);
-    return LL2NUM(duckdb_column_type(&(ctx->result), NUM2LL(col_idx)));
 }
 
 /* :nodoc: */
@@ -718,7 +710,6 @@ void rbduckdb_init_result(void) {
     rb_define_method(cDuckDBResult, "rows_changed", result_rows_changed, 0);
     rb_define_method(cDuckDBResult, "columns", result_columns, 0);
     rb_define_private_method(cDuckDBResult, "_chunk_stream", result__chunk_stream, 0);
-    rb_define_private_method(cDuckDBResult, "_column_type", result__column_type, 1);
     rb_define_private_method(cDuckDBResult, "_return_type", result__return_type, 0);
     rb_define_private_method(cDuckDBResult, "_statement_type", result__statement_type, 0);
 

--- a/lib/duckdb/result.rb
+++ b/lib/duckdb/result.rb
@@ -87,5 +87,13 @@ module DuckDB
       end
       values
     end
+
+    private
+
+    def _column_type(idx)
+      warn(":_column_type is deprecated. use columns[#{idx}].send(:_type) instead.")
+
+      columns[idx].send(:_type)
+    end
   end
 end


### PR DESCRIPTION
## Summary

- Remove C implementation of `Result#_column_type(i)`
- Add Ruby shim that emits a deprecation warning and delegates to `columns[idx].send(:_type)`
- Update CHANGELOG

Closes #1023

## Test plan

- [ ] Existing `test__column_type` test still passes (behavior unchanged)
- [ ] Deprecation warning is emitted when `_column_type` is called

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * The private `_column_type` method on `DuckDB::Result` is deprecated. Update code to use `columns[i].send(:_type)` as the replacement access pattern.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->