### PR TITLE
bump up DuckDB 1.5.3 on CI

### DIFF
--- a/.github/workflows/test_on_macos.yml
+++ b/.github/workflows/test_on_macos.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby: ['3.2.11', '3.3.11', '3.4.9', '4.0.5', 'head']
-        duckdb: ['1.4.4', '1.5.2']
+        duckdb: ['1.4.4', '1.5.3']
     env:
       # Released Bundler is broken on ruby-head due to ruby/ruby#16895.
       # Use Ruby's bundled Bundler until rubygems/rubygems#9529 is released.

--- a/.github/workflows/test_on_macos.yml
+++ b/.github/workflows/test_on_macos.yml
@@ -54,7 +54,7 @@ jobs:
       run: |
         curl -OL https://github.com/duckdb/duckdb/releases/download/v${DUCKDB_VERSION}/libduckdb-osx-universal.zip
         case "${DUCKDB_VERSION}" in
-          "1.5.2") EXPECTED_SHA256="524f3537330a1b747556a0c98b62a46865a3f48c7ead2b2035c62f1ad3e5ca8b" ;;
+          "1.5.3") EXPECTED_SHA256="386f8e8b3b4bc8d128762327121e22065ce45f2ee55ef1b1f412ce11e0e6c51f" ;;
           "1.4.4") EXPECTED_SHA256="5e6d79f5fb86bbd4f24d59cee3bc38f113d1433761df35337e3c01c62eeafe26" ;;
           *) echo "No known SHA256 for DuckDB v${DUCKDB_VERSION}"; exit 1 ;;
         esac

--- a/.github/workflows/test_on_ubuntu.yml
+++ b/.github/workflows/test_on_ubuntu.yml
@@ -67,7 +67,7 @@ jobs:
       run: |
         curl -OL https://github.com/duckdb/duckdb/releases/download/v${DUCKDB_VERSION}/libduckdb-linux-amd64.zip
         case "${DUCKDB_VERSION}" in
-          "1.5.2") EXPECTED_SHA256="4711438f0fdb04f0441803409bec5430b763d4f2ac3482c1f97cfa6b5ecb4c15" ;;
+          "1.5.3") EXPECTED_SHA256="0a926eba5bce0abc0010f4b9109133e4440cb74e97bd10fd2d0fc2a721621b05" ;;
           "1.4.4") EXPECTED_SHA256="09cc288295964d897b47665d1898e16e8ef176cae9ea615797fc136eae15bd5d" ;;
           *) echo "No known SHA256 for DuckDB v${DUCKDB_VERSION}"; exit 1 ;;
         esac

--- a/.github/workflows/test_on_ubuntu.yml
+++ b/.github/workflows/test_on_ubuntu.yml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby: ['3.2.11', '3.3.11', '3.4.9', '4.0.5', 'head']
-        duckdb: ['1.4.4', '1.5.2']
+        duckdb: ['1.4.4', '1.5.3']
     env:
       # Released Bundler is broken on ruby-head due to ruby/ruby#16895.
       # Use Ruby's bundled Bundler until rubygems/rubygems#9529 is released.

--- a/.github/workflows/test_on_windows.yml
+++ b/.github/workflows/test_on_windows.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby: ['3.2.9', '3.3.10', '3.4.8', '4.0.5', 'ucrt', 'mingw', 'mswin', 'head']
-        duckdb: ['1.4.4', '1.5.2']
+        duckdb: ['1.4.4', '1.5.3']
     env:
       # Released Bundler is broken on ruby-head due to ruby/ruby#16895.
       # Use Ruby's bundled Bundler until rubygems/rubygems#9529 is released.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 # Unreleased
+- bump up DuckDB 1.5.3 on CI.
 - add `DuckDB::AggregateFunctionSet` class and `DuckDB::Connection#register_aggregate_function_set` to register multiple overloads of a custom aggregate function under one SQL name.
 - add `DuckDB::Appender#append_default_to_chunk`.
 - add `DuckDB::TableNameParser` module with shared table name parsing logic (quoting and dot-notation), included by `DuckDB::Appender` and `DuckDB::TableDescription`.


### PR DESCRIPTION
## Summary

- Bump up DuckDB version to 1.5.3 in CI workflows (macOS, Ubuntu, Windows)
- Fix SHA256 checksum for DuckDB 1.5.3 in CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI testing workflows to use DuckDB version 1.5.3 across macOS, Ubuntu, and Windows platforms with corresponding binary verification checksums updated.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/suketa/ruby-duckdb/pull/1359?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->