### PR TITLE
Add per-worker proxy thread primitive

### DIFF
--- a/ext/duckdb/function_executor.c
+++ b/ext/duckdb/function_executor.c
@@ -68,6 +68,14 @@ static struct callback_request *g_request_list = NULL;
 static VALUE g_executor_thread = Qnil;
 static int g_executor_started = 0;
 
+/*
+ * GC-protection array holding every live per-worker proxy Ruby thread.
+ * Proxies are created from non-Ruby init hooks (via the global executor) and
+ * are not reachable from any marked object, so without this array the GC could
+ * collect a proxy thread while DuckDB still dispatches callbacks to it.
+ */
+static VALUE g_proxy_threads = Qnil;
+
 /* Data passed to the executor wait function */
 struct executor_wait_data {
     struct callback_request *request;
@@ -166,6 +174,11 @@ void rbduckdb_function_executor_ensure_started(void) {
     }
 #endif
 
+    if (g_proxy_threads == Qnil) {
+        g_proxy_threads = rb_ary_new();
+        rb_global_variable(&g_proxy_threads);
+    }
+
     g_executor_thread = rb_thread_create(executor_thread_func, NULL);
     rb_global_variable(&g_executor_thread);
     g_executor_started = 1;
@@ -240,6 +253,256 @@ static void *callback_with_gvl(void *data) {
     struct with_gvl_arg *arg = (struct with_gvl_arg *)data;
     arg->cb(arg->user_data);
     return NULL;
+}
+
+/*
+ * ============================================================================
+ * Per-worker proxy thread
+ * ============================================================================
+ *
+ * One dedicated Ruby thread per DuckDB worker thread. Same hand-off protocol as
+ * the global executor (mutex + condvars), but private to a single worker so
+ * that callbacks from different workers no longer serialize through one queue.
+ *
+ * Pattern follows the FFI gem's async callback dispatcher:
+ *   https://github.com/ffi/ffi/blob/master/ext/ffi_c/Function.c
+ */
+struct worker_proxy {
+    VALUE ruby_thread;
+    volatile int stop_requested;
+    rbduckdb_function_callback_t cb;
+    void *user_data;
+    volatile int has_request;
+    volatile int request_done;
+    volatile int thread_exited;
+#ifdef _MSC_VER
+    CRITICAL_SECTION lock;
+    CONDITION_VARIABLE request_cond;
+    CONDITION_VARIABLE request_done_cond;
+    CONDITION_VARIABLE thread_exit_cond;
+#else
+    pthread_mutex_t lock;
+    pthread_cond_t request_cond;
+    pthread_cond_t request_done_cond;
+    pthread_cond_t thread_exit_cond;
+#endif
+};
+
+/* Runs without GVL: the proxy waits for a callback request */
+static void *proxy_wait_func(void *data) {
+    struct worker_proxy *proxy = (struct worker_proxy *)data;
+
+#ifdef _MSC_VER
+    EnterCriticalSection(&proxy->lock);
+    while (!proxy->stop_requested && !proxy->has_request) {
+        SleepConditionVariableCS(&proxy->request_cond, &proxy->lock, INFINITE);
+    }
+    LeaveCriticalSection(&proxy->lock);
+#else
+    pthread_mutex_lock(&proxy->lock);
+    while (!proxy->stop_requested && !proxy->has_request) {
+        pthread_cond_wait(&proxy->request_cond, &proxy->lock);
+    }
+    pthread_mutex_unlock(&proxy->lock);
+#endif
+
+    return NULL;
+}
+
+/* Unblock function for the proxy thread (VM shutdown or Thread#kill) */
+static void proxy_stop_func(void *data) {
+    struct worker_proxy *proxy = (struct worker_proxy *)data;
+
+#ifdef _MSC_VER
+    EnterCriticalSection(&proxy->lock);
+    proxy->stop_requested = 1;
+    WakeConditionVariable(&proxy->request_cond);
+    LeaveCriticalSection(&proxy->lock);
+#else
+    pthread_mutex_lock(&proxy->lock);
+    proxy->stop_requested = 1;
+    pthread_cond_signal(&proxy->request_cond);
+    pthread_mutex_unlock(&proxy->lock);
+#endif
+}
+
+/* The proxy thread main loop. Runs as the body of rb_ensure (see below). */
+static VALUE proxy_loop_body(VALUE data) {
+    struct worker_proxy *proxy = (struct worker_proxy *)data;
+
+    while (!proxy->stop_requested) {
+        /* Release the GVL and wait for a request */
+        rb_thread_call_without_gvl(proxy_wait_func, proxy, proxy_stop_func, proxy);
+
+        if (proxy->stop_requested) break;
+
+        if (proxy->has_request) {
+            /* Execute the callback with the GVL held */
+            proxy->cb(proxy->user_data);
+
+            /* Signal completion to the DuckDB worker thread */
+#ifdef _MSC_VER
+            EnterCriticalSection(&proxy->lock);
+            proxy->has_request = 0;
+            proxy->request_done = 1;
+            WakeConditionVariable(&proxy->request_done_cond);
+            LeaveCriticalSection(&proxy->lock);
+#else
+            pthread_mutex_lock(&proxy->lock);
+            proxy->has_request = 0;
+            proxy->request_done = 1;
+            pthread_cond_signal(&proxy->request_done_cond);
+            pthread_mutex_unlock(&proxy->lock);
+#endif
+        }
+    }
+
+    return Qnil;
+}
+
+/*
+ * Teardown for the proxy thread. Run via rb_ensure so it executes even if an
+ * async exception (Thread#kill, VM shutdown via rb_thread_terminate_all)
+ * unwinds proxy_loop_body. If it were skipped, thread_exited would stay 0
+ * forever and rbduckdb_worker_proxy_destroy's join would deadlock.
+ */
+static VALUE proxy_cleanup(VALUE data) {
+    struct worker_proxy *proxy = (struct worker_proxy *)data;
+
+    /* Stop being GC-protected now that we are about to exit */
+    if (g_proxy_threads != Qnil) {
+        rb_ary_delete(g_proxy_threads, proxy->ruby_thread);
+    }
+
+    /*
+     * Signal that this thread has finished and no longer touches the proxy
+     * struct. Only after this may rbduckdb_worker_proxy_destroy free it.
+     */
+#ifdef _MSC_VER
+    EnterCriticalSection(&proxy->lock);
+    proxy->thread_exited = 1;
+    WakeConditionVariable(&proxy->thread_exit_cond);
+    LeaveCriticalSection(&proxy->lock);
+#else
+    pthread_mutex_lock(&proxy->lock);
+    proxy->thread_exited = 1;
+    pthread_cond_signal(&proxy->thread_exit_cond);
+    pthread_mutex_unlock(&proxy->lock);
+#endif
+
+    return Qnil;
+}
+
+/* The proxy thread entry point (Ruby thread). */
+static VALUE proxy_thread_func(void *data) {
+    return rb_ensure(proxy_loop_body, (VALUE)data, proxy_cleanup, (VALUE)data);
+}
+
+struct worker_proxy *rbduckdb_worker_proxy_create(void) {
+    /*
+     * Use calloc (not xcalloc): rbduckdb_worker_proxy_destroy frees the struct
+     * from a non-Ruby thread where xfree is unsafe.
+     */
+    struct worker_proxy *proxy = calloc(1, sizeof(struct worker_proxy));
+    if (proxy == NULL) {
+        rb_raise(rb_eNoMemError, "failed to allocate worker_proxy");
+    }
+
+    proxy->stop_requested = 0;
+    proxy->has_request = 0;
+    proxy->request_done = 0;
+    proxy->thread_exited = 0;
+
+#ifdef _MSC_VER
+    InitializeCriticalSection(&proxy->lock);
+    InitializeConditionVariable(&proxy->request_cond);
+    InitializeConditionVariable(&proxy->request_done_cond);
+    InitializeConditionVariable(&proxy->thread_exit_cond);
+#else
+    pthread_mutex_init(&proxy->lock, NULL);
+    pthread_cond_init(&proxy->request_cond, NULL);
+    pthread_cond_init(&proxy->request_done_cond, NULL);
+    pthread_cond_init(&proxy->thread_exit_cond, NULL);
+#endif
+
+    /*
+     * Lazy-init the GC-protection array so create never silently skips it (see
+     * the g_proxy_threads comment above); create runs with the GVL, so safe.
+     */
+    if (g_proxy_threads == Qnil) {
+        g_proxy_threads = rb_ary_new();
+        rb_global_variable(&g_proxy_threads);
+    }
+
+    proxy->ruby_thread = rb_thread_create(proxy_thread_func, proxy);
+    rb_ary_push(g_proxy_threads, proxy->ruby_thread);
+
+    return proxy;
+}
+
+/* Blocks until the proxy thread has fully exited. Runs without the GVL. */
+static void *proxy_join_func(void *data) {
+    struct worker_proxy *proxy = (struct worker_proxy *)data;
+
+#ifdef _MSC_VER
+    EnterCriticalSection(&proxy->lock);
+    while (!proxy->thread_exited) {
+        SleepConditionVariableCS(&proxy->thread_exit_cond, &proxy->lock, INFINITE);
+    }
+    LeaveCriticalSection(&proxy->lock);
+#else
+    pthread_mutex_lock(&proxy->lock);
+    while (!proxy->thread_exited) {
+        pthread_cond_wait(&proxy->thread_exit_cond, &proxy->lock);
+    }
+    pthread_mutex_unlock(&proxy->lock);
+#endif
+
+    return NULL;
+}
+
+void rbduckdb_worker_proxy_destroy(void *data) {
+    struct worker_proxy *proxy = (struct worker_proxy *)data;
+    if (proxy == NULL) return;
+
+    /* Ask the proxy thread to stop. */
+#ifdef _MSC_VER
+    EnterCriticalSection(&proxy->lock);
+    proxy->stop_requested = 1;
+    WakeConditionVariable(&proxy->request_cond);
+    LeaveCriticalSection(&proxy->lock);
+#else
+    pthread_mutex_lock(&proxy->lock);
+    proxy->stop_requested = 1;
+    pthread_cond_signal(&proxy->request_cond);
+    pthread_mutex_unlock(&proxy->lock);
+#endif
+
+    /*
+     * Wait until the proxy thread has fully exited. Before exiting it runs Ruby
+     * code (removing itself from the GC-protection array), which needs the GVL.
+     * DuckDB may invoke this destructor either from a worker thread (no GVL) or
+     * — depending on when it tears down the local state — from a Ruby thread
+     * that holds the GVL. In the latter case we must release the GVL while
+     * waiting, or the proxy thread could never acquire it and we would deadlock.
+     */
+    if (ruby_native_thread_p() && ruby_thread_has_gvl_p()) {
+        rb_thread_call_without_gvl(proxy_join_func, proxy, NULL, NULL);
+    } else {
+        proxy_join_func(proxy);
+    }
+
+    /* The proxy thread is gone; tear down OS primitives and free the struct. */
+#ifdef _MSC_VER
+    DeleteCriticalSection(&proxy->lock);
+#else
+    pthread_cond_destroy(&proxy->thread_exit_cond);
+    pthread_cond_destroy(&proxy->request_done_cond);
+    pthread_cond_destroy(&proxy->request_cond);
+    pthread_mutex_destroy(&proxy->lock);
+#endif
+
+    free(proxy);
 }
 
 void rbduckdb_function_executor_dispatch(rbduckdb_function_callback_t cb, void *user_data) {

--- a/ext/duckdb/function_executor.h
+++ b/ext/duckdb/function_executor.h
@@ -43,4 +43,36 @@ void rbduckdb_function_executor_ensure_started(void);
  */
 void rbduckdb_function_executor_dispatch(rbduckdb_function_callback_t cb, void *user_data);
 
+/*
+ * ============================================================================
+ * Per-worker proxy threads (DuckDB >= 1.5.0)
+ * ============================================================================
+ *
+ * The global executor above serializes every non-Ruby-thread callback through
+ * a single Ruby thread. A per-worker proxy instead gives each DuckDB worker
+ * thread its own dedicated Ruby thread, so callbacks from different workers can
+ * run concurrently — they compete for the GVL in round-robin fashion, which
+ * helps when callbacks release the GVL (e.g. on I/O).
+ *
+ * Proxies are created lazily from DuckDB's per-worker init hook and stored in
+ * DuckDB's thread-local state; the global executor remains the fallback.
+ */
+
+/* Opaque per-worker proxy handle. */
+struct worker_proxy;
+
+/*
+ * Create a per-worker proxy thread. Must be called with the GVL held
+ * (typically by dispatching this through the global executor from a per-worker
+ * init callback, which itself runs on a non-Ruby thread).
+ */
+struct worker_proxy *rbduckdb_worker_proxy_create(void);
+
+/*
+ * Destroy a per-worker proxy. The signature matches duckdb_delete_callback_t so
+ * it can be handed directly to DuckDB. Safe to call from a non-Ruby thread: it
+ * touches only OS primitives and frees memory allocated with calloc.
+ */
+void rbduckdb_worker_proxy_destroy(void *proxy);
+
 #endif


### PR DESCRIPTION
I did my best to minimize the diff, but it grew larger than I intended.
Apologies for the size of this change.

GitHub: GH-1136

This PR adds only the lifecycle primitive that a `worker_proxy` you can create
and destroy. There is no consumer yet, so it is behavior-preserving dead code
until the dispatch wiring and the scalar/table integrations is merged on top.

For the overall picture I have in mind — the full mechanism with every step
integrated — Please see https://github.com/otegami/ruby-duckdb/pull/7 on my fork.

### What it adds

- `struct worker_proxy` plus `rbduckdb_worker_proxy_create` / `_destroy`.
  `destroy`'s signature matches `duckdb_delete_callback_t` so DuckDB can call it
  directly later.
- The proxy thread loop and a GC-protection array, so proxy threads spawned from
  non-Ruby init hooks aren't collected mid-flight.

### For reviewer's information

- `destroy` releases the GVL while joining only when the caller holds it,
  because the proxy must run Ruby code (leaving the GC array) before it exits.
- The proxy loop runs under `rb_ensure`, so teardown still signals completion if
  an async exception (`Thread#kill`, VM shutdown) unwinds it — otherwise the
  join deadlocks.
- `calloc`/`free`, not `xcalloc`/`xfree`, since `destroy` may run off a non-Ruby
  thread.gi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Enhanced callback handling for user-defined functions, improving throughput and scalability when running concurrent DuckDB operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->