### PR TITLE
Implement append default to chunk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 # Unreleased
+- add `DuckDB::Appender#append_default_to_chunk`.
 ## Breaking Changes
 - deprecate `DuckDB::Result#_column_type(i)` private method. use `columns[i].send(:_type)` instead.
 - `DuckDB::Result#enum_dictionary_values` checks invalid column index.

--- a/ext/duckdb/appender.c
+++ b/ext/duckdb/appender.c
@@ -36,6 +36,7 @@ static VALUE appender__append_hugeint(VALUE self, VALUE lower, VALUE upper);
 static VALUE appender__append_uhugeint(VALUE self, VALUE lower, VALUE upper);
 static VALUE appender__append_value(VALUE self, VALUE val);
 static VALUE appender__append_data_chunk(VALUE self, VALUE chunk);
+static VALUE appender__append_default_to_chunk(VALUE self, VALUE chunk, VALUE col, VALUE row);
 static VALUE appender__flush(VALUE self);
 
 #ifdef HAVE_DUCKDB_H_GE_V1_5_0
@@ -448,6 +449,17 @@ static VALUE appender__append_data_chunk(VALUE self, VALUE chunk) {
 }
 
 /* :nodoc: */
+static VALUE appender__append_default_to_chunk(VALUE self, VALUE chunk, VALUE col, VALUE row) {
+    rubyDuckDBAppender *ctx;
+    rubyDuckDBDataChunk *chunk_ctx;
+
+    TypedData_Get_Struct(self, rubyDuckDBAppender, &appender_data_type, ctx);
+    chunk_ctx = rbduckdb_get_struct_data_chunk(chunk);
+
+    return state_to_rbool(duckdb_append_default_to_chunk(ctx->appender, chunk_ctx->data_chunk, NUM2ULL(col), NUM2ULL(row)));
+}
+
+/* :nodoc: */
 static VALUE appender__flush(VALUE self) {
     rubyDuckDBAppender *ctx;
     TypedData_Get_Struct(self, rubyDuckDBAppender, &appender_data_type, ctx);
@@ -540,4 +552,5 @@ void rbduckdb_init_appender(void) {
     rb_define_private_method(cDuckDBAppender, "_append_uhugeint", appender__append_uhugeint, 2);
     rb_define_private_method(cDuckDBAppender, "_append_value", appender__append_value, 1);
     rb_define_private_method(cDuckDBAppender, "_append_data_chunk", appender__append_data_chunk, 1);
+    rb_define_private_method(cDuckDBAppender, "_append_default_to_chunk", appender__append_default_to_chunk, 3);
 }

--- a/lib/duckdb/appender.rb
+++ b/lib/duckdb/appender.rb
@@ -669,6 +669,16 @@ module DuckDB
       raise_appender_error('failed to append_data_chunk')
     end
 
+    def append_default_to_chunk(chunk, col, row)
+      unless chunk.is_a?(DuckDB::DataChunk)
+        raise ArgumentError, "1st argument is expected DuckDB::DataChunk, got #{chunk.class}"
+      end
+
+      return self if _append_default_to_chunk(chunk, col, row)
+
+      raise_appender_error('failed to append_default_to_chunk')
+    end
+
     # appends value.
     #
     #   require 'duckdb'

--- a/lib/duckdb/appender.rb
+++ b/lib/duckdb/appender.rb
@@ -661,6 +661,20 @@ module DuckDB
 
     # call-seq:
     #   appender.append_data_chunk(chunk) -> self
+    #
+    # Appends a pre-filled DuckDB::DataChunk to the appender.
+    #
+    #   require 'duckdb'
+    #   db = DuckDB::Database.open
+    #   con = db.connect
+    #   con.query('CREATE TABLE users (id INTEGER, name VARCHAR)')
+    #   appender = con.appender('users')
+    #   chunk = DuckDB::DataChunk.new([DuckDB::LogicalType::INTEGER, DuckDB::LogicalType::VARCHAR])
+    #   chunk.set_value(0, 0, 1)
+    #   chunk.set_value(1, 0, 'Alice')
+    #   chunk.size = 1
+    #   appender.append_data_chunk(chunk)
+    #   appender.flush
     def append_data_chunk(chunk)
       raise ArgumentError, "expected DuckDB::DataChunk, got #{chunk.class}" unless chunk.is_a?(DuckDB::DataChunk)
 
@@ -669,10 +683,28 @@ module DuckDB
       raise_appender_error('failed to append_data_chunk')
     end
 
+    # call-seq:
+    #   appender.append_default_to_chunk(chunk, col, row) -> self
+    #
+    # Appends the DEFAULT value for the column at +col+ and +row+ in +chunk+.
+    # If no DEFAULT is defined for the column, NULL is used.
+    # Call this before appending the chunk via #append_data_chunk.
+    #
+    #   require 'duckdb'
+    #   db = DuckDB::Database.open
+    #   con = db.connect
+    #   con.query('CREATE TABLE users (name VARCHAR, enabled BOOLEAN DEFAULT TRUE)')
+    #   appender = con.appender('users')
+    #   chunk = DuckDB::DataChunk.new([DuckDB::LogicalType::VARCHAR, DuckDB::LogicalType::BOOLEAN])
+    #   appender.append_default_to_chunk(chunk, 1, 0)  # enabled DEFAULT for row 0
+    #   appender.append_default_to_chunk(chunk, 1, 1)  # enabled DEFAULT for row 1
+    #   chunk.set_value(0, 0, 'Alice')
+    #   chunk.set_value(0, 1, 'Bob')
+    #   chunk.size = 2
+    #   appender.append_data_chunk(chunk)
+    #   appender.flush
     def append_default_to_chunk(chunk, col, row)
-      unless chunk.is_a?(DuckDB::DataChunk)
-        raise ArgumentError, "1st argument is expected DuckDB::DataChunk, got #{chunk.class}"
-      end
+      raise ArgumentError, "expected DuckDB::DataChunk, got #{chunk.class}" unless chunk.is_a?(DuckDB::DataChunk)
 
       return self if _append_default_to_chunk(chunk, col, row)
 

--- a/test/duckdb_test/appender_test.rb
+++ b/test/duckdb_test/appender_test.rb
@@ -270,6 +270,24 @@ module DuckDBTest
       assert_equal([[42, 'Alice'], [84, 'Bob']], @con.query("SELECT * FROM #{table} ORDER BY id").to_a)
     end
 
+    def test_append_default_to_chunk
+      create_table('name VARCHAR, enabled BOOLEAN DEFAULT TRUE')
+      appender = DuckDB::Appender.new(@con, '', table)
+      chunk = DuckDB::DataChunk.new([DuckDB::LogicalType::VARCHAR, DuckDB::LogicalType::BOOLEAN])
+
+      appender.append_default_to_chunk(chunk, 1, 0)
+      appender.append_default_to_chunk(chunk, 1, 1)
+
+      chunk.set_value(0, 0, 'Alice')
+      chunk.set_value(0, 1, 'Bob')
+      chunk.size = 2
+
+      appender.append_data_chunk(chunk)
+      appender.close
+
+      assert_equal([['Alice', true], ['Bob', true]], @con.query("SELECT * FROM #{table} ORDER BY name").to_a)
+    end
+
     def test_append_uint32
       assert_duckdb_appender(4_294_967_295, 'BIGINT') { |a| a.append_uint32(4_294_967_295) }
     end

--- a/test/duckdb_test/appender_test.rb
+++ b/test/duckdb_test/appender_test.rb
@@ -288,6 +288,91 @@ module DuckDBTest
       assert_equal([['Alice', true], ['Bob', true]], @con.query("SELECT * FROM #{table} ORDER BY name").to_a)
     end
 
+    def test_append_default_to_chunk_with_invalid_chunk
+      create_table('name VARCHAR, enabled BOOLEAN DEFAULT TRUE')
+      appender = DuckDB::Appender.new(@con, '', table)
+
+      assert_raises(ArgumentError) do
+        appender.append_default_to_chunk('not a chunk', 1, 0)
+      end
+    end
+
+    def test_append_default_to_chunk_with_col_out_of_bounds
+      create_table('name VARCHAR, enabled BOOLEAN DEFAULT TRUE')
+      appender = DuckDB::Appender.new(@con, '', table)
+      chunk = DuckDB::DataChunk.new([DuckDB::LogicalType::VARCHAR, DuckDB::LogicalType::BOOLEAN])
+
+      assert_raises(DuckDB::Error) do
+        appender.append_default_to_chunk(chunk, 2, 0)
+      end
+    end
+
+    def test_append_default_to_chunk_with_row_out_of_bounds
+      create_table('name VARCHAR, enabled BOOLEAN DEFAULT TRUE')
+      appender = DuckDB::Appender.new(@con, '', table)
+      chunk = DuckDB::DataChunk.new([DuckDB::LogicalType::VARCHAR, DuckDB::LogicalType::BOOLEAN])
+
+      assert_raises(DuckDB::Error) do
+        appender.append_default_to_chunk(chunk, 1, DuckDB.vector_size)
+      end
+    end
+
+    def test_append_default_to_chunk_without_default
+      # col 0 (name VARCHAR) has no DEFAULT - appends NULL, no error
+      create_table('name VARCHAR, enabled BOOLEAN DEFAULT TRUE')
+      appender = DuckDB::Appender.new(@con, '', table)
+      chunk = DuckDB::DataChunk.new([DuckDB::LogicalType::VARCHAR, DuckDB::LogicalType::BOOLEAN])
+
+      appender.append_default_to_chunk(chunk, 0, 0)
+      appender.append_default_to_chunk(chunk, 1, 0)
+      chunk.size = 1
+      appender.append_data_chunk(chunk)
+      appender.close
+
+      assert_equal([[nil, true]], @con.query("SELECT * FROM #{table}").to_a)
+    end
+
+    def test_append_default_to_chunk_not_null_without_default
+      # NOT NULL column with no DEFAULT: append_default_to_chunk appends NULL without error,
+      # but DuckDB::Error is raised at close (flush) time
+      create_table('name VARCHAR NOT NULL, enabled BOOLEAN DEFAULT TRUE')
+      appender = DuckDB::Appender.new(@con, '', table)
+      chunk = DuckDB::DataChunk.new([DuckDB::LogicalType::VARCHAR, DuckDB::LogicalType::BOOLEAN])
+
+      appender.append_default_to_chunk(chunk, 0, 0)  # no error here
+      appender.append_default_to_chunk(chunk, 1, 0)
+      chunk.size = 1
+      appender.append_data_chunk(chunk)               # no error here
+
+      assert_raises(DuckDB::Error) do
+        appender.close                                 # error raised here
+      end
+    end
+
+    def test_append_default_to_chunk_with_non_foldable_default
+      # random() is non-foldable, so DuckDB::Error is raised
+      @con.execute("CREATE SEQUENCE seq START 1")
+      create_table("name VARCHAR, seq_val INTEGER DEFAULT nextval('seq')")
+      appender = DuckDB::Appender.new(@con, '', table)
+      chunk = DuckDB::DataChunk.new([DuckDB::LogicalType::VARCHAR, DuckDB::LogicalType::INTEGER])
+
+      assert_raises(DuckDB::Error) do
+        appender.append_default_to_chunk(chunk, 1, 0)
+      end
+    end
+
+    def test_append_default_to_chunk_with_query_appender
+      create_table('name VARCHAR, enabled BOOLEAN DEFAULT TRUE')
+      query = "INSERT INTO #{table} SELECT name, enabled FROM my_data"
+      types = [DuckDB::LogicalType::VARCHAR, DuckDB::LogicalType::BOOLEAN]
+      appender = DuckDB::Appender.create_query(@con, query, types, 'my_data', %w[name enabled])
+      chunk = DuckDB::DataChunk.new([DuckDB::LogicalType::VARCHAR, DuckDB::LogicalType::BOOLEAN])
+
+      assert_raises(DuckDB::Error) do
+        appender.append_default_to_chunk(chunk, 1, 0)
+      end
+    end
+
     def test_append_uint32
       assert_duckdb_appender(4_294_967_295, 'BIGINT') { |a| a.append_uint32(4_294_967_295) }
     end

--- a/test/duckdb_test/appender_test.rb
+++ b/test/duckdb_test/appender_test.rb
@@ -339,19 +339,19 @@ module DuckDBTest
       appender = DuckDB::Appender.new(@con, '', table)
       chunk = DuckDB::DataChunk.new([DuckDB::LogicalType::VARCHAR, DuckDB::LogicalType::BOOLEAN])
 
-      appender.append_default_to_chunk(chunk, 0, 0)  # no error here
+      appender.append_default_to_chunk(chunk, 0, 0) # no error here
       appender.append_default_to_chunk(chunk, 1, 0)
       chunk.size = 1
-      appender.append_data_chunk(chunk)               # no error here
+      appender.append_data_chunk(chunk) # no error here
 
       assert_raises(DuckDB::Error) do
-        appender.close                                 # error raised here
+        appender.close # error raised here
       end
     end
 
     def test_append_default_to_chunk_with_non_foldable_default
       # random() is non-foldable, so DuckDB::Error is raised
-      @con.execute("CREATE SEQUENCE seq START 1")
+      @con.execute('CREATE SEQUENCE seq START 1')
       create_table("name VARCHAR, seq_val INTEGER DEFAULT nextval('seq')")
       appender = DuckDB::Appender.new(@con, '', table)
       chunk = DuckDB::DataChunk.new([DuckDB::LogicalType::VARCHAR, DuckDB::LogicalType::INTEGER])


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `append_default_to_chunk` method to Appender for populating default values in data chunk columns.

* **Documentation**
  * Updated documentation with details on appender data chunk operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->