### PR TITLE
feat: support quoted table names in Connection#appender to skip dot-splitting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@ All notable changes to this project will be documented in this file.
 
 # Unreleased
 - add `DuckDB::Appender#append_default_to_chunk`.
-- `DuckDB::Connection#appender`: table names surrounded by double or single quotes (e.g. `'"a.b"'` or `"'a.b'"`) are now treated as literal table names — the quotes are stripped and no dot-splitting is performed. This mirrors SQL identifier quoting and allows appending to tables whose names contain dots.
 ## Breaking Changes
+- `DuckDB::Connection#appender`: table names surrounded by double or single quotes (e.g. `'"a.b"'` or `"'a.b'"`) are now treated as literal table names — the quotes are stripped and no dot-splitting is performed. This mirrors SQL identifier quoting and allows appending to tables whose names contain dots.
 - add `DuckDB::Appender.new(con, table, schema: nil, catalog: nil)` keyword argument form.
 - add `DuckDB::Connection#appender(table, schema: nil, catalog: nil)` keyword argument form.
   - `schema.table` dot-notation form is still supported but deprecated. Use `con.appender(table, schema: schema)` instead.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 # Unreleased
 - add `DuckDB::Appender#append_default_to_chunk`.
+- `DuckDB::Connection#appender`: table names surrounded by double or single quotes (e.g. `'"a.b"'` or `"'a.b'"`) are now treated as literal table names — the quotes are stripped and no dot-splitting is performed. This mirrors SQL identifier quoting and allows appending to tables whose names contain dots.
 ## Breaking Changes
 - add `DuckDB::Appender.new(con, table, schema: nil, catalog: nil)` keyword argument form.
 - add `DuckDB::Connection#appender(table, schema: nil, catalog: nil)` keyword argument form.

--- a/lib/duckdb/connection.rb
+++ b/lib/duckdb/connection.rb
@@ -138,6 +138,16 @@ module DuckDB
     #
     # Raises DuckDB::Error if the table (or schema/catalog) does not exist.
     #
+    # If the table name contains a dot (e.g. a table literally named <tt>a.b</tt>), surround
+    # it with double or single quotes — mirroring SQL identifier quoting — to prevent the name
+    # from being interpreted as <tt>schema.table</tt> dot-notation:
+    #
+    #   con.query('CREATE TABLE "a.b" (id INTEGER)')
+    #   con.appender('"a.b"')   # table name is literally a.b
+    #
+    #   con.query("CREATE TABLE 'a.b' (id INTEGER)")
+    #   con.appender("'a.b'")   # table name is literally a.b
+    #
     #   require 'duckdb'
     #   db = DuckDB::Database.open
     #   con = db.connect

--- a/lib/duckdb/connection.rb
+++ b/lib/duckdb/connection.rb
@@ -162,7 +162,7 @@ module DuckDB
     # *Deprecated:* passing a dot-notation string such as <tt>'schema.table'</tt> is deprecated.
     # Use the +schema:+ keyword argument instead.
     def appender(table, schema: nil, catalog: nil, &)
-      if table.start_with?('"') && table.end_with?('"')
+      if quoted_table_name?(table)
         table = unquote_table_name(table)
       elsif table.include?('.')
         table, schema, catalog = apply_dot_notation(table, schema, catalog)
@@ -357,6 +357,10 @@ module DuckDB
       yield appender
       appender.flush
       appender.close
+    end
+
+    def quoted_table_name?(name)
+      name.match?(/\A(["']).*\1\z/)
     end
 
     def unquote_table_name(name)

--- a/lib/duckdb/connection.rb
+++ b/lib/duckdb/connection.rb
@@ -393,7 +393,8 @@ module DuckDB
     def warn_dot_notation_deprecated(table)
       warn(
         "Passing dot-notation '#{table}' to Connection#appender is deprecated. " \
-        'Use con.appender(table, schema: schema) instead.',
+        "If '#{table}' is a schema-qualified table, use con.appender(table, schema: schema) instead. " \
+        "If '#{table}' is a literal table name containing a dot, use con.appender('\"#{table}\"') instead.",
         category: :deprecated
       )
     end

--- a/lib/duckdb/connection.rb
+++ b/lib/duckdb/connection.rb
@@ -162,7 +162,11 @@ module DuckDB
     # *Deprecated:* passing a dot-notation string such as <tt>'schema.table'</tt> is deprecated.
     # Use the +schema:+ keyword argument instead.
     def appender(table, schema: nil, catalog: nil, &)
-      table, schema, catalog = apply_dot_notation(table, schema, catalog) if table.include?('.')
+      if table.start_with?('"') && table.end_with?('"')
+        table = unquote_table_name(table)
+      elsif table.include?('.')
+        table, schema, catalog = apply_dot_notation(table, schema, catalog)
+      end
       run_appender_block(Appender.new(self, table, schema: schema, catalog: catalog), &)
     end
 
@@ -353,6 +357,10 @@ module DuckDB
       yield appender
       appender.flush
       appender.close
+    end
+
+    def unquote_table_name(name)
+      name[1..-2]
     end
 
     def apply_dot_notation(table, schema, catalog)

--- a/test/duckdb_test/connection_test.rb
+++ b/test/duckdb_test/connection_test.rb
@@ -260,6 +260,13 @@ module DuckDBTest
       assert_instance_of(DuckDB::Appender, @con.appender('a.b'))
     end
 
+    def test_appender_with_double_quoted_table_name
+      @con.execute('CREATE TABLE "a.b" (col1 INTEGER, col2 STRING)')
+      appender = @con.appender('"a.b"')
+
+      assert_instance_of(DuckDB::Appender, appender)
+    end
+
     def test_appender_with_block
       @con.execute('CREATE TABLE t (col1 INTEGER, col2 STRING)')
       @con.appender('t') do |appender|

--- a/test/duckdb_test/connection_test.rb
+++ b/test/duckdb_test/connection_test.rb
@@ -267,6 +267,13 @@ module DuckDBTest
       assert_instance_of(DuckDB::Appender, appender)
     end
 
+    def test_appender_with_single_quoted_table_name
+      @con.execute("CREATE TABLE 'a.b' (col1 INTEGER, col2 STRING)")
+      appender = @con.appender("'a.b'")
+
+      assert_instance_of(DuckDB::Appender, appender)
+    end
+
     def test_appender_with_block
       @con.execute('CREATE TABLE t (col1 INTEGER, col2 STRING)')
       @con.appender('t') do |appender|


### PR DESCRIPTION
## Summary

When a table is created with a name containing a dot (e.g. `CREATE TABLE "a.b"`), `Connection#appender` previously had no way to reference it — passing `'a.b'` would silently split into schema `a` and table `b`.

This PR adds quoting support that mirrors SQL identifier conventions:

| Ruby call | Behaviour |
|-----------|-----------|
| `con.appender('"a.b"')` | strips double quotes → literal table name `a.b` |
| `con.appender("'a.b'")` | strips single quotes → literal table name `a.b` |
| `con.appender('a.b')` | unquoted dot-notation → schema `a`, table `b` (deprecated, unchanged) |

## Changes

- `Connection#appender`: detect surrounding double/single quotes via `quoted_table_name?` predicate, strip them with `unquote_table_name`, and skip dot-splitting
- Improved deprecation warning for dot-notation to mention both alternatives (schema keyword arg and quoted literal form)
- Added tests for double-quoted and single-quoted table names
- Updated rdoc and CHANGELOG

## Example

```ruby
con.execute('CREATE TABLE "a.b" (id INTEGER)')
con.appender('"a.b"') { |a| a.append_row(1) }  # works correctly

con.execute("CREATE TABLE 'a.b' (id INTEGER)")
con.appender("'a.b'") { |a| a.append_row(1) }  # works correctly

con.execute('CREATE SCHEMA s; CREATE TABLE s.t (id INTEGER)')
con.appender('s.t') { |a| a.append_row(1) }  # still works (deprecated)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * The `appender` method now treats quoted table names (wrapped in single or double quotes) as literal identifiers, stripping quotes and disabling dot-notation parsing.

* **Improvements**
  * Enhanced documentation clarifying table name handling, including examples for quoting literal dot-containing table names.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/suketa/ruby-duckdb/pull/1346)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->