### PR TITLE
Move dot-notation/quoting parsing from Connection#appender into Appender.new

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 # Unreleased
 - add `DuckDB::Appender#append_default_to_chunk`.
 ## Breaking Changes
+- `DuckDB::Appender.new`: the 2nd argument now parses dot-notation and quoting (previously only `Connection#appender` did this):
+  - `'schema.table'` is interpreted as schema-qualified (deprecated; use `schema:` keyword instead).
+  - `'"schema.table"'` or `"'schema.table'"` — quotes are stripped and the name is treated as a literal table name containing a dot.
+- `DuckDB::Connection#appender`: table name parsing (dot-notation, quoting) is now delegated entirely to `DuckDB::Appender.new`. `Connection#appender` no longer performs any parsing itself.
 - `DuckDB::Connection#appender`: table names surrounded by double or single quotes (e.g. `'"a.b"'` or `"'a.b'"`) are now treated as literal table names — the quotes are stripped and no dot-splitting is performed. This mirrors SQL identifier quoting and allows appending to tables whose names contain dots.
 - add `DuckDB::Appender.new(con, table, schema: nil, catalog: nil)` keyword argument form.
 - add `DuckDB::Connection#appender(table, schema: nil, catalog: nil)` keyword argument form.

--- a/lib/duckdb/appender.rb
+++ b/lib/duckdb/appender.rb
@@ -7,6 +7,11 @@ require_relative 'converter'
 module DuckDB
   # The DuckDB::Appender encapsulates DuckDB Appender.
   #
+  # The +table+ argument (2nd positional argument) supports dot-notation and quoting:
+  #
+  # - <tt>'schema.table'</tt> — interpreted as schema-qualified (deprecated; use +schema:+ instead)
+  # - <tt>'"schema.table"'</tt> or <tt>"'schema.table'"</tt> — treated as a literal table name containing a dot
+  #
   #   require 'duckdb'
   #   db = DuckDB::Database.open
   #   con = db.connect
@@ -24,10 +29,8 @@ module DuckDB
       if table
         warn_deprecated_3arg
         _initialize(con, table_or_schema, table)
-      elsif catalog
-        _initialize_ext(con, catalog, schema, table_or_schema)
       else
-        _initialize(con, schema, table_or_schema)
+        initialize_with_parsed_table(con, table_or_schema, schema: schema, catalog: catalog)
       end
     end
 
@@ -779,6 +782,48 @@ module DuckDB
       warn(
         'DuckDB::Appender.new(con, schema, table) is deprecated. ' \
         'Use DuckDB::Appender.new(con, table, schema: schema) instead.',
+        category: :deprecated
+      )
+    end
+
+    def initialize_with_parsed_table(con, table_name, schema:, catalog:) # :nodoc:
+      if quoted_table_name?(table_name)
+        table_name = unquote_table_name(table_name)
+      elsif table_name.include?('.')
+        table_name, schema, catalog = apply_dot_notation(table_name, schema, catalog)
+      end
+      if catalog
+        _initialize_ext(con, catalog, schema, table_name)
+      else
+        _initialize(con, schema, table_name)
+      end
+    end
+
+    def quoted_table_name?(name) # :nodoc:
+      name.match?(/\A(["']).*\1\z/)
+    end
+
+    def unquote_table_name(name) # :nodoc:
+      name[1..-2]
+    end
+
+    def apply_dot_notation(table, schema, catalog) # :nodoc:
+      parts = table.split('.')
+      raise ArgumentError, "Too many dot-separated segments in '#{table}'" if parts.length > 3
+
+      warn_dot_notation_deprecated(table)
+      case parts.length
+      when 2 then [parts[1], schema || parts[0], catalog]
+      when 3 then [parts[2], schema || parts[1], catalog || parts[0]]
+      else raise ArgumentError, "Unexpected segment count in '#{table}'"
+      end
+    end
+
+    def warn_dot_notation_deprecated(table) # :nodoc:
+      warn(
+        "Passing dot-notation '#{table}' to DuckDB::Appender.new is deprecated. " \
+        "If '#{table}' is a schema-qualified table, use Appender.new(con, table, schema: schema) instead. " \
+        "If '#{table}' is a literal table name containing a dot, use Appender.new(con, '\"#{table}\"') instead.",
         category: :deprecated
       )
     end

--- a/lib/duckdb/connection.rb
+++ b/lib/duckdb/connection.rb
@@ -138,15 +138,8 @@ module DuckDB
     #
     # Raises DuckDB::Error if the table (or schema/catalog) does not exist.
     #
-    # If the table name contains a dot (e.g. a table literally named <tt>a.b</tt>), surround
-    # it with double or single quotes — mirroring SQL identifier quoting — to prevent the name
-    # from being interpreted as <tt>schema.table</tt> dot-notation:
-    #
-    #   con.query('CREATE TABLE "a.b" (id INTEGER)')
-    #   con.appender('"a.b"')   # table name is literally a.b
-    #
-    #   con.query("CREATE TABLE 'a.b' (id INTEGER)")
-    #   con.appender("'a.b'")   # table name is literally a.b
+    # Table name parsing (quoting, dot-notation) is handled by DuckDB::Appender.new.
+    # See DuckDB::Appender.new for details on quoting and dot-notation.
     #
     #   require 'duckdb'
     #   db = DuckDB::Database.open
@@ -168,15 +161,7 @@ module DuckDB
     #   appender = con.appender('users')
     #   appender.append_row(4, 'Dave')
     #   appender.close
-    #
-    # *Deprecated:* passing a dot-notation string such as <tt>'schema.table'</tt> is deprecated.
-    # Use the +schema:+ keyword argument instead.
     def appender(table, schema: nil, catalog: nil, &)
-      if quoted_table_name?(table)
-        table = unquote_table_name(table)
-      elsif table.include?('.')
-        table, schema, catalog = apply_dot_notation(table, schema, catalog)
-      end
       run_appender_block(Appender.new(self, table, schema: schema, catalog: catalog), &)
     end
 
@@ -367,36 +352,6 @@ module DuckDB
       yield appender
       appender.flush
       appender.close
-    end
-
-    def quoted_table_name?(name)
-      name.match?(/\A(["']).*\1\z/)
-    end
-
-    def unquote_table_name(name)
-      name[1..-2]
-    end
-
-    def apply_dot_notation(table, schema, catalog)
-      parts = table.split('.')
-      raise ArgumentError, "Too many dot-separated segments in '#{table}'" if parts.length > 3
-
-      warn_dot_notation_deprecated(table)
-      # Explicit schema:/catalog: keyword args take precedence over dot-notation parts.
-      case parts.length
-      when 2 then [parts[1], schema || parts[0], catalog]
-      when 3 then [parts[2], schema || parts[1], catalog || parts[0]]
-      else raise ArgumentError, "Unexpected segment count in '#{table}'"
-      end
-    end
-
-    def warn_dot_notation_deprecated(table)
-      warn(
-        "Passing dot-notation '#{table}' to Connection#appender is deprecated. " \
-        "If '#{table}' is a schema-qualified table, use con.appender(table, schema: schema) instead. " \
-        "If '#{table}' is a literal table name containing a dot, use con.appender('\"#{table}\"') instead.",
-        category: :deprecated
-      )
     end
 
     alias execute query

--- a/test/duckdb_test/appender_test.rb
+++ b/test/duckdb_test/appender_test.rb
@@ -6,7 +6,7 @@ require 'time'
 module DuckDBTest
   class AppenderTest < Minitest::Test
     def setup
-      @db = DuckDB::Database.open # FIXME
+      @db = DuckDB::Database.open
       @con = @db.connect
     end
 

--- a/test/duckdb_test/appender_test.rb
+++ b/test/duckdb_test/appender_test.rb
@@ -1345,8 +1345,6 @@ module DuckDBTest
 
       assert_instance_of(DuckDB::Appender, appender)
       assert_includes(err, 'deprecated')
-    ensure
-      @con.query('DETACH ext_new_dot')
     end
 
     def test_s_new_with_double_quoted_table_name_is_treated_as_literal

--- a/test/duckdb_test/appender_test.rb
+++ b/test/duckdb_test/appender_test.rb
@@ -1327,5 +1327,49 @@ module DuckDBTest
       assert_instance_of(DuckDB::Appender, appender)
       assert_includes(err, 'deprecated')
     end
+
+    def test_s_new_with_dot_notation_parses_schema_and_table
+      @con.query('CREATE SCHEMA s_dot; CREATE TABLE s_dot.t_dot (id INT)')
+      appender = nil
+      _, err = capture_io { appender = DuckDB::Appender.new(@con, 's_dot.t_dot') }
+
+      assert_instance_of(DuckDB::Appender, appender)
+      assert_includes(err, 'deprecated')
+    end
+
+    def test_s_new_with_3segment_dot_notation_parses_catalog_schema_table
+      @con.query("ATTACH ':memory:' AS ext_new_dot")
+      @con.query('CREATE TABLE ext_new_dot.main.t_new_dot (id INT)')
+      appender = nil
+      _, err = capture_io { appender = DuckDB::Appender.new(@con, 'ext_new_dot.main.t_new_dot') }
+
+      assert_instance_of(DuckDB::Appender, appender)
+      assert_includes(err, 'deprecated')
+    ensure
+      @con.query('DETACH ext_new_dot')
+    end
+
+    def test_s_new_with_double_quoted_table_name_is_treated_as_literal
+      @con.execute('CREATE TABLE "a.b" (col1 INTEGER)')
+      appender = DuckDB::Appender.new(@con, '"a.b"')
+
+      assert_instance_of(DuckDB::Appender, appender)
+    end
+
+    def test_s_new_with_single_quoted_table_name_is_treated_as_literal
+      @con.execute("CREATE TABLE 'a.b' (col1 INTEGER)")
+      appender = DuckDB::Appender.new(@con, "'a.b'")
+
+      assert_instance_of(DuckDB::Appender, appender)
+    end
+
+    def test_s_new_dot_notation_schema_keyword_overrides_dot_schema
+      @con.query('CREATE SCHEMA s_new_ovr; CREATE TABLE s_new_ovr.t_new_ovr (id INT)')
+      appender = nil
+      _, err = capture_io { appender = DuckDB::Appender.new(@con, 'wrong.t_new_ovr', schema: 's_new_ovr') }
+
+      assert_instance_of(DuckDB::Appender, appender)
+      assert_includes(err, 'deprecated')
+    end
   end
 end

--- a/test/duckdb_test/appender_test.rb
+++ b/test/duckdb_test/appender_test.rb
@@ -15,11 +15,8 @@ module DuckDBTest
     end
 
     def teardown
-      safe_drop_table
       @con.close
       @db.close
-    rescue DuckDB::Error
-      # ignore DuckDB::Error
     end
 
     def table

--- a/test/duckdb_test/appender_test.rb
+++ b/test/duckdb_test/appender_test.rb
@@ -11,9 +11,7 @@ module DuckDBTest
     end
 
     def safe_drop_table
-      @con.execute("DROP TABLE #{table};")
-    rescue DuckDB::Error
-      # ignore DuckDB::Error
+      @con.execute("DROP TABLE IF EXISTS #{table};")
     end
 
     def teardown


### PR DESCRIPTION
## Summary

Move the table name parsing logic (dot-notation and quoting) from `Connection#appender` into `DuckDB::Appender.new`, so that the parsing applies consistently regardless of how an `Appender` is created.

## Changes

### Core change
- `DuckDB::Appender.new` now parses the 2nd argument the same way `Connection#appender` previously did:
  - `'schema.table'` → schema-qualified (deprecated; use `schema:` keyword instead)
  - `'"a.b"'` or `"'a.b'"` → quotes stripped, treated as literal table name
- `Connection#appender` is now a thin delegator to `Appender.new` — no parsing logic of its own
- Moved `quoted_table_name?`, `unquote_table_name`, `apply_dot_notation`, `warn_dot_notation_deprecated` from `Connection` private methods → `Appender` private methods
- Updated deprecation warning to reference `DuckDB::Appender.new`

### Test cleanups (appender_test.rb)
- Add tests for `Appender.new` with dot-notation, quoted names, and keyword override
- Remove unnecessary `ensure/DETACH` (in-memory DB is detached on connection close)
- `safe_drop_table`: use `DROP TABLE IF EXISTS`, remove rescue block
- Remove `safe_drop_table` call and rescue block from `teardown`
- Remove stale `# FIXME` comment from `setup`

### CHANGELOG
- Document the parsing move as a breaking change in Unreleased section

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed table-name parsing to properly handle quoted identifiers and dot-notation.
  * Unified table-name interpretation between `Appender.new` and `Connection#appender` methods.

* **Documentation**
  * Updated changelog documenting table-name parsing behavior changes and deprecation of dot-notation syntax in favor of the schema keyword.

* **Tests**
  * Added comprehensive tests for table-name parsing with quoted identifiers, dot-notation, and schema keywords.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/suketa/ruby-duckdb/pull/1348)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->