### PR TITLE
Add DuckDB::PreparedStatement#bind_timestamp_tz

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 # Unreleased
 - add `DuckDB::Appender#append_default_to_chunk`.
 - add `DuckDB::TableNameParser` module with shared table name parsing logic (quoting and dot-notation), included by `DuckDB::Appender` and `DuckDB::TableDescription`.
+- add `DuckDB::PreparedStatement#bind_timestamp_tz` to bind a `TIMESTAMP WITH TIME ZONE` (TIMESTAMPTZ) parameter from a `Time` or timestamp string.
 ## Breaking Changes
 - `DuckDB::TableDescription.new`: the 2nd argument now parses dot-notation and quoting:
   - `'schema.table'` is interpreted as schema-qualified (deprecated; use `schema:` keyword instead).

--- a/ext/duckdb/prepared_statement.c
+++ b/ext/duckdb/prepared_statement.c
@@ -34,6 +34,7 @@ static VALUE prepared_statement__bind_uint64(VALUE self, VALUE vidx, VALUE val);
 static VALUE prepared_statement__bind_date(VALUE self, VALUE vidx, VALUE year, VALUE month, VALUE day);
 static VALUE prepared_statement__bind_time(VALUE self, VALUE vidx, VALUE hour, VALUE min, VALUE sec, VALUE micros);
 static VALUE prepared_statement__bind_timestamp(VALUE self, VALUE vidx, VALUE year, VALUE month, VALUE day, VALUE hour, VALUE min, VALUE sec, VALUE micros);
+static VALUE prepared_statement__bind_timestamp_tz(VALUE self, VALUE vidx, VALUE year, VALUE month, VALUE day, VALUE hour, VALUE min, VALUE sec, VALUE micros);
 static VALUE prepared_statement__bind_interval(VALUE self, VALUE vidx, VALUE months, VALUE days, VALUE micros);
 static VALUE prepared_statement__bind_hugeint(VALUE self, VALUE vidx, VALUE lower, VALUE upper);
 static VALUE prepared_statement__bind_uhugeint(VALUE self, VALUE vidx, VALUE lower, VALUE upper);
@@ -472,6 +473,21 @@ static VALUE prepared_statement__bind_timestamp(VALUE self, VALUE vidx, VALUE ye
 }
 
 /* :nodoc: */
+static VALUE prepared_statement__bind_timestamp_tz(VALUE self, VALUE vidx, VALUE year, VALUE month, VALUE day, VALUE hour, VALUE min, VALUE sec, VALUE micros) {
+    duckdb_timestamp timestamp_tz;
+    rubyDuckDBPreparedStatement *ctx;
+    idx_t idx = check_index(vidx);
+
+    timestamp_tz = rbduckdb_to_duckdb_timestamp_from_value(year, month, day, hour, min, sec, micros);
+    TypedData_Get_Struct(self, rubyDuckDBPreparedStatement, &prepared_statement_data_type, ctx);
+
+    if (duckdb_bind_timestamp_tz(ctx->prepared_statement, idx, timestamp_tz) == DuckDBError) {
+        rb_raise(eDuckDBError, "fail to bind %llu parameter", (unsigned long long)idx);
+    }
+    return self;
+}
+
+/* :nodoc: */
 static VALUE prepared_statement__bind_interval(VALUE self, VALUE vidx, VALUE months, VALUE days, VALUE micros) {
     duckdb_interval interval;
     rubyDuckDBPreparedStatement *ctx;
@@ -597,6 +613,7 @@ void rbduckdb_init_prepared_statement(void) {
     rb_define_private_method(cDuckDBPreparedStatement, "_bind_date", prepared_statement__bind_date, 4);
     rb_define_private_method(cDuckDBPreparedStatement, "_bind_time", prepared_statement__bind_time, 5);
     rb_define_private_method(cDuckDBPreparedStatement, "_bind_timestamp", prepared_statement__bind_timestamp, 8);
+    rb_define_private_method(cDuckDBPreparedStatement, "_bind_timestamp_tz", prepared_statement__bind_timestamp_tz, 8);
     rb_define_private_method(cDuckDBPreparedStatement, "_bind_interval", prepared_statement__bind_interval, 4);
     rb_define_private_method(cDuckDBPreparedStatement, "_bind_hugeint", prepared_statement__bind_hugeint, 3);
     rb_define_private_method(cDuckDBPreparedStatement, "_bind_uhugeint", prepared_statement__bind_uhugeint, 3);

--- a/lib/duckdb/prepared_statement.rb
+++ b/lib/duckdb/prepared_statement.rb
@@ -250,6 +250,24 @@ module DuckDB
       _bind_timestamp(index, time.year, time.month, time.day, time.hour, time.min, time.sec, time.usec)
     end
 
+    # binds i-th parameter of TIMESTAMP WITH TIME ZONE (TIMESTAMPTZ) type with SQL prepared statement.
+    # The first argument is index of parameter.
+    # The index of first parameter is 1 not 0.
+    # The second argument value is to expected time value.
+    #
+    #   require 'duckdb'
+    #   db = DuckDB::Database.open('duckdb_database')
+    #   con = db.connect
+    #   sql ='SELECT name FROM users WHERE created_at = ?'
+    #   stmt = PreparedStatement.new(con, sql)
+    #   stmt.bind_timestamp_tz(1, Time.now)
+    #   #  or you can specify timestamp string.
+    #   # stmt.bind_timestamp_tz(1, '2022-02-23 07:39:45+00')
+    def bind_timestamp_tz(index, value)
+      time = _parse_time(value).utc
+      _bind_timestamp_tz(index, time.year, time.month, time.day, time.hour, time.min, time.sec, time.usec)
+    end
+
     # binds i-th parameter with SQL prepared statement.
     # The first argument is index of parameter.
     # The index of first parameter is 1 not 0.

--- a/test/duckdb_test/prepared_statement_test.rb
+++ b/test/duckdb_test/prepared_statement_test.rb
@@ -41,6 +41,7 @@ module DuckDBTest
         col_varchar VARCHAR,
         col_date DATE,
         col_timestamp TIMESTAMP,
+        col_timestamp_tz TIMESTAMPTZ,
         col_time TIME,
         col_blob BLOB,
         col_interval INTERVAL
@@ -55,7 +56,8 @@ module DuckDBTest
         1, True, 127, 32767, 2147483647, 9223372036854775807,
         170141183460469231731687303715884105727,
         12345.375, 12345.6789, 98765.4321, 'str', '#{datestr}',
-        '2019-11-09 12:34:56', '12:34:56.000001', 'blob data',
+        '2019-11-09 12:34:56', '2024-06-15 03:00:00+00:00',
+        '12:34:56.000001', 'blob data',
         '1 year 2 months 3 days 12:34:56.987654'
       );
       SQL
@@ -67,6 +69,7 @@ module DuckDBTest
         170_141_183_460_469_231_731_687_303_715_884_105_727,
         12_345.375, 12_345.6789, 98_765.4321, 'str',
         self.class.today, Time.parse('2019-11-09 12:34:56'),
+        Time.utc(2024, 6, 15, 3, 0, 0),
         Time.local(self.class.now.year, self.class.now.month, self.class.now.day, 12, 34, 56, 1),
         'blob data',
         DuckDB::Interval.new(interval_months: 14, interval_days: 3, interval_micros: 45_296_987_654)
@@ -730,6 +733,42 @@ module DuckDBTest
       stmt = DuckDB::PreparedStatement.new(@con, 'SELECT * FROM a WHERE col_timestamp = $1')
 
       stmt.bind_timestamp(1, Time.new(2019, 11, 9, 12, 34, 56))
+      result = stmt.execute
+
+      assert_equal(1, result.each.first[0])
+    end
+
+    def test_bind_timestamp_tz
+      stmt = DuckDB::PreparedStatement.new(@con, 'SELECT * FROM a WHERE col_timestamp_tz = $1')
+
+      stmt.bind_timestamp_tz(1, Time.utc(2024, 6, 15, 3, 0, 0))
+      result = stmt.execute
+
+      assert_equal(1, result.each.first[0])
+    end
+
+    def test_bind_timestamp_tz_with_string
+      stmt = DuckDB::PreparedStatement.new(@con, 'SELECT * FROM a WHERE col_timestamp_tz = $1')
+
+      stmt.bind_timestamp_tz(1, '2024-06-15 03:00:00 UTC')
+      result = stmt.execute
+
+      assert_equal(1, result.each.first[0])
+    end
+
+    def test_bind_timestamp_tz_with_non_utc_time
+      stmt = DuckDB::PreparedStatement.new(@con, 'SELECT * FROM a WHERE col_timestamp_tz = $1')
+
+      stmt.bind_timestamp_tz(1, Time.new(2024, 6, 15, 12, 0, 0, '+09:00'))
+      result = stmt.execute
+
+      assert_equal(1, result.each.first[0])
+    end
+
+    def test_bind_timestamp_tz_with_non_utc_string
+      stmt = DuckDB::PreparedStatement.new(@con, 'SELECT * FROM a WHERE col_timestamp_tz = $1')
+
+      stmt.bind_timestamp_tz(1, '2024-06-15 12:00:00 +09:00')
       result = stmt.execute
 
       assert_equal(1, result.each.first[0])


### PR DESCRIPTION
GitHub: close GH-1269

Wrap duckdb_bind_timestamp_tz() C-API to bind a TIMESTAMP WITH TIME ZONE (TIMESTAMPTZ) parameter from a Ruby Time or timestamp string.

ref: https://duckdb.org/docs/current/sql/data_types/timestamp
ref: https://duckdb.org/docs/stable/clients/c/api.html#duckdb_bind_timestamp_tz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for binding TIMESTAMP WITH TIME ZONE parameters in prepared statements. The feature accepts both Time objects and timestamp strings, automatically converting them to UTC for database storage.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/suketa/ruby-duckdb/pull/1351)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->