### PR TITLE
Remove Ruby 3.2 from CI

### DIFF
--- a/.github/workflows/test_on_macos.yml
+++ b/.github/workflows/test_on_macos.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['3.2.11', '3.3.11', '3.4.9', '4.0.5', 'head']
+        ruby: ['3.3.11', '3.4.9', '4.0.5', 'head']
         duckdb: ['1.4.4', '1.5.3']
     env:
       # Released Bundler is broken on ruby-head due to ruby/ruby#16895.

--- a/.github/workflows/test_on_ubuntu.yml
+++ b/.github/workflows/test_on_ubuntu.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['3.2.11', '3.3.11', '3.4.9', '4.0.5', 'head']
+        ruby: ['3.3.11', '3.4.9', '4.0.5', 'head']
         duckdb: ['1.4.4', '1.5.3']
     env:
       # Released Bundler is broken on ruby-head due to ruby/ruby#16895.

--- a/.github/workflows/test_on_windows.yml
+++ b/.github/workflows/test_on_windows.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['3.2.9', '3.3.10', '3.4.8', '4.0.5', 'ucrt', 'mingw', 'mswin', 'head']
+        ruby: ['3.3.10', '3.4.8', '4.0.5', 'ucrt', 'mingw', 'mswin', 'head']
         duckdb: ['1.4.4', '1.5.3']
     env:
       # Released Bundler is broken on ruby-head due to ruby/ruby#16895.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 # Unreleased
+- remove Ruby 3.2 (EOL) from CI.
 - add `DuckDB::TableFunction::InitInfo#max_threads=` (and `#set_max_threads`) to hint DuckDB how many worker threads can execute a custom table function concurrently.
 
 # 1.5.3.0 - 2026-05-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 # Unreleased
-- remove Ruby 3.2 (EOL) from CI.
+- drop Ruby 3.2.
 - add `DuckDB::TableFunction::InitInfo#max_threads=` (and `#set_max_threads`) to hint DuckDB how many worker threads can execute a custom table function concurrently.
 
 # 1.5.3.0 - 2026-05-24


### PR DESCRIPTION
Ruby 3.2 reached EOL, so remove it from the CI matrix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD testing workflows to adjust Ruby version compatibility across macOS, Ubuntu, and Windows platforms. Testing infrastructure now covers a refined set of Ruby versions to ensure compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/suketa/ruby-duckdb/pull/1363?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->