### PR TITLE
fix: -Wshorten-64-to-32 warning in scalar function callback

### DIFF
--- a/ext/duckdb/scalar_function.c
+++ b/ext/duckdb/scalar_function.c
@@ -272,7 +272,7 @@ static VALUE process_rows(VALUE varg) {
         }
 
         /* Call the Ruby block with the arguments */
-        result = rb_funcallv(arg->ctx->function_proc, rb_intern("call"), arg->col_count, arg->args);
+        result = rb_funcallv(arg->ctx->function_proc, rb_intern("call"), (int)arg->col_count, arg->args);
 
         /* Write result to output using helper function */
         rbduckdb_vector_set_value_at(arg->output, arg->output_type, i, result);


### PR DESCRIPTION
One-line cast fixing the only compiler warning in the build.

## Reproduction

```console
$ touch ext/duckdb/scalar_function.c && rake compile
cd tmp/arm64-darwin23/duckdb_native/4.0.5
/usr/bin/make
compiling ../../../../ext/duckdb/scalar_function.c
../../../../ext/duckdb/scalar_function.c:275:79: warning: implicit
      conversion loses integer precision: 'idx_t' (aka 'unsigned long long') to 'int'
      [-Wshorten-64-to-32]
  275 |         result = rb_funcallv(arg->ctx->function_proc, rb_intern("call"), arg->col_count, arg->...
      |                  ~~~~~~~~~~~                                             ~~~~~^~~~~~~~~
1 warning generated.
```

After the fix the same command compiles silently.

## Why

`rb_funcallv`'s argc parameter is `int`, but `col_count` is DuckDB's `idx_t`
(`unsigned long long`). The warning flag is not project-local: it comes from
Ruby's own `warnflags` (`RbConfig::CONFIG['warnflags']` includes
`-Wshorten-64-to-32`), which mkmf applies to every extension build. It is a
clang flag, so it fires on every macOS build but never on Linux/gcc CI —
macOS contributors see it on each compile.

The fix mirrors the cast the codebase already uses for the same value in
`aggregate_function.c` (`one.argc = (int)(arg->col_count + 1)`), so
`scalar_function.c` was the one call site missing it. Behavior is unchanged:
`col_count` is the UDF's declared parameter count, which can never approach
`INT_MAX`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed argument handling in function calls to ensure proper type conversion and maintain compatibility with underlying systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->