### PR TITLE
Fix HACKING.md naming violations in scalar_function* files

### DIFF
--- a/ext/duckdb/connection.c
+++ b/ext/duckdb/connection.c
@@ -231,7 +231,7 @@ static VALUE connection__register_scalar_function(VALUE self, VALUE scalar_funct
     duckdb_state state;
 
     ctxcon = rbduckdb_get_struct_connection(self);
-    ctxsf = get_struct_scalar_function(scalar_function);
+    ctxsf = rbduckdb_get_struct_scalar_function(scalar_function);
 
     state = duckdb_register_scalar_function(ctxcon->con, ctxsf->scalar_function);
 
@@ -252,7 +252,7 @@ static VALUE connection__register_scalar_function_set(VALUE self, VALUE scalar_f
     duckdb_state state;
 
     ctxcon = rbduckdb_get_struct_connection(self);
-    ctxsfs = get_struct_scalar_function_set(scalar_function_set);
+    ctxsfs = rbduckdb_get_struct_scalar_function_set(scalar_function_set);
 
     state = duckdb_register_scalar_function_set(ctxcon->con, ctxsfs->scalar_function_set);
 

--- a/ext/duckdb/duckdb.c
+++ b/ext/duckdb/duckdb.c
@@ -56,13 +56,13 @@ Init_duckdb_native(void) {
     rbduckdb_init_extracted_statements();
     rbduckdb_init_instance_cache();
     rbduckdb_init_value();
-    rbduckdb_init_duckdb_scalar_function();
-    rbduckdb_init_duckdb_scalar_function_set();
+    rbduckdb_init_scalar_function();
+    rbduckdb_init_scalar_function_set();
     rbduckdb_init_aggregate_function();
     rbduckdb_init_aggregate_function_set();
     rbduckdb_init_expression();
     rbduckdb_init_client_context();
-    rbduckdb_init_duckdb_scalar_function_bind_info();
+    rbduckdb_init_scalar_function_bind_info();
     rbduckdb_init_vector();
     rbduckdb_init_data_chunk();
     rbduckdb_init_memory_helper();

--- a/ext/duckdb/scalar_function.c
+++ b/ext/duckdb/scalar_function.c
@@ -7,14 +7,14 @@ static void deallocate(void *);
 static VALUE allocate(VALUE klass);
 static size_t memsize(const void *p);
 static void compact(void *);
-static VALUE duckdb_scalar_function_initialize(VALUE self);
-static VALUE rbduckdb_scalar_function_set_name(VALUE self, VALUE name);
-static VALUE rbduckdb_scalar_function__set_return_type(VALUE self, VALUE logical_type);
-static VALUE rbduckdb_scalar_function__set_varargs(VALUE self, VALUE logical_type);
-static VALUE rbduckdb_scalar_function_add_parameter(VALUE self, VALUE logical_type);
-static VALUE rbduckdb_scalar_function__set_special_handling(VALUE self);
-static VALUE rbduckdb_scalar_function_set_function(VALUE self);
-static VALUE rbduckdb_scalar_function__set_bind(VALUE self);
+static VALUE scalar_function_initialize(VALUE self);
+static VALUE scalar_function_set_name(VALUE self, VALUE name);
+static VALUE scalar_function__set_return_type(VALUE self, VALUE logical_type);
+static VALUE scalar_function__set_varargs(VALUE self, VALUE logical_type);
+static VALUE scalar_function__add_parameter(VALUE self, VALUE logical_type);
+static VALUE scalar_function__set_special_handling(VALUE self);
+static VALUE scalar_function_set_function(VALUE self);
+static VALUE scalar_function__set_bind(VALUE self);
 static void scalar_function_callback(duckdb_function_info info, duckdb_data_chunk input, duckdb_vector output);
 static void scalar_function_bind_callback(duckdb_bind_info info);
 #ifdef HAVE_DUCKDB_H_GE_V1_5_0
@@ -123,7 +123,7 @@ static size_t memsize(const void *p) {
     return sizeof(rubyDuckDBScalarFunction);
 }
 
-static VALUE duckdb_scalar_function_initialize(VALUE self) {
+static VALUE scalar_function_initialize(VALUE self) {
     rubyDuckDBScalarFunction *p;
     TypedData_Get_Struct(self, rubyDuckDBScalarFunction, &scalar_function_data_type, p);
     p->scalar_function = duckdb_create_scalar_function();
@@ -132,7 +132,7 @@ static VALUE duckdb_scalar_function_initialize(VALUE self) {
     return self;
 }
 
-static VALUE rbduckdb_scalar_function_set_name(VALUE self, VALUE name) {
+static VALUE scalar_function_set_name(VALUE self, VALUE name) {
     rubyDuckDBScalarFunction *p;
     TypedData_Get_Struct(self, rubyDuckDBScalarFunction, &scalar_function_data_type, p);
 
@@ -142,7 +142,7 @@ static VALUE rbduckdb_scalar_function_set_name(VALUE self, VALUE name) {
     return self;
 }
 
-static VALUE rbduckdb_scalar_function__set_return_type(VALUE self, VALUE logical_type) {
+static VALUE scalar_function__set_return_type(VALUE self, VALUE logical_type) {
     rubyDuckDBScalarFunction *p;
     rubyDuckDBLogicalType *lt;
 
@@ -154,7 +154,7 @@ static VALUE rbduckdb_scalar_function__set_return_type(VALUE self, VALUE logical
     return self;
 }
 
-static VALUE rbduckdb_scalar_function__set_varargs(VALUE self, VALUE logical_type) {
+static VALUE scalar_function__set_varargs(VALUE self, VALUE logical_type) {
     rubyDuckDBScalarFunction *p;
     rubyDuckDBLogicalType *lt;
 
@@ -166,7 +166,7 @@ static VALUE rbduckdb_scalar_function__set_varargs(VALUE self, VALUE logical_typ
     return self;
 }
 
-static VALUE rbduckdb_scalar_function__set_special_handling(VALUE self) {
+static VALUE scalar_function__set_special_handling(VALUE self) {
     rubyDuckDBScalarFunction *p;
 
     TypedData_Get_Struct(self, rubyDuckDBScalarFunction, &scalar_function_data_type, p);
@@ -175,7 +175,7 @@ static VALUE rbduckdb_scalar_function__set_special_handling(VALUE self) {
     return self;
 }
 
-static VALUE rbduckdb_scalar_function_add_parameter(VALUE self, VALUE logical_type) {
+static VALUE scalar_function__add_parameter(VALUE self, VALUE logical_type) {
     rubyDuckDBScalarFunction *p;
     rubyDuckDBLogicalType *lt;
 
@@ -359,14 +359,14 @@ static void scalar_function_init_callback(duckdb_init_info info) {
 }
 #endif
 
-rubyDuckDBScalarFunction *get_struct_scalar_function(VALUE obj) {
+rubyDuckDBScalarFunction *rbduckdb_get_struct_scalar_function(VALUE obj) {
     rubyDuckDBScalarFunction *ctx;
     TypedData_Get_Struct(obj, rubyDuckDBScalarFunction, &scalar_function_data_type, ctx);
     return ctx;
 }
 
 /* :nodoc: */
-static VALUE rbduckdb_scalar_function_set_function(VALUE self) {
+static VALUE scalar_function_set_function(VALUE self) {
     rubyDuckDBScalarFunction *p;
 
     if (!rb_block_given_p()) {
@@ -397,7 +397,7 @@ static VALUE rbduckdb_scalar_function_set_function(VALUE self) {
 }
 
 /* :nodoc: */
-static VALUE rbduckdb_scalar_function__set_bind(VALUE self) {
+static VALUE scalar_function__set_bind(VALUE self) {
     rubyDuckDBScalarFunction *p;
 
     TypedData_Get_Struct(self, rubyDuckDBScalarFunction, &scalar_function_data_type, p);
@@ -475,19 +475,19 @@ static void scalar_function_bind_callback(duckdb_bind_info info) {
 }
 
 
-void rbduckdb_init_duckdb_scalar_function(void) {
+void rbduckdb_init_scalar_function(void) {
 #if 0
     VALUE mDuckDB = rb_define_module("DuckDB");
 #endif
     cDuckDBScalarFunction = rb_define_class_under(mDuckDB, "ScalarFunction", rb_cObject);
     rb_define_alloc_func(cDuckDBScalarFunction, allocate);
-    rb_define_method(cDuckDBScalarFunction, "initialize", duckdb_scalar_function_initialize, 0);
-    rb_define_method(cDuckDBScalarFunction, "set_name", rbduckdb_scalar_function_set_name, 1);
-    rb_define_method(cDuckDBScalarFunction, "name=", rbduckdb_scalar_function_set_name, 1);
-    rb_define_private_method(cDuckDBScalarFunction, "_set_return_type", rbduckdb_scalar_function__set_return_type, 1);
-    rb_define_private_method(cDuckDBScalarFunction, "_set_varargs", rbduckdb_scalar_function__set_varargs, 1);
-    rb_define_private_method(cDuckDBScalarFunction, "_set_special_handling", rbduckdb_scalar_function__set_special_handling, 0);
-    rb_define_private_method(cDuckDBScalarFunction, "_add_parameter", rbduckdb_scalar_function_add_parameter, 1);
-    rb_define_method(cDuckDBScalarFunction, "set_function", rbduckdb_scalar_function_set_function, 0);
-    rb_define_private_method(cDuckDBScalarFunction, "_set_bind", rbduckdb_scalar_function__set_bind, 0);
+    rb_define_method(cDuckDBScalarFunction, "initialize", scalar_function_initialize, 0);
+    rb_define_method(cDuckDBScalarFunction, "set_name", scalar_function_set_name, 1);
+    rb_define_method(cDuckDBScalarFunction, "name=", scalar_function_set_name, 1);
+    rb_define_private_method(cDuckDBScalarFunction, "_set_return_type", scalar_function__set_return_type, 1);
+    rb_define_private_method(cDuckDBScalarFunction, "_set_varargs", scalar_function__set_varargs, 1);
+    rb_define_private_method(cDuckDBScalarFunction, "_set_special_handling", scalar_function__set_special_handling, 0);
+    rb_define_private_method(cDuckDBScalarFunction, "_add_parameter", scalar_function__add_parameter, 1);
+    rb_define_method(cDuckDBScalarFunction, "set_function", scalar_function_set_function, 0);
+    rb_define_private_method(cDuckDBScalarFunction, "_set_bind", scalar_function__set_bind, 0);
 }

--- a/ext/duckdb/scalar_function.h
+++ b/ext/duckdb/scalar_function.h
@@ -9,9 +9,7 @@ struct _rubyDuckDBScalarFunction {
 
 typedef struct _rubyDuckDBScalarFunction rubyDuckDBScalarFunction;
 
-void rbduckdb_init_duckdb_scalar_function(void);
-rubyDuckDBScalarFunction *get_struct_scalar_function(VALUE obj);
+void rbduckdb_init_scalar_function(void);
+rubyDuckDBScalarFunction *rbduckdb_get_struct_scalar_function(VALUE obj);
 
 #endif
-
-

--- a/ext/duckdb/scalar_function_bind_info.c
+++ b/ext/duckdb/scalar_function_bind_info.c
@@ -5,10 +5,10 @@ VALUE cDuckDBScalarFunctionBindInfo;
 static void deallocate(void *ctx);
 static VALUE allocate(VALUE klass);
 static size_t memsize(const void *p);
-static VALUE rbduckdb_scalar_function_bind_info_argument_count(VALUE self);
-static VALUE rbduckdb_scalar_function_bind_info_set_error(VALUE self, VALUE error);
-static VALUE rbduckdb_scalar_function_bind_info_get_argument(VALUE self, VALUE index);
-static VALUE rbduckdb_scalar_function_bind_info_client_context(VALUE self);
+static VALUE scalar_function_bind_info_argument_count(VALUE self);
+static VALUE scalar_function_bind_info_set_error(VALUE self, VALUE error);
+static VALUE scalar_function_bind_info__get_argument(VALUE self, VALUE index);
+static VALUE scalar_function_bind_info_client_context(VALUE self);
 
 static const rb_data_type_t scalar_function_bind_info_data_type = {
     "DuckDB/ScalarFunction/BindInfo",
@@ -46,7 +46,7 @@ VALUE rbduckdb_scalar_function_bind_info_new(duckdb_bind_info bind_info) {
  *
  *   bind_info.argument_count  # => 2
  */
-static VALUE rbduckdb_scalar_function_bind_info_argument_count(VALUE self) {
+static VALUE scalar_function_bind_info_argument_count(VALUE self) {
     rubyDuckDBScalarFunctionBindInfo *ctx;
     TypedData_Get_Struct(self, rubyDuckDBScalarFunctionBindInfo, &scalar_function_bind_info_data_type, ctx);
     return ULL2NUM(duckdb_scalar_function_bind_get_argument_count(ctx->bind_info));
@@ -61,7 +61,7 @@ static VALUE rbduckdb_scalar_function_bind_info_argument_count(VALUE self) {
  *
  *   bind_info.set_error('invalid argument')
  */
-static VALUE rbduckdb_scalar_function_bind_info_set_error(VALUE self, VALUE error) {
+static VALUE scalar_function_bind_info_set_error(VALUE self, VALUE error) {
     rubyDuckDBScalarFunctionBindInfo *ctx;
     TypedData_Get_Struct(self, rubyDuckDBScalarFunctionBindInfo, &scalar_function_bind_info_data_type, ctx);
     duckdb_scalar_function_bind_set_error(ctx->bind_info, StringValueCStr(error));
@@ -75,7 +75,7 @@ static VALUE rbduckdb_scalar_function_bind_info_set_error(VALUE self, VALUE erro
  * Returns the expression at the given argument index.
  * Called internally by +get_argument+ after index validation.
  */
-static VALUE rbduckdb_scalar_function_bind_info_get_argument(VALUE self, VALUE index) {
+static VALUE scalar_function_bind_info__get_argument(VALUE self, VALUE index) {
     rubyDuckDBScalarFunctionBindInfo *ctx;
     TypedData_Get_Struct(self, rubyDuckDBScalarFunctionBindInfo, &scalar_function_bind_info_data_type, ctx);
     duckdb_expression expr = duckdb_scalar_function_bind_get_argument(ctx->bind_info, (idx_t)NUM2ULL(index));
@@ -88,7 +88,7 @@ static VALUE rbduckdb_scalar_function_bind_info_get_argument(VALUE self, VALUE i
  *
  * Returns the client context associated with the bind phase of the scalar function.
  */
-static VALUE rbduckdb_scalar_function_bind_info_client_context(VALUE self) {
+static VALUE scalar_function_bind_info_client_context(VALUE self) {
     rubyDuckDBScalarFunctionBindInfo *ctx;
     duckdb_client_context client_context;
     TypedData_Get_Struct(self, rubyDuckDBScalarFunctionBindInfo, &scalar_function_bind_info_data_type, ctx);
@@ -96,14 +96,14 @@ static VALUE rbduckdb_scalar_function_bind_info_client_context(VALUE self) {
     return rbduckdb_client_context_new(client_context);
 }
 
-void rbduckdb_init_duckdb_scalar_function_bind_info(void) {
+void rbduckdb_init_scalar_function_bind_info(void) {
 #if 0
     VALUE mDuckDB = rb_define_module("DuckDB");
 #endif
     cDuckDBScalarFunctionBindInfo = rb_define_class_under(cDuckDBScalarFunction, "BindInfo", rb_cObject);
     rb_define_alloc_func(cDuckDBScalarFunctionBindInfo, allocate);
-    rb_define_method(cDuckDBScalarFunctionBindInfo, "argument_count", rbduckdb_scalar_function_bind_info_argument_count, 0);
-    rb_define_method(cDuckDBScalarFunctionBindInfo, "set_error", rbduckdb_scalar_function_bind_info_set_error, 1);
-    rb_define_private_method(cDuckDBScalarFunctionBindInfo, "_get_argument", rbduckdb_scalar_function_bind_info_get_argument, 1);
-    rb_define_method(cDuckDBScalarFunctionBindInfo, "client_context", rbduckdb_scalar_function_bind_info_client_context, 0);
+    rb_define_method(cDuckDBScalarFunctionBindInfo, "argument_count", scalar_function_bind_info_argument_count, 0);
+    rb_define_method(cDuckDBScalarFunctionBindInfo, "set_error", scalar_function_bind_info_set_error, 1);
+    rb_define_private_method(cDuckDBScalarFunctionBindInfo, "_get_argument", scalar_function_bind_info__get_argument, 1);
+    rb_define_method(cDuckDBScalarFunctionBindInfo, "client_context", scalar_function_bind_info_client_context, 0);
 }

--- a/ext/duckdb/scalar_function_bind_info.h
+++ b/ext/duckdb/scalar_function_bind_info.h
@@ -7,7 +7,7 @@ struct _rubyDuckDBScalarFunctionBindInfo {
 
 typedef struct _rubyDuckDBScalarFunctionBindInfo rubyDuckDBScalarFunctionBindInfo;
 
-void rbduckdb_init_duckdb_scalar_function_bind_info(void);
+void rbduckdb_init_scalar_function_bind_info(void);
 VALUE rbduckdb_scalar_function_bind_info_new(duckdb_bind_info bind_info);
 
 #endif

--- a/ext/duckdb/scalar_function_set.c
+++ b/ext/duckdb/scalar_function_set.c
@@ -7,8 +7,8 @@ static void deallocate(void *);
 static VALUE allocate(VALUE klass);
 static size_t memsize(const void *p);
 static void compact(void *);
-static VALUE rbduckdb_scalar_function_set__initialize(VALUE self, VALUE name);
-static VALUE rbduckdb_scalar_function_set__add(VALUE self, VALUE scalar_function);
+static VALUE scalar_function_set__initialize(VALUE self, VALUE name);
+static VALUE scalar_function_set__add(VALUE self, VALUE scalar_function);
 
 static const rb_data_type_t scalar_function_set_data_type = {
     "DuckDB/ScalarFunctionSet",
@@ -44,14 +44,14 @@ static size_t memsize(const void *p) {
     return sizeof(rubyDuckDBScalarFunctionSet);
 }
 
-rubyDuckDBScalarFunctionSet *get_struct_scalar_function_set(VALUE obj) {
+rubyDuckDBScalarFunctionSet *rbduckdb_get_struct_scalar_function_set(VALUE obj) {
     rubyDuckDBScalarFunctionSet *ctx;
     TypedData_Get_Struct(obj, rubyDuckDBScalarFunctionSet, &scalar_function_set_data_type, ctx);
     return ctx;
 }
 
 /* :nodoc: */
-static VALUE rbduckdb_scalar_function_set__initialize(VALUE self, VALUE name) {
+static VALUE scalar_function_set__initialize(VALUE self, VALUE name) {
     rubyDuckDBScalarFunctionSet *p;
 
     TypedData_Get_Struct(self, rubyDuckDBScalarFunctionSet, &scalar_function_set_data_type, p);
@@ -60,12 +60,12 @@ static VALUE rbduckdb_scalar_function_set__initialize(VALUE self, VALUE name) {
 }
 
 /* :nodoc: */
-static VALUE rbduckdb_scalar_function_set__add(VALUE self, VALUE scalar_function) {
+static VALUE scalar_function_set__add(VALUE self, VALUE scalar_function) {
     rubyDuckDBScalarFunctionSet *p;
     rubyDuckDBScalarFunction *sf;
 
     TypedData_Get_Struct(self, rubyDuckDBScalarFunctionSet, &scalar_function_set_data_type, p);
-    sf = get_struct_scalar_function(scalar_function);
+    sf = rbduckdb_get_struct_scalar_function(scalar_function);
 
     if (duckdb_add_scalar_function_to_set(p->scalar_function_set, sf->scalar_function) == DuckDBError) {
         rb_raise(eDuckDBError, "failed to add scalar function to set (duplicate overload?)");
@@ -75,12 +75,12 @@ static VALUE rbduckdb_scalar_function_set__add(VALUE self, VALUE scalar_function
     return self;
 }
 
-void rbduckdb_init_duckdb_scalar_function_set(void) {
+void rbduckdb_init_scalar_function_set(void) {
 #if 0
     VALUE mDuckDB = rb_define_module("DuckDB");
 #endif
     cDuckDBScalarFunctionSet = rb_define_class_under(mDuckDB, "ScalarFunctionSet", rb_cObject);
     rb_define_alloc_func(cDuckDBScalarFunctionSet, allocate);
-    rb_define_private_method(cDuckDBScalarFunctionSet, "_initialize", rbduckdb_scalar_function_set__initialize, 1);
-    rb_define_private_method(cDuckDBScalarFunctionSet, "_add", rbduckdb_scalar_function_set__add, 1);
+    rb_define_private_method(cDuckDBScalarFunctionSet, "_initialize", scalar_function_set__initialize, 1);
+    rb_define_private_method(cDuckDBScalarFunctionSet, "_add", scalar_function_set__add, 1);
 }

--- a/ext/duckdb/scalar_function_set.h
+++ b/ext/duckdb/scalar_function_set.h
@@ -8,7 +8,7 @@ struct _rubyDuckDBScalarFunctionSet {
 
 typedef struct _rubyDuckDBScalarFunctionSet rubyDuckDBScalarFunctionSet;
 
-void rbduckdb_init_duckdb_scalar_function_set(void);
-rubyDuckDBScalarFunctionSet *get_struct_scalar_function_set(VALUE obj);
+void rbduckdb_init_scalar_function_set(void);
+rubyDuckDBScalarFunctionSet *rbduckdb_get_struct_scalar_function_set(VALUE obj);
 
 #endif


### PR DESCRIPTION
## Summary

Fix C function naming rule violations in `scalar_function.c`, `scalar_function_bind_info.c`, and `scalar_function_set.c` as defined in [HACKING.md](HACKING.md).

## Rules Fixed

| Rule | Description | Example |
|---|---|---|
| Rule 1 | `rb_define_method` static functions must be `classname_methodname` | `duckdb_scalar_function_initialize` → `scalar_function_initialize` |
| Rule 2 | `rb_define_private_method` static functions must be `classname__methodname` | `rbduckdb_scalar_function_add_parameter` → `scalar_function__add_parameter` |
| Rule 10 | `rbduckdb_init_*` must not contain redundant `duckdb_` | `rbduckdb_init_duckdb_scalar_function` → `rbduckdb_init_scalar_function` |
| Rule 11 | Extern functions must use `rbduckdb_` prefix | `get_struct_scalar_function` → `rbduckdb_get_struct_scalar_function` |

## Files Changed

- `ext/duckdb/scalar_function.{c,h}`
- `ext/duckdb/scalar_function_bind_info.{c,h}`
- `ext/duckdb/scalar_function_set.{c,h}`
- `ext/duckdb/duckdb.c` — updated init call sites
- `ext/duckdb/connection.c` — updated `get_struct` call sites

## Testing

All 1150 tests pass with 0 failures and 0 errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized internal naming conventions across multiple modules for improved consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->