### PR TITLE
ci: upgrade Ruby 4.0.x and fix bundled Bundler on ruby-head

### DIFF
--- a/.github/workflows/test_on_macos.yml
+++ b/.github/workflows/test_on_macos.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['3.2.11', '3.3.11', '3.4.9', '4.0.3', 'head']
+        ruby: ['3.2.11', '3.3.11', '3.4.9', '4.0.4', 'head']
         duckdb: ['1.4.4', '1.5.2']
 
     steps:

--- a/.github/workflows/test_on_macos.yml
+++ b/.github/workflows/test_on_macos.yml
@@ -26,6 +26,10 @@ jobs:
       matrix:
         ruby: ['3.2.11', '3.3.11', '3.4.9', '4.0.4', 'head']
         duckdb: ['1.4.4', '1.5.2']
+    env:
+      # Released Bundler is broken on ruby-head due to ruby/ruby#16895.
+      # Use Ruby's bundled Bundler until rubygems/rubygems#9529 is released.
+      BUNDLER_VERSION: ${{ matrix.ruby == 'head' && '0' || '' }}
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test_on_ubuntu.yml
+++ b/.github/workflows/test_on_ubuntu.yml
@@ -27,6 +27,10 @@ jobs:
       matrix:
         ruby: ['3.2.11', '3.3.11', '3.4.9', '4.0.4', 'head']
         duckdb: ['1.4.4', '1.5.2']
+    env:
+      # Released Bundler is broken on ruby-head due to ruby/ruby#16895.
+      # Use Ruby's bundled Bundler until rubygems/rubygems#9529 is released.
+      BUNDLER_VERSION: ${{ matrix.ruby == 'head' && '0' || '' }}
 
     services:
       mysql:

--- a/.github/workflows/test_on_ubuntu.yml
+++ b/.github/workflows/test_on_ubuntu.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['3.2.11', '3.3.11', '3.4.9', '4.0.3', 'head']
+        ruby: ['3.2.11', '3.3.11', '3.4.9', '4.0.4', 'head']
         duckdb: ['1.4.4', '1.5.2']
 
     services:

--- a/.github/workflows/test_on_windows.yml
+++ b/.github/workflows/test_on_windows.yml
@@ -29,7 +29,7 @@ jobs:
     env:
       # Released Bundler is broken on ruby-head due to ruby/ruby#16895.
       # Use Ruby's bundled Bundler until rubygems/rubygems#9529 is released.
-      BUNDLER_VERSION: ${{ matrix.ruby == 'head' && '0' || '' }}
+      BUNDLER_VERSION: ${{ (matrix.ruby == 'head' || matrix.ruby == 'ucrt' || matrix.ruby == 'mswin') && '0' || '' }}
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test_on_windows.yml
+++ b/.github/workflows/test_on_windows.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['3.2.9', '3.3.10', '3.4.8', '4.0.1', 'ucrt', 'mingw', 'mswin', 'head']
+        ruby: ['3.2.9', '3.3.10', '3.4.8', '4.0.3', 'ucrt', 'mingw', 'mswin', 'head']
         duckdb: ['1.4.4', '1.5.2']
 
     steps:

--- a/.github/workflows/test_on_windows.yml
+++ b/.github/workflows/test_on_windows.yml
@@ -26,6 +26,10 @@ jobs:
       matrix:
         ruby: ['3.2.9', '3.3.10', '3.4.8', '4.0.3', 'ucrt', 'mingw', 'mswin', 'head']
         duckdb: ['1.4.4', '1.5.2']
+    env:
+      # Released Bundler is broken on ruby-head due to ruby/ruby#16895.
+      # Use Ruby's bundled Bundler until rubygems/rubygems#9529 is released.
+      BUNDLER_VERSION: ${{ matrix.ruby == 'head' && '0' || '' }}
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
## Changes

- macOS/Linux: Ruby 4.0.3 → 4.0.4
- Windows: Ruby 4.0.1 → 4.0.3 (latest available on RubyInstaller)
- All platforms: set `BUNDLER_VERSION: 0` when `matrix.ruby == 'head'` to use Ruby's bundled Bundler, working around the broken released Bundler on ruby-head (ruby/ruby#16895, rubygems/rubygems#9529)
  - refs #1347 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration test matrices to use Ruby 4.0.4 across macOS and Ubuntu (4.0.3 on Windows).
  * Enhanced CI workflow configuration for improved Bundler compatibility on Ruby head versions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/suketa/ruby-duckdb/pull/1352)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->