### PR TITLE
add NG test for DuckDB::Connection#appender

### DIFF
--- a/test/ng/connection_appender_ng.rb
+++ b/test/ng/connection_appender_ng.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'duckdb'
+
+db = DuckDB::Database.new
+con = db.connect
+con.execute("create table 'a.b' (i integer)")
+appender = DuckDB::Appender.new(con, nil, 'a.b')
+appender.append_row(1)
+appender.flush
+result = con.execute("select * from 'a.b'").to_a
+p result
+
+db = DuckDB::Database.new
+con = db.connect
+con.execute("create table 'a.b' (i integer)")
+appender = con.appender('a.b') # => bug. DuckDB::Error
+appender.append_row(1)
+appender.flush
+result = con.execute("select * from 'a.b'").to_a
+p result


### PR DESCRIPTION
DuckDB::Connection#appender tries to split 1st argument into schema and table.

But this behavior will be deprecated and introduce the following syntax.

```ruby
DuckDB::Connection#appender(table, schema:, catalog:)
```

The table argument will be passed directly without splitting. So this bug will be fixed in the future.