### PR TITLE
ci: upgrade Ruby 4.0.5

### DIFF
--- a/.github/workflows/test_on_macos.yml
+++ b/.github/workflows/test_on_macos.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['3.2.11', '3.3.11', '3.4.9', '4.0.4', 'head']
+        ruby: ['3.2.11', '3.3.11', '3.4.9', '4.0.5', 'head']
         duckdb: ['1.4.4', '1.5.2']
     env:
       # Released Bundler is broken on ruby-head due to ruby/ruby#16895.

--- a/.github/workflows/test_on_ubuntu.yml
+++ b/.github/workflows/test_on_ubuntu.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['3.2.11', '3.3.11', '3.4.9', '4.0.4', 'head']
+        ruby: ['3.2.11', '3.3.11', '3.4.9', '4.0.5', 'head']
         duckdb: ['1.4.4', '1.5.2']
     env:
       # Released Bundler is broken on ruby-head due to ruby/ruby#16895.

--- a/.github/workflows/test_on_windows.yml
+++ b/.github/workflows/test_on_windows.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['3.2.9', '3.3.10', '3.4.8', '4.0.3', 'ucrt', 'mingw', 'mswin', 'head']
+        ruby: ['3.2.9', '3.3.10', '3.4.8', '4.0.5', 'ucrt', 'mingw', 'mswin', 'head']
         duckdb: ['1.4.4', '1.5.2']
     env:
       # Released Bundler is broken on ruby-head due to ruby/ruby#16895.


### PR DESCRIPTION
Upgrade Ruby 4.0.5 in CI workflows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated testing infrastructure with Ruby patch version updates across macOS, Ubuntu, and Windows CI environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/suketa/ruby-duckdb/pull/1358?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->