### PR TITLE
feat: add DuckDB::TableFunction::InitInfo#column_count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 # Unreleased
 - drop Ruby 3.2.
 - add `DuckDB::TableFunction::InitInfo#max_threads=` (and `#set_max_threads`) to hint DuckDB how many worker threads can execute a custom table function concurrently.
+- add `DuckDB::TableFunction::InitInfo#column_count` to get the number of projected result columns of a custom table function scan.
 
 # 1.5.3.0 - 2026-05-24
 - bump up DuckDB 1.5.3 on CI.

--- a/ext/duckdb/table_function_init_info.c
+++ b/ext/duckdb/table_function_init_info.c
@@ -7,6 +7,7 @@ static VALUE allocate(VALUE klass);
 static size_t memsize(const void *p);
 static VALUE rbduckdb_init_info_set_error(VALUE self, VALUE error);
 static VALUE rbduckdb_init_info_set_max_threads(VALUE self, VALUE max_threads);
+static VALUE table_function_init_info_column_count(VALUE self);
 
 static const rb_data_type_t init_info_data_type = {
     "DuckDB/TableFunctionInitInfo",
@@ -76,6 +77,24 @@ static VALUE rbduckdb_init_info_set_max_threads(VALUE self, VALUE max_threads) {
     return self;
 }
 
+/*
+ * call-seq:
+ *   init_info.column_count -> Integer
+ *
+ * Returns the number of projected result columns for this scan.
+ * Without projection pushdown this equals the number of result columns
+ * added in the bind callback.
+ *
+ *   init_info.column_count # => 2
+ */
+static VALUE table_function_init_info_column_count(VALUE self) {
+    rubyDuckDBInitInfo *ctx;
+
+    TypedData_Get_Struct(self, rubyDuckDBInitInfo, &init_info_data_type, ctx);
+
+    return ULL2NUM(duckdb_init_get_column_count(ctx->info));
+}
+
 void rbduckdb_init_duckdb_table_function_init_info(void) {
 #if 0
     VALUE mDuckDB = rb_define_module("DuckDB");
@@ -86,4 +105,5 @@ void rbduckdb_init_duckdb_table_function_init_info(void) {
     rb_define_method(cDuckDBTableFunctionInitInfo, "set_error", rbduckdb_init_info_set_error, 1);
     rb_define_method(cDuckDBTableFunctionInitInfo, "set_max_threads", rbduckdb_init_info_set_max_threads, 1);
     rb_define_method(cDuckDBTableFunctionInitInfo, "max_threads=", rbduckdb_init_info_set_max_threads, 1);
+    rb_define_method(cDuckDBTableFunctionInitInfo, "column_count", table_function_init_info_column_count, 0);
 }

--- a/test/duckdb_test/table_function/init_info_test.rb
+++ b/test/duckdb_test/table_function/init_info_test.rb
@@ -76,6 +76,38 @@ module DuckDBTest
       assert_equal table_function, result
     end
 
+    def test_init_info_column_count
+      table_function = DuckDB::TableFunction.new
+      table_function.name = 'test_init_column_count'
+
+      table_function.bind do |bind_info|
+        bind_info.add_result_column('id', DuckDB::LogicalType::BIGINT)
+        bind_info.add_result_column('value', DuckDB::LogicalType::BIGINT)
+      end
+
+      observed_column_count = nil
+      table_function.init do |init_info|
+        observed_column_count = init_info.column_count
+      end
+
+      done = false
+      table_function.execute do |_func_info, output|
+        if done
+          output.size = 0
+        else
+          output.set_value(0, 0, 1)
+          output.set_value(1, 0, 10)
+          output.size = 1
+          done = true
+        end
+      end
+
+      @connection.register_table_function(table_function)
+      @connection.query('SELECT * FROM test_init_column_count()').each.to_a
+
+      assert_equal 2, observed_column_count
+    end
+
     def test_init_info_alias
       assert_same DuckDB::TableFunction::InitInfo, DuckDB::InitInfo
     end


### PR DESCRIPTION
Wrap duckdb_init_get_column_count() C-API to expose how many result columns the scan projects.
ref: https://duckdb.org/docs/stable/clients/c/api.html#duckdb_init_get_column_count

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `column_count` method to table function initialization, providing access to the number of projected result columns during custom table function scans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->