### PR TITLE
fix: AggregateFunction#name= accepts Symbol (consistent with ScalarFunction)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 - add `DuckDB::Appender#append_default_to_chunk`.
 - add `DuckDB::TableNameParser` module with shared table name parsing logic (quoting and dot-notation), included by `DuckDB::Appender` and `DuckDB::TableDescription`.
 - add `DuckDB::PreparedStatement#bind_timestamp_tz` to bind a `TIMESTAMP WITH TIME ZONE` (TIMESTAMPTZ) parameter from a `Time` or timestamp string.
+- `DuckDB::AggregateFunction#name=` and `DuckDB::ScalarFunction#name=` now accept Symbol arguments (coerced to String).
 ## Breaking Changes
 - `DuckDB::ScalarFunction.create`: `name:` is now a required keyword argument (previously optional with `nil` default). Parameter order changed to `name:, return_type:, ...`.
 - `DuckDB::ScalarFunctionSet#add`: no longer overrides the scalar function's name with the set's name. The individual function must have its own name set before being added to the set.

--- a/ext/duckdb/aggregate_function.c
+++ b/ext/duckdb/aggregate_function.c
@@ -736,6 +736,7 @@ void rbduckdb_init_aggregate_function(void) {
     cDuckDBAggregateFunction = rb_define_class_under(mDuckDB, "AggregateFunction", rb_cObject);
     rb_define_alloc_func(cDuckDBAggregateFunction, allocate);
     rb_define_method(cDuckDBAggregateFunction, "initialize", aggregate_function_initialize, 0);
+    rb_define_method(cDuckDBAggregateFunction, "set_name", aggregate_function_set_name, 1);
     rb_define_method(cDuckDBAggregateFunction, "name=", aggregate_function_set_name, 1);
     rb_define_private_method(cDuckDBAggregateFunction, "_set_return_type", aggregate_function__set_return_type, 1);
     rb_define_private_method(cDuckDBAggregateFunction, "_add_parameter", aggregate_function__add_parameter, 1);

--- a/lib/duckdb/aggregate_function.rb
+++ b/lib/duckdb/aggregate_function.rb
@@ -57,6 +57,12 @@ module DuckDB
   class AggregateFunction
     include FunctionTypeValidation
 
+    def name=(value)
+      set_name(value.to_s)
+    end
+
+    private :set_name
+
     class << self
       # Creates a new AggregateFunction in a single call.
       #
@@ -64,7 +70,7 @@ module DuckDB
       # AggregateFunction without requiring you to set each attribute
       # separately.
       #
-      # @param name [String] the SQL function name
+      # @param name [String, Symbol] the SQL function name
       # @param return_type [DuckDB::LogicalType | Symbol] the SQL return type
       # @param params [Array<DuckDB::LogicalType | Symbol>] input parameter types
       #   (empty array for a zero-argument aggregate)

--- a/test/duckdb_test/aggregate_function_test.rb
+++ b/test/duckdb_test/aggregate_function_test.rb
@@ -425,6 +425,7 @@ module DuckDBTest
     def test_name_setter_accepts_symbol
       af = DuckDB::AggregateFunction.new
       result = af.name = :my_agg
+
       assert_instance_of DuckDB::AggregateFunction, af
       assert_equal 'my_agg', result.to_s
     end

--- a/test/duckdb_test/aggregate_function_test.rb
+++ b/test/duckdb_test/aggregate_function_test.rb
@@ -422,6 +422,13 @@ module DuckDBTest
       assert_equal 44, result.first.first
     end
 
+    def test_name_setter_accepts_symbol
+      af = DuckDB::AggregateFunction.new
+      result = af.name = :my_agg
+      assert_instance_of DuckDB::AggregateFunction, af
+      assert_equal 'my_agg', result.to_s
+    end
+
     private
 
     # Force DuckDB to actually parallelise aggregation so the combine callback


### PR DESCRIPTION
## Summary

`AggregateFunction#name=` previously only accepted String (C-level `StringValuePtr` rejects Symbols). This made it inconsistent with `ScalarFunction#name=` which already accepts Symbols.

### Changes

#### `ext/duckdb/aggregate_function.c`
- Register `set_name` as a C-level alias for `aggregate_function_set_name`, mirroring what `scalar_function.c` already does

#### `lib/duckdb/aggregate_function.rb`
- Add Ruby-level `name=` wrapper: `def name=(value); set_name(value.to_s); end`
- `private :set_name` — enforce `name=` as the sole public entry-point
- Update `@param name` doc in `AggregateFunction.create` to `[String, Symbol]`

Now both classes share the same exact pattern:
```ruby
def name=(value)
  set_name(value.to_s)
end
private :set_name
```