### PR TITLE
feat: per-worker proxy for scalar function execute callback

### DIFF
--- a/ext/duckdb/scalar_function.c
+++ b/ext/duckdb/scalar_function.c
@@ -17,6 +17,14 @@ static VALUE rbduckdb_scalar_function_set_function(VALUE self);
 static VALUE rbduckdb_scalar_function__set_bind(VALUE self);
 static void scalar_function_callback(duckdb_function_info info, duckdb_data_chunk input, duckdb_vector output);
 static void scalar_function_bind_callback(duckdb_bind_info info);
+#ifdef HAVE_DUCKDB_H_GE_V1_5_0
+/*
+ * Thread detection functions (available since Ruby 2.3).
+ * Used to skip the proxy on Ruby threads.
+ */
+extern int ruby_native_thread_p(void);
+static void scalar_function_init_callback(duckdb_init_info info);
+#endif
 
 
 struct callback_arg {
@@ -191,6 +199,7 @@ static void scalar_function_callback(duckdb_function_info info, duckdb_data_chun
     rubyDuckDBScalarFunction *ctx;
     idx_t i;
     struct callback_arg arg;
+    struct worker_proxy *proxy = NULL;
 
     ctx = (rubyDuckDBScalarFunction *)duckdb_scalar_function_get_extra_info(info);
 
@@ -218,7 +227,11 @@ static void scalar_function_callback(duckdb_function_info info, duckdb_data_chun
     arg.row_count = duckdb_data_chunk_get_size(input);
     arg.col_count = duckdb_data_chunk_get_column_count(input);
 
-    rbduckdb_function_executor_dispatch(execute_callback_protected, &arg);
+#ifdef HAVE_DUCKDB_H_GE_V1_5_0
+    /* On DuckDB >= 1.5.0 each worker thread carries its own proxy (see init). */
+    proxy = (struct worker_proxy *)duckdb_scalar_function_get_state(info);
+#endif
+    rbduckdb_function_executor_dispatch_via_proxy(execute_callback_protected, &arg, proxy);
 }
 
 static VALUE process_no_param_rows(VALUE varg) {
@@ -294,6 +307,58 @@ static VALUE cleanup_callback(VALUE varg) {
     return Qnil;
 }
 
+#ifdef HAVE_DUCKDB_H_GE_V1_5_0
+/*
+ * Per-worker init for the execute path (DuckDB >= 1.5.0).
+ *
+ * DuckDB calls this once on each worker thread that will run the execute
+ * callback. We create a per-worker proxy (allocating its Ruby thread under the
+ * GVL via the global executor, since this runs on a non-Ruby thread) and store
+ * it as per-worker state. The execute callback then dispatches through it
+ * instead of the shared global executor, so workers run callbacks concurrently.
+ * DuckDB invokes rbduckdb_worker_proxy_destroy when the state is freed.
+ */
+struct create_proxy_callback_arg {
+    struct worker_proxy *proxy;
+};
+
+static VALUE create_proxy_callback(VALUE varg) {
+    struct create_proxy_callback_arg *arg = (struct create_proxy_callback_arg *)varg;
+    arg->proxy = rbduckdb_worker_proxy_create();
+    return Qnil;
+}
+
+/*
+ * rbduckdb_worker_proxy_create may raise (NoMemError, Thread.new failure),
+ * and the executor runs callbacks unprotected — a raise would longjmp past
+ * its done-signaling and block the waiting DuckDB worker forever. Swallow
+ * the exception instead: the proxy stays NULL, init sets no state, and the
+ * execute callback falls back to the global executor.
+ */
+static void create_proxy_callback_protected(void *user_data) {
+    int exception_state;
+
+    rb_protect(create_proxy_callback, (VALUE)user_data, &exception_state);
+    if (exception_state) {
+        rb_set_errinfo(Qnil);
+    }
+}
+
+static void scalar_function_init_callback(duckdb_init_info info) {
+    struct create_proxy_callback_arg arg;
+
+    /* A Ruby calling thread runs the callback inline (Case 1/2); no proxy needed. */
+    if (ruby_native_thread_p()) return;
+
+    arg.proxy = NULL;
+    rbduckdb_function_executor_dispatch(create_proxy_callback_protected, &arg);
+
+    if (arg.proxy != NULL) {
+        duckdb_scalar_function_init_set_state(info, arg.proxy, rbduckdb_worker_proxy_destroy);
+    }
+}
+#endif
+
 rubyDuckDBScalarFunction *get_struct_scalar_function(VALUE obj) {
     rubyDuckDBScalarFunction *ctx;
     TypedData_Get_Struct(obj, rubyDuckDBScalarFunction, &scalar_function_data_type, ctx);
@@ -314,6 +379,10 @@ static VALUE rbduckdb_scalar_function_set_function(VALUE self) {
 
     duckdb_scalar_function_set_extra_info(p->scalar_function, p, NULL);
     duckdb_scalar_function_set_function(p->scalar_function, scalar_function_callback);
+#ifdef HAVE_DUCKDB_H_GE_V1_5_0
+    /* Per-worker proxy threads for the execute path (DuckDB >= 1.5.0). */
+    duckdb_scalar_function_set_init(p->scalar_function, scalar_function_init_callback);
+#endif
 
     /*
      * Mark as volatile to prevent constant folding during query optimization.

--- a/sample/issue1136.rb
+++ b/sample/issue1136.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+# GH-1136: per-worker proxy threads for scalar UDF callbacks (DuckDB >= 1.5.0).
+#
+# Each DuckDB worker thread gets its own dedicated Ruby proxy thread, so UDF
+# callbacks from different workers run concurrently instead of serializing on
+# the single global executor. Two observables demonstrate it:
+#   - callbacks run on multiple distinct Ruby threads (one proxy per worker;
+#     with the global executor the count can never exceed two)
+#   - wall-clock improves for a GVL-releasing (I/O-bound) callback
+#
+# Note: pure-CPU Ruby callbacks stay effectively serialized by the GVL; the
+# throughput win is specific to callbacks that release it (e.g. on I/O,
+# simulated here with sleep). A large base table is used so the morsel-driven
+# scan actually distributes work across workers.
+require 'duckdb'
+
+ROWS = 500_000
+SLEEP_EVERY = 1_000 # simulate I/O on every Nth value
+SLEEP_SEC = 0.002
+
+def register_slow_triple(con, threads_seen)
+  sf = DuckDB::ScalarFunction.new
+  sf.name = 'slow_triple'
+  sf.add_parameter(DuckDB::LogicalType::INTEGER)
+  sf.return_type = DuckDB::LogicalType::BIGINT
+  sf.set_function do |v|
+    threads_seen[Thread.current] = true
+    sleep(SLEEP_SEC) if (v % SLEEP_EVERY).zero?
+    v * 3
+  end
+  con.register_scalar_function(sf)
+end
+
+def timed_sum(con)
+  started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+  sum = con.execute('SELECT SUM(slow_triple(value)) FROM t').first.first
+  [Process.clock_gettime(Process::CLOCK_MONOTONIC) - started, sum]
+end
+
+def measure(threads)
+  db = DuckDB::Database.open
+  con = db.connect
+  con.execute("SET threads=#{threads}")
+  con.execute("CREATE TABLE t AS SELECT range::INTEGER AS value FROM range(#{ROWS})")
+  threads_seen = {}
+  register_slow_triple(con, threads_seen)
+  elapsed, sum = timed_sum(con)
+  con.close
+  db.close
+  [elapsed, threads_seen.size, sum]
+end
+
+expected = (ROWS - 1) * ROWS / 2 * 3
+[1, 4].each do |threads|
+  elapsed, distinct, sum = measure(threads)
+  raise "wrong result: #{sum} (expected #{expected})" unless sum == expected
+
+  puts "SET threads=#{threads}: #{elapsed.round(3)}s, callbacks ran on #{distinct} distinct Ruby thread(s)"
+end

--- a/test/duckdb_test/scalar_function_test.rb
+++ b/test/duckdb_test/scalar_function_test.rb
@@ -697,6 +697,47 @@ module DuckDBTest
       assert_equal 149_985_000, result.first.first
     end
 
+    # Per-worker proxy: exercises the init -> proxy -> destroy lifecycle under
+    # real multi-threaded execution (SET threads=4) and asserts the proxy path
+    # actually fired: callbacks must run on more than two distinct Ruby
+    # threads. Without per-worker proxies that count can never exceed two (the
+    # calling thread plus the single global executor), so this fails on the
+    # old implementation. A large base table is used so the morsel-driven scan
+    # actually spreads execution over worker threads (a small range() stays
+    # single pipeline and never fires the proxy). Simultaneity assertions
+    # (max concurrency) are avoided as scheduler-dependent; throughput is
+    # demonstrated by sample/issue1136.rb instead. Requires DuckDB >= 1.5.0
+    # (duckdb_scalar_function_set_init).
+    def test_scalar_function_runs_on_per_worker_proxy_threads
+      if ::DuckDBTest.duckdb_library_version < Gem::Version.new('1.5.0')
+        skip 'per-worker proxy requires DuckDB >= 1.5.0'
+      end
+
+      rows = 500_000
+      @con.execute('SET threads=4')
+      @con.execute("CREATE TABLE large_parallel AS SELECT range::INTEGER AS value FROM range(#{rows})")
+
+      threads_seen = {}
+      sf = DuckDB::ScalarFunction.new
+      sf.name = 'triple'
+      sf.add_parameter(DuckDB::LogicalType::INTEGER)
+      sf.return_type = DuckDB::LogicalType::BIGINT
+      sf.set_function do |v|
+        threads_seen[Thread.current] = true
+        v * 3
+      end
+
+      @con.register_scalar_function(sf)
+      result = @con.execute('SELECT SUM(triple(value)) FROM large_parallel')
+
+      # SUM(0..rows-1) * 3
+      expected = (rows - 1) * rows / 2 * 3
+
+      assert_equal expected, result.first.first
+      assert_operator threads_seen.size, :>, 2,
+                      'expected callbacks on per-worker proxy threads, not just caller + global executor'
+    end
+
     def test_scalar_function_with_symbol_return_type_and_params
       @con.execute('CREATE TABLE large_test AS SELECT range::INTEGER AS value FROM range(10000)')
 


### PR DESCRIPTION
GitHub: GH-1136

Step 3 of the per-worker proxy work and the first consumer of the proxy: on
DuckDB >= 1.5.0, scalar execute callbacks now run on one proxy thread per
DuckDB worker instead of all funneling through the single global executor.
The table function integration follows in the last PR.

Full picture: <https://github.com/otegami/ruby-duckdb/pull/7>

## Why

With one global executor, callbacks from different workers can never overlap —
even when they release the GVL (e.g. on I/O). Per-worker proxies lift exactly
that ceiling. Measured with `sample/issue1136.rb` (GVL-releasing callback over
a 500k-row scan):

|        | SET threads=1             | SET threads=4              |
|--------|---------------------------|----------------------------|
| before | 1.379s, 1 callback thread | 0.976s, 2 callback threads |
| after  | 1.374s, 1 callback thread | 0.365s, 4 callback threads |

The before run caps at 2 threads (calling thread + global executor) no matter
how many workers DuckDB spawns. Pure-CPU callbacks stay bounded by the GVL,
so the win is specific to GVL-releasing UDFs.

Notes for review:

- DuckDB 1.4.x LTS is untouched: `duckdb_scalar_function_set_init` is a
  1.5.0 API, so everything is behind `HAVE_DUCKDB_H_GE_V1_5_0`.
- The test asserts callbacks ran on more than two distinct Ruby threads.
  The old path structurally caps at two (calling thread + global executor),
  so the test fails without this change. Timing/simultaneity assertions were
  deliberately avoided as scheduler-dependent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Scalar user-defined functions now support per-worker execution in DuckDB 1.5.0+, enabling improved performance and thread safety for parallel query execution.

* **Tests**
  * Added test case validating multi-threaded scalar function behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->