### PR TITLE
fix: ScalarFunction.create requires name:; ScalarFunctionSet#add no longer overrides function name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to this project will be documented in this file.
 - add `DuckDB::Appender#append_default_to_chunk`.
 - add `DuckDB::TableNameParser` module with shared table name parsing logic (quoting and dot-notation), included by `DuckDB::Appender` and `DuckDB::TableDescription`.
 - add `DuckDB::PreparedStatement#bind_timestamp_tz` to bind a `TIMESTAMP WITH TIME ZONE` (TIMESTAMPTZ) parameter from a `Time` or timestamp string.
+- `DuckDB::ScalarFunction.create`: `name:` is now a required keyword argument (previously optional with `nil` default). Parameter order changed to `name:, return_type:, ...`.
+- `DuckDB::ScalarFunctionSet#add`: no longer overrides the scalar function's name with the set's name. The individual function must have its own name set before being added to the set.
 ## Breaking Changes
 - `DuckDB::TableDescription.new`: the 2nd argument now parses dot-notation and quoting:
   - `'schema.table'` is interpreted as schema-qualified (deprecated; use `schema:` keyword instead).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ All notable changes to this project will be documented in this file.
 - add `DuckDB::Appender#append_default_to_chunk`.
 - add `DuckDB::TableNameParser` module with shared table name parsing logic (quoting and dot-notation), included by `DuckDB::Appender` and `DuckDB::TableDescription`.
 - add `DuckDB::PreparedStatement#bind_timestamp_tz` to bind a `TIMESTAMP WITH TIME ZONE` (TIMESTAMPTZ) parameter from a `Time` or timestamp string.
+## Breaking Changes
 - `DuckDB::ScalarFunction.create`: `name:` is now a required keyword argument (previously optional with `nil` default). Parameter order changed to `name:, return_type:, ...`.
 - `DuckDB::ScalarFunctionSet#add`: no longer overrides the scalar function's name with the set's name. The individual function must have its own name set before being added to the set.
-## Breaking Changes
 - `DuckDB::TableDescription.new`: the 2nd argument now parses dot-notation and quoting:
   - `'schema.table'` is interpreted as schema-qualified (deprecated; use `schema:` keyword instead).
   - `'"schema.table"'` or `"'schema.table'"` — quotes are stripped and the name is treated as a literal table name containing a dot.

--- a/lib/duckdb/scalar_function.rb
+++ b/lib/duckdb/scalar_function.rb
@@ -7,8 +7,7 @@ module DuckDB
   class ScalarFunction
     # Create and configure a scalar function in one call
     #
-    # @param name [String, Symbol, nil] the function name; use +nil+ when creating overloads
-    #   intended for use in a +DuckDB::ScalarFunctionSet+ (the set provides the name)
+    # @param name [String, Symbol] the function name (required)
     # @param return_type [DuckDB::LogicalType|:logical_type_symbol] the return type
     # @param parameter_type [DuckDB::LogicalType|:logical_type_symbol, nil] single fixed parameter type
     # @param parameter_types [Array<DuckDB::LogicalType|:logical_type_symbol>, nil] multiple fixed parameter types
@@ -64,7 +63,7 @@ module DuckDB
     #     null_handling: true
     #   ) { |v| v.nil? ? 0 : v }
     def self.create( # rubocop:disable Metrics/MethodLength,Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity,Metrics/ParameterLists
-      return_type:, name: nil, parameter_type: nil, parameter_types: nil, varargs_type: nil, null_handling: false, &
+      return_type:, name:, parameter_type: nil, parameter_types: nil, varargs_type: nil, null_handling: false, &
     )
       raise ArgumentError, 'Block required' unless block_given?
       raise ArgumentError, 'Cannot specify both parameter_type and parameter_types' if parameter_type && parameter_types
@@ -78,7 +77,7 @@ module DuckDB
                end
 
       sf = new
-      sf.name = name if name
+      sf.name = name
       sf.return_type = return_type
       params.each { |type| sf.add_parameter(type) }
       sf.varargs_type = varargs_type if varargs_type

--- a/lib/duckdb/scalar_function.rb
+++ b/lib/duckdb/scalar_function.rb
@@ -86,15 +86,9 @@ module DuckDB
       sf
     end
 
-    # Overrides the C-level name= to also cache the name in a Ruby ivar,
-    # enabling ScalarFunctionSet#add to verify the function has a name.
     def name=(value)
-      @name = value.to_s
-      set_name(@name)
+      set_name(value.to_s)
     end
-
-    # @return [String, nil] the function name, or nil if not set
-    attr_reader :name
 
     private :set_name
 

--- a/lib/duckdb/scalar_function.rb
+++ b/lib/duckdb/scalar_function.rb
@@ -63,7 +63,7 @@ module DuckDB
     #     null_handling: true
     #   ) { |v| v.nil? ? 0 : v }
     def self.create( # rubocop:disable Metrics/MethodLength,Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity,Metrics/ParameterLists
-      return_type:, name:, parameter_type: nil, parameter_types: nil, varargs_type: nil, null_handling: false, &
+      name:, return_type:, parameter_type: nil, parameter_types: nil, varargs_type: nil, null_handling: false, &
     )
       raise ArgumentError, 'Block required' unless block_given?
       raise ArgumentError, 'Cannot specify both parameter_type and parameter_types' if parameter_type && parameter_types

--- a/lib/duckdb/scalar_function.rb
+++ b/lib/duckdb/scalar_function.rb
@@ -78,7 +78,7 @@ module DuckDB
                end
 
       sf = new
-      sf.name = name.to_s if name
+      sf.name = name if name
       sf.return_type = return_type
       params.each { |type| sf.add_parameter(type) }
       sf.varargs_type = varargs_type if varargs_type
@@ -86,6 +86,18 @@ module DuckDB
       sf.set_function(&)
       sf
     end
+
+    # Overrides the C-level name= to also cache the name in a Ruby ivar,
+    # enabling ScalarFunctionSet#add to verify the function has a name.
+    def name=(value)
+      @name = value.to_s
+      set_name(@name)
+    end
+
+    # @return [String, nil] the function name, or nil if not set
+    attr_reader :name
+
+    private :set_name
 
     include FunctionTypeValidation
 

--- a/lib/duckdb/scalar_function_set.rb
+++ b/lib/duckdb/scalar_function_set.rb
@@ -24,7 +24,10 @@ module DuckDB
         raise TypeError, "#{scalar_function.class} is not a DuckDB::ScalarFunction"
       end
 
-      scalar_function.name = @name
+      if scalar_function.name.to_s.empty?
+        raise ArgumentError, 'ScalarFunction must have a name before being added to a ScalarFunctionSet'
+      end
+
       _add(scalar_function)
     end
   end

--- a/lib/duckdb/scalar_function_set.rb
+++ b/lib/duckdb/scalar_function_set.rb
@@ -24,10 +24,6 @@ module DuckDB
         raise TypeError, "#{scalar_function.class} is not a DuckDB::ScalarFunction"
       end
 
-      if scalar_function.name.to_s.empty?
-        raise ArgumentError, 'ScalarFunction must have a name before being added to a ScalarFunctionSet'
-      end
-
       _add(scalar_function)
     end
   end

--- a/test/duckdb_test/scalar_function_set_test.rb
+++ b/test/duckdb_test/scalar_function_set_test.rb
@@ -47,18 +47,6 @@ module DuckDBTest
       assert_raises(TypeError) { set.add('not a scalar function') }
     end
 
-    def test_add_raises_with_nameless_scalar_function
-      # ScalarFunction built manually without setting a name → C-level name is empty string
-      sf = DuckDB::ScalarFunction.new
-      sf.add_parameter(:integer)
-      sf.add_parameter(:integer)
-      sf.return_type = :integer
-      sf.set_function { |a, b| a + b }
-      set = DuckDB::ScalarFunctionSet.new('set_name')
-
-      assert_raises(ArgumentError) { set.add(sf) }
-    end
-
     def test_add_accepts_duplicate_overload
       sf1 = DuckDB::ScalarFunction.create(name: :add, return_type: :integer, parameter_types: %i[integer integer]) { |a, b| a + b }
       sf2 = DuckDB::ScalarFunction.create(name: :add, return_type: :integer, parameter_types: %i[integer integer]) { |a, b| a * b }

--- a/test/duckdb_test/scalar_function_set_test.rb
+++ b/test/duckdb_test/scalar_function_set_test.rb
@@ -35,7 +35,7 @@ module DuckDBTest
     end
 
     def test_add_returns_self
-      sf = DuckDB::ScalarFunction.create(return_type: :integer, parameter_types: %i[integer integer]) { |a, b| a + b }
+      sf = DuckDB::ScalarFunction.create(name: :add, return_type: :integer, parameter_types: %i[integer integer]) { |a, b| a + b }
       set = DuckDB::ScalarFunctionSet.new(:add)
 
       assert_same set, set.add(sf)
@@ -56,8 +56,8 @@ module DuckDBTest
     end
 
     def test_add_accepts_duplicate_overload
-      sf1 = DuckDB::ScalarFunction.create(return_type: :integer, parameter_types: %i[integer integer]) { |a, b| a + b }
-      sf2 = DuckDB::ScalarFunction.create(return_type: :integer, parameter_types: %i[integer integer]) { |a, b| a * b }
+      sf1 = DuckDB::ScalarFunction.create(name: :add, return_type: :integer, parameter_types: %i[integer integer]) { |a, b| a + b }
+      sf2 = DuckDB::ScalarFunction.create(name: :add, return_type: :integer, parameter_types: %i[integer integer]) { |a, b| a * b }
       set = DuckDB::ScalarFunctionSet.new(:add)
       set.add(sf1)
 
@@ -65,9 +65,9 @@ module DuckDBTest
     end
 
     def test_add_multiple_overloads_with_different_parameter_types
-      sf_int = DuckDB::ScalarFunction.create(return_type: :integer, parameter_types: %i[integer integer]) { |a, b| a + b }
-      sf_dbl = DuckDB::ScalarFunction.create(return_type: :double, parameter_types: %i[double double]) { |a, b| a + b }
-      sf_str = DuckDB::ScalarFunction.create(return_type: :varchar, parameter_types: %i[varchar varchar]) { |a, b| "#{a}#{b}" }
+      sf_int = DuckDB::ScalarFunction.create(name: :add, return_type: :integer, parameter_types: %i[integer integer]) { |a, b| a + b }
+      sf_dbl = DuckDB::ScalarFunction.create(name: :add, return_type: :double, parameter_types: %i[double double]) { |a, b| a + b }
+      sf_str = DuckDB::ScalarFunction.create(name: :add, return_type: :varchar, parameter_types: %i[varchar varchar]) { |a, b| "#{a}#{b}" }
       set = DuckDB::ScalarFunctionSet.new(:add)
 
       assert_same set, set.add(sf_int)
@@ -76,8 +76,8 @@ module DuckDBTest
     end
 
     def test_add_overloads_with_different_parameter_counts
-      sf_unary = DuckDB::ScalarFunction.create(return_type: :integer, parameter_types: [:integer]) { |a| a * 2 }
-      sf_binary = DuckDB::ScalarFunction.create(return_type: :integer, parameter_types: %i[integer integer]) { |a, b| a + b }
+      sf_unary = DuckDB::ScalarFunction.create(name: :my_func, return_type: :integer, parameter_types: [:integer]) { |a| a * 2 }
+      sf_binary = DuckDB::ScalarFunction.create(name: :my_func, return_type: :integer, parameter_types: %i[integer integer]) { |a, b| a + b }
       set = DuckDB::ScalarFunctionSet.new(:my_func)
 
       assert_same set, set.add(sf_unary)
@@ -85,7 +85,7 @@ module DuckDBTest
     end
 
     def test_add_overload_with_varargs_type
-      sf_varargs = DuckDB::ScalarFunction.create(return_type: :integer, varargs_type: :integer) { |*args| args.sum }
+      sf_varargs = DuckDB::ScalarFunction.create(name: :sum_all, return_type: :integer, varargs_type: :integer) { |*args| args.sum }
       set = DuckDB::ScalarFunctionSet.new(:sum_all)
 
       assert_same set, set.add(sf_varargs)
@@ -96,7 +96,7 @@ module DuckDBTest
     end
 
     def test_register_scalar_function_set_with_single_integer_overload
-      sf = DuckDB::ScalarFunction.create(return_type: :integer, parameter_types: %i[integer integer]) { |a, b| a + b }
+      sf = DuckDB::ScalarFunction.create(name: :add_set, return_type: :integer, parameter_types: %i[integer integer]) { |a, b| a + b }
       set = DuckDB::ScalarFunctionSet.new(:add_set)
       set.add(sf)
 
@@ -107,9 +107,9 @@ module DuckDBTest
     end
 
     def test_register_scalar_function_set_with_multiple_overloads
-      sf_int = DuckDB::ScalarFunction.create(return_type: :integer, parameter_types: %i[integer integer]) { |a, b| a + b }
-      sf_dbl = DuckDB::ScalarFunction.create(return_type: :double, parameter_types: %i[double double]) { |a, b| a + b }
-      sf_str = DuckDB::ScalarFunction.create(return_type: :varchar, parameter_types: %i[varchar varchar]) { |a, b| "#{a}#{b}" }
+      sf_int = DuckDB::ScalarFunction.create(name: :poly_add, return_type: :integer, parameter_types: %i[integer integer]) { |a, b| a + b }
+      sf_dbl = DuckDB::ScalarFunction.create(name: :poly_add, return_type: :double, parameter_types: %i[double double]) { |a, b| a + b }
+      sf_str = DuckDB::ScalarFunction.create(name: :poly_add, return_type: :varchar, parameter_types: %i[varchar varchar]) { |a, b| "#{a}#{b}" }
 
       set = DuckDB::ScalarFunctionSet.new(:poly_add)
       set.add(sf_int).add(sf_dbl).add(sf_str)
@@ -121,7 +121,7 @@ module DuckDBTest
     end
 
     def test_register_scalar_function_set_gc_safety
-      sf = DuckDB::ScalarFunction.create(return_type: :integer, parameter_types: [:integer]) { |a| a * 10 }
+      sf = DuckDB::ScalarFunction.create(name: :tenx, return_type: :integer, parameter_types: [:integer]) { |a| a * 10 }
       set = DuckDB::ScalarFunctionSet.new(:tenx)
       set.add(sf)
       @con.register_scalar_function_set(set)

--- a/test/duckdb_test/scalar_function_set_test.rb
+++ b/test/duckdb_test/scalar_function_set_test.rb
@@ -47,6 +47,14 @@ module DuckDBTest
       assert_raises(TypeError) { set.add('not a scalar function') }
     end
 
+    def test_add_raises_with_nameless_scalar_function
+      # ScalarFunction created without name: → C-level name is empty string
+      sf = DuckDB::ScalarFunction.create(return_type: :integer, parameter_types: %i[integer integer]) { |a, b| a + b }
+      set = DuckDB::ScalarFunctionSet.new('set_name')
+
+      assert_raises(ArgumentError) { set.add(sf) }
+    end
+
     def test_add_accepts_duplicate_overload
       sf1 = DuckDB::ScalarFunction.create(return_type: :integer, parameter_types: %i[integer integer]) { |a, b| a + b }
       sf2 = DuckDB::ScalarFunction.create(return_type: :integer, parameter_types: %i[integer integer]) { |a, b| a * b }

--- a/test/duckdb_test/scalar_function_set_test.rb
+++ b/test/duckdb_test/scalar_function_set_test.rb
@@ -48,8 +48,12 @@ module DuckDBTest
     end
 
     def test_add_raises_with_nameless_scalar_function
-      # ScalarFunction created without name: → C-level name is empty string
-      sf = DuckDB::ScalarFunction.create(return_type: :integer, parameter_types: %i[integer integer]) { |a, b| a + b }
+      # ScalarFunction built manually without setting a name → C-level name is empty string
+      sf = DuckDB::ScalarFunction.new
+      sf.add_parameter(:integer)
+      sf.add_parameter(:integer)
+      sf.return_type = :integer
+      sf.set_function { |a, b| a + b }
       set = DuckDB::ScalarFunctionSet.new('set_name')
 
       assert_raises(ArgumentError) { set.add(sf) }

--- a/test/duckdb_test/scalar_function_test.rb
+++ b/test/duckdb_test/scalar_function_test.rb
@@ -630,6 +630,12 @@ module DuckDBTest
       assert_match(/cannot specify both/i, error.message)
     end
 
+    def test_create_requires_name
+      assert_raises(ArgumentError) do
+        DuckDB::ScalarFunction.create(return_type: :integer) { 1 }
+      end
+    end
+
     def test_create_accepts_symbol_for_name
       sf = DuckDB::ScalarFunction.create(
         name: :symbol_name,


### PR DESCRIPTION
## Summary

Aligns `ScalarFunction`/`ScalarFunctionSet` with the `AggregateFunction`/`AggregateFunctionSet` API design.

### Changes

#### `ScalarFunction.create` — `name:` is now required
- Changed `name: nil` → `name:` (required keyword argument)
- Parameter order changed to `name:, return_type:, ...` for consistency
- A nameless `ScalarFunction` can no longer be created via `create`; use the low-level `ScalarFunction.new` + `name=` if needed
- Updated `@param name` docstring accordingly

#### `ScalarFunction#name=` — thin coercion wrapper
- Added a Ruby-level `name=` that coerces the argument with `.to_s` before delegating to the private C-level `set_name`
- This allows `name: :my_func` (Symbol) to work in `create`
- No `@name` ivar / `attr_reader :name` — consistent with `AggregateFunction`

#### `ScalarFunctionSet#add` — no longer overrides function name
- Removed `scalar_function.name = @name` (the set no longer mutates the caller's function object)
- DuckDB uses the **set's** name for SQL registration regardless; individual function names only need to be non-empty for C-level validation (checked at `register_scalar_function_set` time)
- All existing tests updated to pass `name:` explicitly when creating functions used in a set

## Notes
- `ScalarFunction` and `ScalarFunctionSet` are both marked `@note experimental`
- `AggregateFunction#name=` accepting Symbols will be addressed in a separate PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * `ScalarFunction.create` now requires `name:` as a mandatory keyword argument (previously optional)
  * `ScalarFunction.create` parameter order updated to `name:, return_type:, ...`
  * `ScalarFunctionSet#add` no longer automatically assigns the set's name to scalar functions; each function must be named individually before adding

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/suketa/ruby-duckdb/pull/1355?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->