### PR TITLE
Add DuckDB::TableFunction::InitInfo#max_threads=

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 # Unreleased
+- add `DuckDB::TableFunction::InitInfo#max_threads=` (and `#set_max_threads`) to hint DuckDB how many worker threads can execute a custom table function concurrently.
 
 # 1.5.3.0 - 2026-05-24
 - bump up DuckDB 1.5.3 on CI.

--- a/ext/duckdb/table_function_init_info.c
+++ b/ext/duckdb/table_function_init_info.c
@@ -6,6 +6,7 @@ static void deallocate(void *ctx);
 static VALUE allocate(VALUE klass);
 static size_t memsize(const void *p);
 static VALUE rbduckdb_init_info_set_error(VALUE self, VALUE error);
+static VALUE rbduckdb_init_info_set_max_threads(VALUE self, VALUE max_threads);
 
 static const rb_data_type_t init_info_data_type = {
     "DuckDB/TableFunctionInitInfo",
@@ -54,6 +55,27 @@ static VALUE rbduckdb_init_info_set_error(VALUE self, VALUE error) {
     return self;
 }
 
+/*
+ * call-seq:
+ *   init_info.set_max_threads(max_threads) -> self
+ *   init_info.max_threads = max_threads
+ *
+ * Sets the maximum number of threads that can execute the table function concurrently.
+ * This is a hint to DuckDB's scheduler; the actual number of threads is also bounded
+ * by the configured worker pool size (e.g., +SET threads+).
+ *
+ *   init_info.max_threads = 4
+ */
+static VALUE rbduckdb_init_info_set_max_threads(VALUE self, VALUE max_threads) {
+    rubyDuckDBInitInfo *ctx;
+
+    TypedData_Get_Struct(self, rubyDuckDBInitInfo, &init_info_data_type, ctx);
+
+    duckdb_init_set_max_threads(ctx->info, NUM2ULL(max_threads));
+
+    return self;
+}
+
 void rbduckdb_init_duckdb_table_function_init_info(void) {
 #if 0
     VALUE mDuckDB = rb_define_module("DuckDB");
@@ -62,4 +84,6 @@ void rbduckdb_init_duckdb_table_function_init_info(void) {
     rb_define_alloc_func(cDuckDBTableFunctionInitInfo, allocate);
 
     rb_define_method(cDuckDBTableFunctionInitInfo, "set_error", rbduckdb_init_info_set_error, 1);
+    rb_define_method(cDuckDBTableFunctionInitInfo, "set_max_threads", rbduckdb_init_info_set_max_threads, 1);
+    rb_define_method(cDuckDBTableFunctionInitInfo, "max_threads=", rbduckdb_init_info_set_max_threads, 1);
 }

--- a/test/duckdb_test/table_function/init_info_test.rb
+++ b/test/duckdb_test/table_function/init_info_test.rb
@@ -54,6 +54,28 @@ module DuckDBTest
       assert_equal table_function, result
     end
 
+    def test_init_info_set_max_threads
+      table_function = DuckDB::TableFunction.new
+      table_function.name = 'test_init_max_threads'
+
+      result = table_function.init do |init_info|
+        init_info.set_max_threads(4)
+      end
+
+      assert_equal table_function, result
+    end
+
+    def test_init_info_max_threads_setter
+      table_function = DuckDB::TableFunction.new
+      table_function.name = 'test_init_max_threads_setter'
+
+      result = table_function.init do |init_info|
+        init_info.max_threads = 4
+      end
+
+      assert_equal table_function, result
+    end
+
     def test_init_info_alias
       assert_same DuckDB::TableFunction::InitInfo, DuckDB::InitInfo
     end


### PR DESCRIPTION
GitHub: ref GH-1136

Wrap `duckdb_init_set_max_threads()` C-API to hint DuckDB how many worker threads can execute a custom table function concurrently.
Without this hint, DuckDB treats a table function as single-threaded by default.

ref: https://duckdb.org/docs/stable/clients/c/api.html#duckdb_init_set_max_threads

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Table functions can now specify maximum worker thread counts during initialization.

* **Documentation**
  * Updated changelog documenting the new initialization hint.

* **Tests**
  * Added integration tests for the thread configuration capability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/suketa/ruby-duckdb/pull/1361?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->