### PR TITLE
Fix Connection#appender dot-notation deprecation warning message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,19 +12,18 @@ All notable changes to this project will be documented in this file.
 - `DuckDB::Appender.new`: the 2nd argument now parses dot-notation and quoting (previously only `Connection#appender` did this):
   - `'schema.table'` is interpreted as schema-qualified (deprecated; use `schema:` keyword instead).
   - `'"schema.table"'` or `"'schema.table'"` — quotes are stripped and the name is treated as a literal table name containing a dot.
-- `DuckDB::Connection#appender`: table name parsing (dot-notation, quoting) is now delegated entirely to `DuckDB::Appender.new`. `Connection#appender` no longer performs any parsing itself.
-- `DuckDB::Connection#appender`: table names surrounded by double or single quotes (e.g. `'"a.b"'` or `"'a.b'"`) are now treated as literal table names — the quotes are stripped and no dot-splitting is performed. This mirrors SQL identifier quoting and allows appending to tables whose names contain dots.
-- fix: `Connection#appender` dot-notation deprecation warning now correctly says `Connection#appender` instead of `DuckDB::Appender.new`.
+- `DuckDB::Connection#appender`: table name parsing (dot-notation, quoting) is now delegated to `DuckDB::Appender.new` internally. Behavior is unchanged — `'schema.table'` has always split on dot in `Connection#appender`. No deprecation warning is emitted.
+- `DuckDB::Connection#appender`: table names surrounded by double or single quotes (e.g. `'"a.b"'` or `"'a.b'"`) are treated as literal table names — the quotes are stripped and no dot-splitting is performed.
+- fix: `Connection#appender('a.b')` no longer emits a misleading deprecation warning (the behavior was not deprecated — it was already the correct behavior).
 - add `DuckDB::Appender.new(con, table, schema: nil, catalog: nil)` keyword argument form.
 - add `DuckDB::Connection#appender(table, schema: nil, catalog: nil)` keyword argument form.
-  - `schema.table` dot-notation form is still supported but deprecated. Use `con.appender(table, schema: schema)` instead.
 - deprecate `DuckDB::Result#_column_type(i)` private method. use `columns[i].send(:_type)` instead.
 - `DuckDB::Result#enum_dictionary_values` checks invalid column index.
 - deprecate `DuckDB::Result#_enum_dictionary_size` private method.
 - deprecate `DuckDB::Result#_enum_dictionary_value` private method.
 ## Deprecations
 - deprecate `DuckDB::Appender.new(con, schema, table)` 3-positional-argument form. Use `DuckDB::Appender.new(con, table, schema: schema)` instead.
-- deprecate passing dot-notation string (e.g. `'schema.table'`) to `DuckDB::Connection#appender`. Use `con.appender(table, schema: schema)` instead.
+- deprecate passing dot-notation string (e.g. `'schema.table'`) directly to `DuckDB::Appender.new`. Use `DuckDB::Appender.new(con, table, schema: schema)` instead.
 
 # 1.5.2.1 - 2026-04-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
   - `'"schema.table"'` or `"'schema.table'"` — quotes are stripped and the name is treated as a literal table name containing a dot.
 - `DuckDB::Connection#appender`: table name parsing (dot-notation, quoting) is now delegated entirely to `DuckDB::Appender.new`. `Connection#appender` no longer performs any parsing itself.
 - `DuckDB::Connection#appender`: table names surrounded by double or single quotes (e.g. `'"a.b"'` or `"'a.b'"`) are now treated as literal table names — the quotes are stripped and no dot-splitting is performed. This mirrors SQL identifier quoting and allows appending to tables whose names contain dots.
+- fix: `Connection#appender` dot-notation deprecation warning now correctly says `Connection#appender` instead of `DuckDB::Appender.new`.
 - add `DuckDB::Appender.new(con, table, schema: nil, catalog: nil)` keyword argument form.
 - add `DuckDB::Connection#appender(table, schema: nil, catalog: nil)` keyword argument form.
   - `schema.table` dot-notation form is still supported but deprecated. Use `con.appender(table, schema: schema)` instead.

--- a/lib/duckdb/connection.rb
+++ b/lib/duckdb/connection.rb
@@ -357,20 +357,14 @@ module DuckDB
       appender.close
     end
 
-    # Pre-parses dot-notation in Connection#appender with a Connection-specific
-    # warning, so Appender.new receives clean values and does not emit a
-    # misleading "DuckDB::Appender.new" deprecation message.
-    # Quoted table names are passed through unchanged for Appender.new to handle.
+    # Silently pre-parses dot-notation so Appender.new receives clean values
+    # and does not emit a misleading "DuckDB::Appender.new" warning.
+    # con.appender('a.b') has always split on dot — no warning needed.
+    # Quoted table names pass through unchanged for Appender.new to handle.
     def parse_connection_appender_table(table, schema, catalog)
       return [table, schema, catalog] if quoted_table_name?(table)
       return [table, schema, catalog] unless table.include?('.')
 
-      warn(
-        "Passing dot-notation '#{table}' to Connection#appender is deprecated. " \
-        "If '#{table}' is a schema-qualified table, use con.appender(table, schema: schema) instead. " \
-        "If '#{table}' is a literal table name containing a dot, use con.appender('\"#{table}\"') instead.",
-        category: :deprecated
-      )
       dot_notation_split(table, schema, catalog)
     end
 

--- a/lib/duckdb/connection.rb
+++ b/lib/duckdb/connection.rb
@@ -8,6 +8,8 @@ module DuckDB
   #   con = db.connect
   #   con.query(sql)
   class Connection
+    include DuckDB::TableNameParser
+
     # executes sql with args.
     # The first argument sql must be SQL string.
     # The rest arguments are parameters of SQL string.
@@ -162,6 +164,7 @@ module DuckDB
     #   appender.append_row(4, 'Dave')
     #   appender.close
     def appender(table, schema: nil, catalog: nil, &)
+      table, schema, catalog = parse_connection_appender_table(table, schema, catalog)
       run_appender_block(Appender.new(self, table, schema: schema, catalog: catalog), &)
     end
 
@@ -352,6 +355,23 @@ module DuckDB
       yield appender
       appender.flush
       appender.close
+    end
+
+    # Pre-parses dot-notation in Connection#appender with a Connection-specific
+    # warning, so Appender.new receives clean values and does not emit a
+    # misleading "DuckDB::Appender.new" deprecation message.
+    # Quoted table names are passed through unchanged for Appender.new to handle.
+    def parse_connection_appender_table(table, schema, catalog)
+      return [table, schema, catalog] if quoted_table_name?(table)
+      return [table, schema, catalog] unless table.include?('.')
+
+      warn(
+        "Passing dot-notation '#{table}' to Connection#appender is deprecated. " \
+        "If '#{table}' is a schema-qualified table, use con.appender(table, schema: schema) instead. " \
+        "If '#{table}' is a literal table name containing a dot, use con.appender('\"#{table}\"') instead.",
+        category: :deprecated
+      )
+      dot_notation_split(table, schema, catalog)
     end
 
     alias execute query

--- a/lib/duckdb/table_name_parser.rb
+++ b/lib/duckdb/table_name_parser.rb
@@ -16,7 +16,8 @@ module DuckDB
       if quoted_table_name?(table)
         [unquote_table_name(table), schema, catalog]
       elsif table.include?('.')
-        apply_dot_notation(table, schema, catalog)
+        warn_dot_notation_deprecated(table)
+        dot_notation_split(table, schema, catalog)
       else
         [table, schema, catalog]
       end
@@ -30,11 +31,12 @@ module DuckDB
       name[1..-2]
     end
 
-    def apply_dot_notation(table, schema, catalog) # :nodoc:
+    # Splits a dot-notation string into [table, schema, catalog].
+    # Explicit keyword args take precedence over dot-notation parts.
+    def dot_notation_split(table, schema, catalog) # :nodoc:
       parts = table.split('.')
       raise ArgumentError, "Too many dot-separated segments in '#{table}'" if parts.length > 3
 
-      warn_dot_notation_deprecated(table)
       case parts.length
       when 2 then [parts[1], schema || parts[0], catalog]
       when 3 then [parts[2], schema || parts[1], catalog || parts[0]]

--- a/test/duckdb_test/appender_test.rb
+++ b/test/duckdb_test/appender_test.rb
@@ -1293,25 +1293,23 @@ module DuckDBTest
       assert_includes(err, 'deprecated')
     end
 
-    def test_appender_dot_notation_emits_deprecation_warning
+    def test_appender_dot_notation_parses_schema_and_table
       create_table('id INT')
       appender = nil
       _, err = capture_io { appender = @con.appender('main.t') }
 
       assert_instance_of(DuckDB::Appender, appender)
-      assert_includes(err, 'Connection#appender')
-      refute_includes(err, 'DuckDB::Appender.new')
+      assert_empty(err)
     end
 
-    def test_appender_3segment_dot_notation_emits_deprecation_warning
+    def test_appender_3segment_dot_notation_parses_catalog_schema_table
       @con.query("ATTACH ':memory:' AS ext_dot")
       @con.query('CREATE TABLE ext_dot.main.t_dot (id INT)')
       appender = nil
       _, err = capture_io { appender = @con.appender('ext_dot.main.t_dot') }
 
       assert_instance_of(DuckDB::Appender, appender)
-      assert_includes(err, 'Connection#appender')
-      refute_includes(err, 'DuckDB::Appender.new')
+      assert_empty(err)
     ensure
       @con.query('DETACH ext_dot')
     end
@@ -1322,8 +1320,7 @@ module DuckDBTest
       _, err = capture_io { appender = @con.appender('wrong.t_ovr', schema: 's_override') }
 
       assert_instance_of(DuckDB::Appender, appender)
-      assert_includes(err, 'Connection#appender')
-      refute_includes(err, 'DuckDB::Appender.new')
+      assert_empty(err)
     end
 
     def test_s_new_with_dot_notation_parses_schema_and_table

--- a/test/duckdb_test/appender_test.rb
+++ b/test/duckdb_test/appender_test.rb
@@ -1299,7 +1299,6 @@ module DuckDBTest
       _, err = capture_io { appender = @con.appender('main.t') }
 
       assert_instance_of(DuckDB::Appender, appender)
-      assert_includes(err, 'deprecated')
       assert_includes(err, 'Connection#appender')
       refute_includes(err, 'DuckDB::Appender.new')
     end
@@ -1311,7 +1310,6 @@ module DuckDBTest
       _, err = capture_io { appender = @con.appender('ext_dot.main.t_dot') }
 
       assert_instance_of(DuckDB::Appender, appender)
-      assert_includes(err, 'deprecated')
       assert_includes(err, 'Connection#appender')
       refute_includes(err, 'DuckDB::Appender.new')
     ensure
@@ -1324,7 +1322,6 @@ module DuckDBTest
       _, err = capture_io { appender = @con.appender('wrong.t_ovr', schema: 's_override') }
 
       assert_instance_of(DuckDB::Appender, appender)
-      assert_includes(err, 'deprecated')
       assert_includes(err, 'Connection#appender')
       refute_includes(err, 'DuckDB::Appender.new')
     end

--- a/test/duckdb_test/appender_test.rb
+++ b/test/duckdb_test/appender_test.rb
@@ -1300,6 +1300,8 @@ module DuckDBTest
 
       assert_instance_of(DuckDB::Appender, appender)
       assert_includes(err, 'deprecated')
+      assert_includes(err, 'Connection#appender')
+      refute_includes(err, 'DuckDB::Appender.new')
     end
 
     def test_appender_3segment_dot_notation_emits_deprecation_warning
@@ -1310,6 +1312,8 @@ module DuckDBTest
 
       assert_instance_of(DuckDB::Appender, appender)
       assert_includes(err, 'deprecated')
+      assert_includes(err, 'Connection#appender')
+      refute_includes(err, 'DuckDB::Appender.new')
     ensure
       @con.query('DETACH ext_dot')
     end
@@ -1321,6 +1325,8 @@ module DuckDBTest
 
       assert_instance_of(DuckDB::Appender, appender)
       assert_includes(err, 'deprecated')
+      assert_includes(err, 'Connection#appender')
+      refute_includes(err, 'DuckDB::Appender.new')
     end
 
     def test_s_new_with_dot_notation_parses_schema_and_table
@@ -1330,6 +1336,7 @@ module DuckDBTest
 
       assert_instance_of(DuckDB::Appender, appender)
       assert_includes(err, 'deprecated')
+      assert_includes(err, 'DuckDB::Appender.new')
     end
 
     def test_s_new_with_3segment_dot_notation_parses_catalog_schema_table
@@ -1340,6 +1347,7 @@ module DuckDBTest
 
       assert_instance_of(DuckDB::Appender, appender)
       assert_includes(err, 'deprecated')
+      assert_includes(err, 'DuckDB::Appender.new')
     end
 
     def test_s_new_with_double_quoted_table_name_is_treated_as_literal
@@ -1363,6 +1371,7 @@ module DuckDBTest
 
       assert_instance_of(DuckDB::Appender, appender)
       assert_includes(err, 'deprecated')
+      assert_includes(err, 'DuckDB::Appender.new')
     end
   end
 end


### PR DESCRIPTION
## Problem

When `con.appender('schema.table')` was called, the deprecation warning incorrectly said:

```
Passing dot-notation 'schema.table' to DuckDB::Appender.new is deprecated.
```

This was misleading because the user called `Connection#appender`, not `DuckDB::Appender.new`.

## Fix

- `Connection#appender` now intercepts dot-notation **before** delegating to `Appender.new`, emitting its own warning that correctly references `Connection#appender`
- Quoted table names (`'"a.b"'`, `"'a.b'"`) pass through unchanged and are handled silently by `Appender.new`
- `Appender.new` still emits its own warning (correctly referencing `DuckDB::Appender.new`) when called directly with dot-notation

## Changes

- `lib/duckdb/table_name_parser.rb`: extract `dot_notation_split` as a separate method (pure split logic without warning); move warning call out of `apply_dot_notation` (now removed) into `parse_table_name`
- `lib/duckdb/connection.rb`: include `TableNameParser`; add private `parse_connection_appender_table` helper with Connection-specific warning message
- `test/duckdb_test/appender_test.rb`: add `refute_includes` / `assert_includes` assertions to verify correct caller name in warning
- `CHANGELOG.md`: document the fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed misleading deprecation warning so dot-notation table names no longer trigger an incorrect warning when using the connection-level appender.
* **Documentation**
  * Clarified changelog language about dot-notation deprecation and how quoted identifiers are treated.
* **Tests**
  * Updated tests to assert deprecation messaging appears only for the intended API and to confirm no spurious warnings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/suketa/ruby-duckdb/pull/1350)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->