### PR TITLE
Fix HACKING.md Rule 10 violations in blob, config, error files

### DIFF
--- a/ext/duckdb/blob.c
+++ b/ext/duckdb/blob.c
@@ -2,7 +2,7 @@
 
 VALUE cDuckDBBlob;
 
-void rbduckdb_init_duckdb_blob(void) {
+void rbduckdb_init_blob(void) {
 #if 0
     VALUE mDuckDB = rb_define_module("DuckDB");
 #endif

--- a/ext/duckdb/blob.h
+++ b/ext/duckdb/blob.h
@@ -1,7 +1,6 @@
 #ifndef RUBY_DUCKDB_BLOB_H
 #define RUBY_DUCKDB_BLOB_H
 
-void rbduckdb_init_duckdb_blob(void);
+void rbduckdb_init_blob(void);
 
 #endif
-

--- a/ext/duckdb/config.c
+++ b/ext/duckdb/config.c
@@ -79,7 +79,7 @@ static VALUE config_set_config(VALUE self, VALUE key, VALUE value) {
     return self;
 }
 
-void rbduckdb_init_duckdb_config(void) {
+void rbduckdb_init_config(void) {
 #if 0
     VALUE mDuckDB = rb_define_module("DuckDB");
 #endif

--- a/ext/duckdb/config.h
+++ b/ext/duckdb/config.h
@@ -9,6 +9,6 @@ typedef struct _rubyDuckDBConfig rubyDuckDBConfig;
 
 rubyDuckDBConfig *get_struct_config(VALUE obj);
 
-void rbduckdb_init_duckdb_config(void);
+void rbduckdb_init_config(void);
 
 #endif

--- a/ext/duckdb/duckdb.c
+++ b/ext/duckdb/duckdb.c
@@ -41,7 +41,7 @@ Init_duckdb_native(void) {
     rb_define_singleton_method(mDuckDB, "library_version", duckdb_s_library_version, 0);
     rb_define_singleton_method(mDuckDB, "vector_size", duckdb_s_vector_size, 0);
 
-    rbduckdb_init_duckdb_error();
+    rbduckdb_init_error();
     rbduckdb_init_database();
     rbduckdb_init_connection();
     rbduckdb_init_result();
@@ -49,9 +49,9 @@ Init_duckdb_native(void) {
     rbduckdb_init_logical_type();
     rbduckdb_init_prepared_statement();
     rbduckdb_init_pending_result();
-    rbduckdb_init_duckdb_blob();
+    rbduckdb_init_blob();
     rbduckdb_init_appender();
-    rbduckdb_init_duckdb_config();
+    rbduckdb_init_config();
     rbduckdb_init_converter();
     rbduckdb_init_extracted_statements();
     rbduckdb_init_instance_cache();

--- a/ext/duckdb/error.c
+++ b/ext/duckdb/error.c
@@ -2,7 +2,7 @@
 
 VALUE eDuckDBError;
 
-void rbduckdb_init_duckdb_error(void) {
+void rbduckdb_init_error(void) {
 #if 0
     VALUE mDuckDB = rb_define_module("DuckDB");
 #endif

--- a/ext/duckdb/error.h
+++ b/ext/duckdb/error.h
@@ -1,8 +1,6 @@
 #ifndef RUBY_DUCKDB_ERROR_H
 #define RUBY_DUCKDB_ERROR_H
 
-void rbduckdb_init_duckdb_error(void);
+void rbduckdb_init_error(void);
 
 #endif
-
-


### PR DESCRIPTION
## Summary

Fix Rule 10 violations from HACKING.md: `rbduckdb_init_*` functions must not contain redundant `duckdb_` segment.

| Old name | New name |
|---|---|
| `rbduckdb_init_duckdb_blob` | `rbduckdb_init_blob` |
| `rbduckdb_init_duckdb_config` | `rbduckdb_init_config` |
| `rbduckdb_init_duckdb_error` | `rbduckdb_init_error` |

**Tests:** 1150 runs, 2333 assertions, 0 failures, 0 errors.