### PR TITLE
Fix HACKING.md naming violations in table_function* and table_description files

### DIFF
--- a/ext/duckdb/connection.c
+++ b/ext/duckdb/connection.c
@@ -314,7 +314,7 @@ static VALUE connection__register_table_function(VALUE self, VALUE table_functio
     duckdb_state state;
 
     ctxcon = rbduckdb_get_struct_connection(self);
-    ctxtf = get_struct_table_function(table_function);
+    ctxtf = rbduckdb_get_struct_table_function(table_function);
 
     state = duckdb_register_table_function(ctxcon->con, ctxtf->table_function);
 

--- a/ext/duckdb/duckdb.c
+++ b/ext/duckdb/duckdb.c
@@ -66,11 +66,11 @@ Init_duckdb_native(void) {
     rbduckdb_init_vector();
     rbduckdb_init_data_chunk();
     rbduckdb_init_memory_helper();
-    rbduckdb_init_duckdb_table_function();
-    rbduckdb_init_duckdb_table_function_bind_info();
-    rbduckdb_init_duckdb_table_function_init_info();
-    rbduckdb_init_duckdb_table_function_function_info();
+    rbduckdb_init_table_function();
+    rbduckdb_init_table_function_bind_info();
+    rbduckdb_init_table_function_init_info();
+    rbduckdb_init_table_function_function_info();
 #ifdef HAVE_DUCKDB_H_GE_V1_5_0
-    rbduckdb_init_duckdb_table_description();
+    rbduckdb_init_table_description();
 #endif
 }

--- a/ext/duckdb/table_description.c
+++ b/ext/duckdb/table_description.c
@@ -8,13 +8,13 @@ static void deallocate(void *ctx);
 static VALUE allocate(VALUE klass);
 static size_t memsize(const void *p);
 static rubyDuckDBTableDescription *get_struct_table_description(VALUE obj);
-static VALUE rbduckdb_table_description_error_message(VALUE self);
-static VALUE duckdb_table_description__initialize(VALUE self, VALUE conn, VALUE catalog, VALUE schema, VALUE table);
+static VALUE table_description_error_message(VALUE self);
+static VALUE table_description__initialize(VALUE self, VALUE conn, VALUE catalog, VALUE schema, VALUE table);
 
-static VALUE duckdb_table_description__column_count(VALUE self);
-static VALUE duckdb_table_description__column_name(VALUE self, VALUE idx);
-static VALUE duckdb_table_description__column_logical_type(VALUE self, VALUE idx);
-static VALUE duckdb_table_description__column_has_default(VALUE self, VALUE idx);
+static VALUE table_description__column_count(VALUE self);
+static VALUE table_description__column_name(VALUE self, VALUE idx);
+static VALUE table_description__column_logical_type(VALUE self, VALUE idx);
+static VALUE table_description__column_has_default(VALUE self, VALUE idx);
 
 static const rb_data_type_t table_description_data_type = {
     "DuckDB/TableDescription",
@@ -46,14 +46,14 @@ static rubyDuckDBTableDescription *get_struct_table_description(VALUE obj) {
     return ctx;
 }
 
-static VALUE rbduckdb_table_description_error_message(VALUE self) {
+static VALUE table_description_error_message(VALUE self) {
     rubyDuckDBTableDescription *ctx = get_struct_table_description(self);
     const char *p = duckdb_table_description_error(ctx->table_description);
     return p ? rb_str_new2(p) : Qnil;
 }
 
 /* nodoc */
-static VALUE duckdb_table_description__initialize(VALUE self, VALUE con, VALUE catalog, VALUE schema, VALUE table) {
+static VALUE table_description__initialize(VALUE self, VALUE con, VALUE catalog, VALUE schema, VALUE table) {
     char *pcatalog = NULL;
     char *pschema = NULL;
     char *ptable = NULL;
@@ -89,14 +89,14 @@ static VALUE duckdb_table_description__initialize(VALUE self, VALUE con, VALUE c
 }
 
 /* nodoc */
-static VALUE duckdb_table_description__column_count(VALUE self) {
+static VALUE table_description__column_count(VALUE self) {
     rubyDuckDBTableDescription *ctx;
     ctx = get_struct_table_description(self);
     return ULL2NUM(duckdb_table_description_get_column_count(ctx->table_description));
 }
 
 /* nodoc */
-static VALUE duckdb_table_description__column_name(VALUE self, VALUE idx) {
+static VALUE table_description__column_name(VALUE self, VALUE idx) {
     VALUE name = Qnil;
     rubyDuckDBTableDescription *ctx;
     ctx = get_struct_table_description(self);
@@ -109,7 +109,7 @@ static VALUE duckdb_table_description__column_name(VALUE self, VALUE idx) {
 }
 
 /* nodoc */
-static VALUE duckdb_table_description__column_logical_type(VALUE self, VALUE idx) {
+static VALUE table_description__column_logical_type(VALUE self, VALUE idx) {
     rubyDuckDBTableDescription *ctx;
     duckdb_logical_type lt;
     ctx = get_struct_table_description(self);
@@ -117,7 +117,7 @@ static VALUE duckdb_table_description__column_logical_type(VALUE self, VALUE idx
     return rbduckdb_create_logical_type(lt);
 }
 
-static VALUE duckdb_table_description__column_has_default(VALUE self, VALUE idx) {
+static VALUE table_description__column_has_default(VALUE self, VALUE idx) {
     rubyDuckDBTableDescription *ctx;
     bool has_default;
     ctx = get_struct_table_description(self);
@@ -128,17 +128,17 @@ static VALUE duckdb_table_description__column_has_default(VALUE self, VALUE idx)
     return has_default ? Qtrue : Qfalse;
 }
 
-void rbduckdb_init_duckdb_table_description(void) {
+void rbduckdb_init_table_description(void) {
 #if 0
     VALUE mDuckDB = rb_define_module("DuckDB");
 #endif
     cDuckDBTableDescription = rb_define_class_under(mDuckDB, "TableDescription", rb_cObject);
     rb_define_alloc_func(cDuckDBTableDescription, allocate);
-    rb_define_method(cDuckDBTableDescription, "error_message", rbduckdb_table_description_error_message, 0);
-    rb_define_private_method(cDuckDBTableDescription, "_initialize", duckdb_table_description__initialize, 4);
-    rb_define_private_method(cDuckDBTableDescription, "_column_count", duckdb_table_description__column_count, 0);
-    rb_define_private_method(cDuckDBTableDescription, "_column_name", duckdb_table_description__column_name, 1);
-    rb_define_private_method(cDuckDBTableDescription, "_column_logical_type", duckdb_table_description__column_logical_type, 1);
-    rb_define_private_method(cDuckDBTableDescription, "_column_has_default", duckdb_table_description__column_has_default, 1);
+    rb_define_method(cDuckDBTableDescription, "error_message", table_description_error_message, 0);
+    rb_define_private_method(cDuckDBTableDescription, "_initialize", table_description__initialize, 4);
+    rb_define_private_method(cDuckDBTableDescription, "_column_count", table_description__column_count, 0);
+    rb_define_private_method(cDuckDBTableDescription, "_column_name", table_description__column_name, 1);
+    rb_define_private_method(cDuckDBTableDescription, "_column_logical_type", table_description__column_logical_type, 1);
+    rb_define_private_method(cDuckDBTableDescription, "_column_has_default", table_description__column_has_default, 1);
 }
 #endif

--- a/ext/duckdb/table_description.h
+++ b/ext/duckdb/table_description.h
@@ -9,7 +9,7 @@ struct _rubyDuckDBTableDescription {
 
 typedef struct _rubyDuckDBTableDescription rubyDuckDBTableDescription;
 
-void rbduckdb_init_duckdb_table_description(void);
+void rbduckdb_init_table_description(void);
 
 #endif /* HAVE_DUCKDB_H_GE_V1_5_0 */
 

--- a/ext/duckdb/table_function.c
+++ b/ext/duckdb/table_function.c
@@ -11,15 +11,15 @@ static void deallocate(void *ctx);
 static VALUE allocate(VALUE klass);
 static size_t memsize(const void *p);
 static void compact(void *ctx);
-static VALUE duckdb_table_function_initialize(VALUE self);
-static VALUE rbduckdb_table_function_set_name(VALUE self, VALUE name);
-static VALUE rbduckdb_table_function_add_parameter(VALUE self, VALUE logical_type);
-static VALUE rbduckdb_table_function_add_named_parameter(VALUE self, VALUE name, VALUE logical_type);
-static VALUE rbduckdb_table_function_set_bind(VALUE self);
+static VALUE table_function_initialize(VALUE self);
+static VALUE table_function_set_name(VALUE self, VALUE name);
+static VALUE table_function_add_parameter(VALUE self, VALUE logical_type);
+static VALUE table_function_add_named_parameter(VALUE self, VALUE name, VALUE logical_type);
+static VALUE table_function_bind(VALUE self);
 static void table_function_bind_callback(duckdb_bind_info info);
-static VALUE rbduckdb_table_function_set_init(VALUE self);
+static VALUE table_function_init(VALUE self);
 static void table_function_init_callback(duckdb_init_info info);
-static VALUE rbduckdb_table_function_set_execute(VALUE self);
+static VALUE table_function_execute(VALUE self);
 static void table_function_execute_callback(duckdb_function_info info, duckdb_data_chunk output);
 #ifdef HAVE_DUCKDB_H_GE_V1_5_0
 /* Thread detection (declared in function_executor.c); used to skip the proxy on Ruby threads. */
@@ -89,7 +89,7 @@ static size_t memsize(const void *p) {
  *   tf.name = "my_function"
  *   # ... configure tf ...
  */
-static VALUE duckdb_table_function_initialize(VALUE self) {
+static VALUE table_function_initialize(VALUE self) {
     rubyDuckDBTableFunction *ctx;
 
     TypedData_Get_Struct(self, rubyDuckDBTableFunction, &table_function_data_type, ctx);
@@ -118,7 +118,7 @@ static VALUE duckdb_table_function_initialize(VALUE self) {
  *
  *   tf.name = "my_function"
  */
-static VALUE rbduckdb_table_function_set_name(VALUE self, VALUE name) {
+static VALUE table_function_set_name(VALUE self, VALUE name) {
     rubyDuckDBTableFunction *ctx;
     const char *func_name;
 
@@ -143,7 +143,7 @@ static VALUE rbduckdb_table_function_set_name(VALUE self, VALUE name) {
  *   tf.add_parameter(DuckDB::LogicalType::BIGINT)
  *   tf.add_parameter(DuckDB::LogicalType::VARCHAR)
  */
-static VALUE rbduckdb_table_function_add_parameter(VALUE self, VALUE logical_type) {
+static VALUE table_function_add_parameter(VALUE self, VALUE logical_type) {
     rubyDuckDBTableFunction *ctx;
     rubyDuckDBLogicalType *ctx_logical_type;
 
@@ -167,7 +167,7 @@ static VALUE rbduckdb_table_function_add_parameter(VALUE self, VALUE logical_typ
  *
  *   tf.add_named_parameter("limit", DuckDB::LogicalType::BIGINT)
  */
-static VALUE rbduckdb_table_function_add_named_parameter(VALUE self, VALUE name, VALUE logical_type) {
+static VALUE table_function_add_named_parameter(VALUE self, VALUE name, VALUE logical_type) {
     rubyDuckDBTableFunction *ctx;
     rubyDuckDBLogicalType *ctx_logical_type;
     const char *param_name;
@@ -197,7 +197,7 @@ static VALUE rbduckdb_table_function_add_named_parameter(VALUE self, VALUE name,
  *     bind_info.add_result_column('name', DuckDB::LogicalType::VARCHAR)
  *   end
  */
-static VALUE rbduckdb_table_function_set_bind(VALUE self) {
+static VALUE table_function_bind(VALUE self) {
     rubyDuckDBTableFunction *ctx;
 
     if (!rb_block_given_p()) {
@@ -236,7 +236,7 @@ static void execute_bind_callback_protected(void *user_data) {
     int state = 0;
 
     bind_info_obj = rb_class_new_instance(0, NULL, cDuckDBTableFunctionBindInfo);
-    bind_info_ctx = get_struct_bind_info(bind_info_obj);
+    bind_info_ctx = rbduckdb_get_struct_bind_info(bind_info_obj);
     bind_info_ctx->bind_info = darg->info;
 
     VALUE call_args[2] = { darg->ctx->bind_proc, bind_info_obj };
@@ -274,7 +274,7 @@ static void table_function_bind_callback(duckdb_bind_info info) {
  *     # Initialize execution state
  *   end
  */
-static VALUE rbduckdb_table_function_set_init(VALUE self) {
+static VALUE table_function_init(VALUE self) {
     rubyDuckDBTableFunction *ctx;
 
     if (!rb_block_given_p()) {
@@ -312,7 +312,7 @@ static void execute_init_callback_protected(void *user_data) {
     int state = 0;
 
     init_info_obj = rb_class_new_instance(0, NULL, cDuckDBTableFunctionInitInfo);
-    init_info_ctx = get_struct_init_info(init_info_obj);
+    init_info_ctx = rbduckdb_get_struct_init_info(init_info_obj);
     init_info_ctx->info = darg->info;
 
     VALUE call_args[2] = { darg->ctx->init_proc, init_info_obj };
@@ -352,7 +352,7 @@ static void table_function_init_callback(duckdb_init_info info) {
  *     # Write data...
  *   end
  */
-static VALUE rbduckdb_table_function_set_execute(VALUE self) {
+static VALUE table_function_execute(VALUE self) {
     rubyDuckDBTableFunction *ctx;
 
     if (!rb_block_given_p()) {
@@ -393,7 +393,7 @@ static void execute_execute_callback_protected(void *user_data) {
     int state = 0;
 
     func_info_obj = rb_class_new_instance(0, NULL, cDuckDBTableFunctionFunctionInfo);
-    func_info_ctx = get_struct_function_info(func_info_obj);
+    func_info_ctx = rbduckdb_get_struct_function_info(func_info_obj);
     func_info_ctx->info = darg->info;
 
     data_chunk_obj = rb_class_new_instance(0, NULL, cDuckDBDataChunk);
@@ -482,25 +482,25 @@ static void table_function_local_init_callback(duckdb_init_info info) {
 }
 #endif
 
-rubyDuckDBTableFunction *get_struct_table_function(VALUE self) {
+rubyDuckDBTableFunction *rbduckdb_get_struct_table_function(VALUE self) {
     rubyDuckDBTableFunction *ctx;
     TypedData_Get_Struct(self, rubyDuckDBTableFunction, &table_function_data_type, ctx);
     return ctx;
 }
 
-void rbduckdb_init_duckdb_table_function(void) {
+void rbduckdb_init_table_function(void) {
 #if 0
     VALUE mDuckDB = rb_define_module("DuckDB");
 #endif
     cDuckDBTableFunction = rb_define_class_under(mDuckDB, "TableFunction", rb_cObject);
     rb_define_alloc_func(cDuckDBTableFunction, allocate);
 
-    rb_define_method(cDuckDBTableFunction, "initialize", duckdb_table_function_initialize, 0);
-    rb_define_method(cDuckDBTableFunction, "set_name", rbduckdb_table_function_set_name, 1);
-    rb_define_method(cDuckDBTableFunction, "name=", rbduckdb_table_function_set_name, 1);
-    rb_define_method(cDuckDBTableFunction, "add_parameter", rbduckdb_table_function_add_parameter, 1);
-    rb_define_method(cDuckDBTableFunction, "add_named_parameter", rbduckdb_table_function_add_named_parameter, 2);
-    rb_define_method(cDuckDBTableFunction, "bind", rbduckdb_table_function_set_bind, 0);
-    rb_define_method(cDuckDBTableFunction, "init", rbduckdb_table_function_set_init, 0);
-    rb_define_method(cDuckDBTableFunction, "execute", rbduckdb_table_function_set_execute, 0);
+    rb_define_method(cDuckDBTableFunction, "initialize", table_function_initialize, 0);
+    rb_define_method(cDuckDBTableFunction, "set_name", table_function_set_name, 1);
+    rb_define_method(cDuckDBTableFunction, "name=", table_function_set_name, 1);
+    rb_define_method(cDuckDBTableFunction, "add_parameter", table_function_add_parameter, 1);
+    rb_define_method(cDuckDBTableFunction, "add_named_parameter", table_function_add_named_parameter, 2);
+    rb_define_method(cDuckDBTableFunction, "bind", table_function_bind, 0);
+    rb_define_method(cDuckDBTableFunction, "init", table_function_init, 0);
+    rb_define_method(cDuckDBTableFunction, "execute", table_function_execute, 0);
 }

--- a/ext/duckdb/table_function.h
+++ b/ext/duckdb/table_function.h
@@ -11,7 +11,7 @@ struct _rubyDuckDBTableFunction {
 typedef struct _rubyDuckDBTableFunction rubyDuckDBTableFunction;
 
 extern VALUE cDuckDBTableFunction;
-rubyDuckDBTableFunction *get_struct_table_function(VALUE self);
-void rbduckdb_init_duckdb_table_function(void);
+rubyDuckDBTableFunction *rbduckdb_get_struct_table_function(VALUE self);
+void rbduckdb_init_table_function(void);
 
 #endif

--- a/ext/duckdb/table_function_bind_info.c
+++ b/ext/duckdb/table_function_bind_info.c
@@ -5,12 +5,12 @@ VALUE cDuckDBTableFunctionBindInfo;
 static void deallocate(void *ctx);
 static VALUE allocate(VALUE klass);
 static size_t memsize(const void *p);
-static VALUE rbduckdb_bind_info_parameter_count(VALUE self);
-static VALUE rbduckdb_bind_info_get_parameter(VALUE self, VALUE index);
-static VALUE rbduckdb_bind_info_get_named_parameter(VALUE self, VALUE name);
-static VALUE rbduckdb_bind_info__add_result_column(VALUE self, VALUE column_name, VALUE logical_type);
-static VALUE rbduckdb_bind_info_set_cardinality(VALUE self, VALUE cardinality, VALUE is_exact);
-static VALUE rbduckdb_bind_info_set_error(VALUE self, VALUE error);
+static VALUE table_function_bind_info_parameter_count(VALUE self);
+static VALUE table_function_bind_info_get_parameter(VALUE self, VALUE index);
+static VALUE table_function_bind_info_get_named_parameter(VALUE self, VALUE name);
+static VALUE table_function_bind_info__add_result_column(VALUE self, VALUE column_name, VALUE logical_type);
+static VALUE table_function_bind_info_set_cardinality(VALUE self, VALUE cardinality, VALUE is_exact);
+static VALUE table_function_bind_info_set_error(VALUE self, VALUE error);
 
 static const rb_data_type_t bind_info_data_type = {
     "DuckDB/TableFunctionBindInfo",
@@ -32,7 +32,7 @@ static size_t memsize(const void *p) {
     return sizeof(rubyDuckDBBindInfo);
 }
 
-rubyDuckDBBindInfo *get_struct_bind_info(VALUE obj) {
+rubyDuckDBBindInfo *rbduckdb_get_struct_bind_info(VALUE obj) {
     rubyDuckDBBindInfo *ctx;
     TypedData_Get_Struct(obj, rubyDuckDBBindInfo, &bind_info_data_type, ctx);
     return ctx;
@@ -52,7 +52,7 @@ rubyDuckDBBindInfo *get_struct_bind_info(VALUE obj) {
  *
  *   bind_info.parameter_count  # => 2
  */
-static VALUE rbduckdb_bind_info_parameter_count(VALUE self) {
+static VALUE table_function_bind_info_parameter_count(VALUE self) {
     rubyDuckDBBindInfo *ctx;
     idx_t count;
 
@@ -71,7 +71,7 @@ static VALUE rbduckdb_bind_info_parameter_count(VALUE self) {
  *
  *   param = bind_info.get_parameter(0)
  */
-static VALUE rbduckdb_bind_info_get_parameter(VALUE self, VALUE index) {
+static VALUE table_function_bind_info_get_parameter(VALUE self, VALUE index) {
     rubyDuckDBBindInfo *ctx;
     idx_t idx;
     duckdb_value param_value;
@@ -97,7 +97,7 @@ static VALUE rbduckdb_bind_info_get_parameter(VALUE self, VALUE index) {
  *
  *   param = bind_info.get_named_parameter('limit')
  */
-static VALUE rbduckdb_bind_info_get_named_parameter(VALUE self, VALUE name) {
+static VALUE table_function_bind_info_get_named_parameter(VALUE self, VALUE name) {
     rubyDuckDBBindInfo *ctx;
     const char *param_name;
     duckdb_value param_value;
@@ -129,7 +129,7 @@ static VALUE rbduckdb_bind_info_get_named_parameter(VALUE self, VALUE name) {
  *   bind_info.add_result_column('id', DuckDB::LogicalType::BIGINT)
  *   bind_info.add_result_column('name', DuckDB::LogicalType::VARCHAR)
  */
-static VALUE rbduckdb_bind_info__add_result_column(VALUE self, VALUE column_name, VALUE logical_type) {
+static VALUE table_function_bind_info__add_result_column(VALUE self, VALUE column_name, VALUE logical_type) {
     rubyDuckDBBindInfo *ctx;
     rubyDuckDBLogicalType *ctx_logical_type;
     const char *col_name;
@@ -152,7 +152,7 @@ static VALUE rbduckdb_bind_info__add_result_column(VALUE self, VALUE column_name
  *   bind_info.set_cardinality(100, true)  # Exactly 100 rows
  *   bind_info.set_cardinality(1000, false)  # Approximately 1000 rows
  */
-static VALUE rbduckdb_bind_info_set_cardinality(VALUE self, VALUE cardinality, VALUE is_exact) {
+static VALUE table_function_bind_info_set_cardinality(VALUE self, VALUE cardinality, VALUE is_exact) {
     rubyDuckDBBindInfo *ctx;
     idx_t card;
     bool exact;
@@ -175,7 +175,7 @@ static VALUE rbduckdb_bind_info_set_cardinality(VALUE self, VALUE cardinality, V
  *
  *   bind_info.set_error('Invalid parameter value')
  */
-static VALUE rbduckdb_bind_info_set_error(VALUE self, VALUE error) {
+static VALUE table_function_bind_info_set_error(VALUE self, VALUE error) {
     rubyDuckDBBindInfo *ctx;
     const char *error_msg;
 
@@ -187,18 +187,18 @@ static VALUE rbduckdb_bind_info_set_error(VALUE self, VALUE error) {
     return self;
 }
 
-void rbduckdb_init_duckdb_table_function_bind_info(void) {
+void rbduckdb_init_table_function_bind_info(void) {
 #if 0
     VALUE mDuckDB = rb_define_module("DuckDB");
 #endif
     cDuckDBTableFunctionBindInfo = rb_define_class_under(cDuckDBTableFunction, "BindInfo", rb_cObject);
     rb_define_alloc_func(cDuckDBTableFunctionBindInfo, allocate);
 
-    rb_define_method(cDuckDBTableFunctionBindInfo, "parameter_count", rbduckdb_bind_info_parameter_count, 0);
-    rb_define_method(cDuckDBTableFunctionBindInfo, "get_parameter", rbduckdb_bind_info_get_parameter, 1);
-    rb_define_method(cDuckDBTableFunctionBindInfo, "get_named_parameter", rbduckdb_bind_info_get_named_parameter, 1);
-    rb_define_method(cDuckDBTableFunctionBindInfo, "set_cardinality", rbduckdb_bind_info_set_cardinality, 2);
-    rb_define_method(cDuckDBTableFunctionBindInfo, "set_error", rbduckdb_bind_info_set_error, 1);
+    rb_define_method(cDuckDBTableFunctionBindInfo, "parameter_count", table_function_bind_info_parameter_count, 0);
+    rb_define_method(cDuckDBTableFunctionBindInfo, "get_parameter", table_function_bind_info_get_parameter, 1);
+    rb_define_method(cDuckDBTableFunctionBindInfo, "get_named_parameter", table_function_bind_info_get_named_parameter, 1);
+    rb_define_method(cDuckDBTableFunctionBindInfo, "set_cardinality", table_function_bind_info_set_cardinality, 2);
+    rb_define_method(cDuckDBTableFunctionBindInfo, "set_error", table_function_bind_info_set_error, 1);
 
-    rb_define_private_method(cDuckDBTableFunctionBindInfo, "_add_result_column", rbduckdb_bind_info__add_result_column, 2);
+    rb_define_private_method(cDuckDBTableFunctionBindInfo, "_add_result_column", table_function_bind_info__add_result_column, 2);
 }

--- a/ext/duckdb/table_function_bind_info.h
+++ b/ext/duckdb/table_function_bind_info.h
@@ -8,7 +8,7 @@ struct _rubyDuckDBBindInfo {
 typedef struct _rubyDuckDBBindInfo rubyDuckDBBindInfo;
 
 extern VALUE cDuckDBTableFunctionBindInfo;
-rubyDuckDBBindInfo *get_struct_bind_info(VALUE obj);
-void rbduckdb_init_duckdb_table_function_bind_info(void);
+rubyDuckDBBindInfo *rbduckdb_get_struct_bind_info(VALUE obj);
+void rbduckdb_init_table_function_bind_info(void);
 
 #endif

--- a/ext/duckdb/table_function_function_info.c
+++ b/ext/duckdb/table_function_function_info.c
@@ -5,7 +5,7 @@ VALUE cDuckDBTableFunctionFunctionInfo;
 static void deallocate(void *ctx);
 static VALUE allocate(VALUE klass);
 static size_t memsize(const void *p);
-static VALUE rbduckdb_function_info_set_error(VALUE self, VALUE error);
+static VALUE table_function_function_info_set_error(VALUE self, VALUE error);
 
 static const rb_data_type_t function_info_data_type = {
     "DuckDB/TableFunctionFunctionInfo",
@@ -27,7 +27,7 @@ static size_t memsize(const void *p) {
     return sizeof(rubyDuckDBFunctionInfo);
 }
 
-rubyDuckDBFunctionInfo *get_struct_function_info(VALUE obj) {
+rubyDuckDBFunctionInfo *rbduckdb_get_struct_function_info(VALUE obj) {
     rubyDuckDBFunctionInfo *ctx;
     TypedData_Get_Struct(obj, rubyDuckDBFunctionInfo, &function_info_data_type, ctx);
     return ctx;
@@ -42,7 +42,7 @@ rubyDuckDBFunctionInfo *get_struct_function_info(VALUE obj) {
  *
  *   function_info.set_error('Invalid parameter value')
  */
-static VALUE rbduckdb_function_info_set_error(VALUE self, VALUE error) {
+static VALUE table_function_function_info_set_error(VALUE self, VALUE error) {
     rubyDuckDBFunctionInfo *ctx;
     const char *error_msg;
 
@@ -54,12 +54,12 @@ static VALUE rbduckdb_function_info_set_error(VALUE self, VALUE error) {
     return self;
 }
 
-void rbduckdb_init_duckdb_table_function_function_info(void) {
+void rbduckdb_init_table_function_function_info(void) {
 #if 0
     VALUE mDuckDB = rb_define_module("DuckDB");
 #endif
     cDuckDBTableFunctionFunctionInfo = rb_define_class_under(cDuckDBTableFunction, "FunctionInfo", rb_cObject);
     rb_define_alloc_func(cDuckDBTableFunctionFunctionInfo, allocate);
 
-    rb_define_method(cDuckDBTableFunctionFunctionInfo, "set_error", rbduckdb_function_info_set_error, 1);
+    rb_define_method(cDuckDBTableFunctionFunctionInfo, "set_error", table_function_function_info_set_error, 1);
 }

--- a/ext/duckdb/table_function_function_info.h
+++ b/ext/duckdb/table_function_function_info.h
@@ -7,7 +7,7 @@ struct _rubyDuckDBFunctionInfo {
 
 typedef struct _rubyDuckDBFunctionInfo rubyDuckDBFunctionInfo;
 
-rubyDuckDBFunctionInfo *get_struct_function_info(VALUE obj);
-void rbduckdb_init_duckdb_table_function_function_info(void);
+rubyDuckDBFunctionInfo *rbduckdb_get_struct_function_info(VALUE obj);
+void rbduckdb_init_table_function_function_info(void);
 
 #endif

--- a/ext/duckdb/table_function_init_info.c
+++ b/ext/duckdb/table_function_init_info.c
@@ -5,8 +5,8 @@ VALUE cDuckDBTableFunctionInitInfo;
 static void deallocate(void *ctx);
 static VALUE allocate(VALUE klass);
 static size_t memsize(const void *p);
-static VALUE rbduckdb_init_info_set_error(VALUE self, VALUE error);
-static VALUE rbduckdb_init_info_set_max_threads(VALUE self, VALUE max_threads);
+static VALUE table_function_init_info_set_error(VALUE self, VALUE error);
+static VALUE table_function_init_info_set_max_threads(VALUE self, VALUE max_threads);
 static VALUE table_function_init_info_column_count(VALUE self);
 
 static const rb_data_type_t init_info_data_type = {
@@ -29,7 +29,7 @@ static size_t memsize(const void *p) {
     return sizeof(rubyDuckDBInitInfo);
 }
 
-rubyDuckDBInitInfo *get_struct_init_info(VALUE obj) {
+rubyDuckDBInitInfo *rbduckdb_get_struct_init_info(VALUE obj) {
     rubyDuckDBInitInfo *ctx;
     TypedData_Get_Struct(obj, rubyDuckDBInitInfo, &init_info_data_type, ctx);
     return ctx;
@@ -44,7 +44,7 @@ rubyDuckDBInitInfo *get_struct_init_info(VALUE obj) {
  *
  *   init_info.set_error('Invalid initialization')
  */
-static VALUE rbduckdb_init_info_set_error(VALUE self, VALUE error) {
+static VALUE table_function_init_info_set_error(VALUE self, VALUE error) {
     rubyDuckDBInitInfo *ctx;
     const char *error_msg;
 
@@ -67,7 +67,7 @@ static VALUE rbduckdb_init_info_set_error(VALUE self, VALUE error) {
  *
  *   init_info.max_threads = 4
  */
-static VALUE rbduckdb_init_info_set_max_threads(VALUE self, VALUE max_threads) {
+static VALUE table_function_init_info_set_max_threads(VALUE self, VALUE max_threads) {
     rubyDuckDBInitInfo *ctx;
 
     TypedData_Get_Struct(self, rubyDuckDBInitInfo, &init_info_data_type, ctx);
@@ -95,15 +95,15 @@ static VALUE table_function_init_info_column_count(VALUE self) {
     return ULL2NUM(duckdb_init_get_column_count(ctx->info));
 }
 
-void rbduckdb_init_duckdb_table_function_init_info(void) {
+void rbduckdb_init_table_function_init_info(void) {
 #if 0
     VALUE mDuckDB = rb_define_module("DuckDB");
 #endif
     cDuckDBTableFunctionInitInfo = rb_define_class_under(cDuckDBTableFunction, "InitInfo", rb_cObject);
     rb_define_alloc_func(cDuckDBTableFunctionInitInfo, allocate);
 
-    rb_define_method(cDuckDBTableFunctionInitInfo, "set_error", rbduckdb_init_info_set_error, 1);
-    rb_define_method(cDuckDBTableFunctionInitInfo, "set_max_threads", rbduckdb_init_info_set_max_threads, 1);
-    rb_define_method(cDuckDBTableFunctionInitInfo, "max_threads=", rbduckdb_init_info_set_max_threads, 1);
+    rb_define_method(cDuckDBTableFunctionInitInfo, "set_error", table_function_init_info_set_error, 1);
+    rb_define_method(cDuckDBTableFunctionInitInfo, "set_max_threads", table_function_init_info_set_max_threads, 1);
+    rb_define_method(cDuckDBTableFunctionInitInfo, "max_threads=", table_function_init_info_set_max_threads, 1);
     rb_define_method(cDuckDBTableFunctionInitInfo, "column_count", table_function_init_info_column_count, 0);
 }

--- a/ext/duckdb/table_function_init_info.h
+++ b/ext/duckdb/table_function_init_info.h
@@ -8,7 +8,7 @@ struct _rubyDuckDBInitInfo {
 typedef struct _rubyDuckDBInitInfo rubyDuckDBInitInfo;
 
 extern VALUE cDuckDBTableFunctionInitInfo;
-rubyDuckDBInitInfo *get_struct_init_info(VALUE obj);
-void rbduckdb_init_duckdb_table_function_init_info(void);
+rubyDuckDBInitInfo *rbduckdb_get_struct_init_info(VALUE obj);
+void rbduckdb_init_table_function_init_info(void);
 
 #endif


### PR DESCRIPTION
## Summary

Fix C function naming rule violations in `table_function.c`, `table_function_bind_info.c`, `table_function_function_info.c`, `table_function_init_info.c`, and `table_description.c` as defined in [HACKING.md](HACKING.md).

Follow-up to #1370 which fixed the `scalar_function*` files.

## Rules Fixed

| Rule | Description | Example |
|---|---|---|
| Rule 1 | `rb_define_method` static functions must be `classname_methodname` | `rbduckdb_table_function_set_bind` → `table_function_bind` |
| Rule 2 | `rb_define_private_method` static functions must be `classname__methodname` | `duckdb_table_description__initialize` → `table_description__initialize` |
| Rule 10 | `rbduckdb_init_*` must not contain redundant `duckdb_` | `rbduckdb_init_duckdb_table_function` → `rbduckdb_init_table_function` |
| Rule 11 | Extern functions must use `rbduckdb_` prefix | `get_struct_table_function` → `rbduckdb_get_struct_table_function` |

## Files Changed

- `ext/duckdb/table_function.{c,h}`
- `ext/duckdb/table_function_bind_info.{c,h}`
- `ext/duckdb/table_function_function_info.{c,h}`
- `ext/duckdb/table_function_init_info.{c,h}`
- `ext/duckdb/table_description.{c,h}`
- `ext/duckdb/duckdb.c` — updated init call sites
- `ext/duckdb/connection.c` — updated `get_struct` call site

## Testing

All 1150 tests pass with 0 failures and 0 errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized internal C API naming conventions for table function components across initialization functions and accessor helpers to improve code organization and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->