### PR TITLE
Add experimental Connection#append_arrow (Arrow import via append)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 # Unreleased
 - add experimental `DuckDB::Result#arrow_c_stream` returning `DuckDB::ArrowArrayStream` to export a query result as an Arrow C stream (Arrow C Data Interface). The stream can be consumed directly by ruby-polars (`Polars::DataFrame.new(result)`) and red-arrow (`Arrow::RecordBatchReader.import(stream.to_i)`).
+- add experimental `DuckDB::Connection#append_arrow(table, producer)` to import an Arrow producer (any object responding to `#arrow_c_stream`, such as a Polars `DataFrame` or a `DuckDB::Result`) into an existing table, returning the number of rows appended.
 - drop Ruby 3.2.
 - add `DuckDB::TableFunction::InitInfo#max_threads=` (and `#set_max_threads`) to hint DuckDB how many worker threads can execute a custom table function concurrently.
 - add `DuckDB::TableFunction::InitInfo#column_count` to get the number of projected result columns of a custom table function scan.

--- a/README.md
+++ b/README.md
@@ -292,7 +292,23 @@ reader = Arrow::RecordBatchReader.import(result.arrow_c_stream.to_i)
 The consumer takes ownership of the stream's contents, so a result can be
 exported only once; exporting the same result again raises `DuckDB::Error`.
 
-This feature is **experimental**: it is built on DuckDB's unstable Arrow
+In the other direction, `DuckDB::Connection#append_arrow` imports an Arrow
+producer into an existing table. Any object responding to `#arrow_c_stream`
+works as the producer — for example a Polars `DataFrame`, or another
+`DuckDB::Result`:
+
+```ruby
+con.query('CREATE TABLE users (id BIGINT, name VARCHAR)')
+rows = con.append_arrow('users', polars_df) # => number of rows appended
+con.query('SELECT * FROM users').to_a
+```
+
+The producer's columns must line up with the table's columns by count and
+position. DuckDB casts compatible column types (e.g. INTEGER into a BIGINT
+column); a type that cannot be cast raises `DuckDB::Error`. `append_arrow` is
+not transactional — wrap it in your own transaction if you need all-or-nothing.
+
+These features are **experimental**: they are built on DuckDB's unstable Arrow
 C API and may change in any minor release.
 
 Note: [red-arrow-format](https://github.com/apache/arrow/tree/main/ruby/red-arrow-format)

--- a/ext/duckdb/arrow_import.c
+++ b/ext/duckdb/arrow_import.c
@@ -1,0 +1,162 @@
+#include "ruby-duckdb.h"
+
+/*
+ * Internal helpers backing DuckDB::Connection#append_arrow. They consume an
+ * Arrow producer's struct ArrowArrayStream (given by its address) and convert
+ * each chunk into a DuckDB::DataChunk using DuckDB's unstable Arrow C API. The
+ * Ruby layer owns the loop, the appender lifecycle, and error handling; these
+ * primitives only do the raw-pointer / C-API work.
+ */
+
+static VALUE cDuckDBArrowConvertedSchema;
+
+typedef struct {
+    duckdb_arrow_converted_schema converted_schema;
+} rubyDuckDBArrowConvertedSchema;
+
+static void deallocate(void *ctx);
+static VALUE allocate(VALUE klass);
+static size_t memsize(const void *p);
+static void raise_error_data(duckdb_error_data error_data);
+
+static VALUE connection__arrow_converted_schema(VALUE self, VALUE address);
+static VALUE connection__arrow_next_chunk(VALUE self, VALUE address, VALUE converted);
+static VALUE connection__arrow_release(VALUE self, VALUE address);
+
+static const rb_data_type_t arrow_converted_schema_data_type = {
+    "DuckDB/ArrowConvertedSchema",
+    {NULL, deallocate, memsize,},
+    0, 0, RUBY_TYPED_FREE_IMMEDIATELY
+};
+
+static void deallocate(void *ctx) {
+    rubyDuckDBArrowConvertedSchema *p = (rubyDuckDBArrowConvertedSchema *)ctx;
+
+    if (p->converted_schema) {
+        duckdb_destroy_arrow_converted_schema(&(p->converted_schema));
+    }
+    xfree(p);
+}
+
+static VALUE allocate(VALUE klass) {
+    rubyDuckDBArrowConvertedSchema *ctx = xcalloc((size_t)1, sizeof(rubyDuckDBArrowConvertedSchema));
+    return TypedData_Wrap_Struct(klass, &arrow_converted_schema_data_type, ctx);
+}
+
+static size_t memsize(const void *p) {
+    return sizeof(rubyDuckDBArrowConvertedSchema);
+}
+
+static void raise_error_data(duckdb_error_data error_data) {
+    VALUE message;
+
+    if (error_data == NULL) {
+        return;
+    }
+    if (!duckdb_error_data_has_error(error_data)) {
+        duckdb_destroy_error_data(&error_data);
+        return;
+    }
+    message = rb_str_new_cstr(duckdb_error_data_message(error_data));
+    duckdb_destroy_error_data(&error_data);
+    rb_raise(eDuckDBError, "%s", StringValueCStr(message));
+}
+
+static struct ArrowArrayStream *stream_from_address(VALUE address) {
+    return (struct ArrowArrayStream *)(uintptr_t)NUM2ULL(address);
+}
+
+/* :nodoc: */
+static VALUE connection__arrow_converted_schema(VALUE self, VALUE address) {
+    rubyDuckDBConnection *ctx;
+    struct ArrowArrayStream *stream;
+    struct ArrowSchema schema;
+    duckdb_arrow_converted_schema converted_schema = NULL;
+    duckdb_error_data error_data;
+    VALUE obj;
+    rubyDuckDBArrowConvertedSchema *schema_ctx;
+    int rc;
+
+    ctx = rbduckdb_get_struct_connection(self);
+    stream = stream_from_address(address);
+
+    memset(&schema, 0, sizeof(schema));
+    rc = stream->get_schema(stream, &schema);
+    if (rc != 0) {
+        const char *err = stream->get_last_error(stream);
+        rb_raise(eDuckDBError, "failed to get Arrow schema: %s", err ? err : "unknown error");
+    }
+
+    error_data = duckdb_schema_from_arrow(ctx->con, &schema, &converted_schema);
+    if (schema.release != NULL) {
+        schema.release(&schema);
+    }
+    raise_error_data(error_data);
+
+    obj = allocate(cDuckDBArrowConvertedSchema);
+    TypedData_Get_Struct(obj, rubyDuckDBArrowConvertedSchema, &arrow_converted_schema_data_type, schema_ctx);
+    schema_ctx->converted_schema = converted_schema;
+    return obj;
+}
+
+/* :nodoc: */
+static VALUE connection__arrow_next_chunk(VALUE self, VALUE address, VALUE converted) {
+    rubyDuckDBConnection *ctx;
+    rubyDuckDBArrowConvertedSchema *schema_ctx;
+    struct ArrowArrayStream *stream;
+    struct ArrowArray array;
+    duckdb_data_chunk chunk = NULL;
+    duckdb_error_data error_data;
+    int rc;
+
+    ctx = rbduckdb_get_struct_connection(self);
+    TypedData_Get_Struct(converted, rubyDuckDBArrowConvertedSchema, &arrow_converted_schema_data_type, schema_ctx);
+    stream = stream_from_address(address);
+
+    memset(&array, 0, sizeof(array));
+    rc = stream->get_next(stream, &array);
+    if (rc != 0) {
+        const char *err = stream->get_last_error(stream);
+        rb_raise(eDuckDBError, "failed to get next Arrow chunk: %s", err ? err : "unknown error");
+    }
+    /* End of stream: a released array (release == NULL). */
+    if (array.release == NULL) {
+        return Qnil;
+    }
+
+    /* duckdb_data_chunk_from_arrow takes ownership of the array (nulls its
+     * release). On error before that, we still own it and must release it. */
+    error_data = duckdb_data_chunk_from_arrow(ctx->con, &array, schema_ctx->converted_schema, &chunk);
+    if (error_data != NULL && duckdb_error_data_has_error(error_data)) {
+        if (array.release != NULL) {
+            array.release(&array);
+        }
+        raise_error_data(error_data);
+    } else if (error_data != NULL) {
+        duckdb_destroy_error_data(&error_data);
+    }
+
+    return rbduckdb_create_data_chunk(chunk, true);
+}
+
+/* :nodoc: */
+static VALUE connection__arrow_release(VALUE self, VALUE address) {
+    struct ArrowArrayStream *stream = stream_from_address(address);
+
+    if (stream != NULL && stream->release != NULL) {
+        stream->release(stream);
+    }
+    return Qnil;
+}
+
+void rbduckdb_init_arrow_import(void) {
+#if 0
+    VALUE mDuckDB = rb_define_module("DuckDB");
+#endif
+    cDuckDBArrowConvertedSchema = rb_define_class_under(mDuckDB, "ArrowConvertedSchema", rb_cObject);
+    rb_define_alloc_func(cDuckDBArrowConvertedSchema, allocate);
+
+    rb_define_private_method(cDuckDBConnection, "_arrow_converted_schema", connection__arrow_converted_schema, 1);
+    rb_define_private_method(cDuckDBConnection, "_arrow_next_chunk", connection__arrow_next_chunk, 2);
+    rb_define_private_method(cDuckDBConnection, "_arrow_release", connection__arrow_release, 1);
+}

--- a/ext/duckdb/arrow_import.c
+++ b/ext/duckdb/arrow_import.c
@@ -79,6 +79,9 @@ static VALUE connection__arrow_converted_schema(VALUE self, VALUE address) {
 
     ctx = rbduckdb_get_struct_connection(self);
     stream = stream_from_address(address);
+    if (stream == NULL) {
+        rb_raise(eDuckDBError, "Arrow producer returned a NULL stream");
+    }
 
     memset(&schema, 0, sizeof(schema));
     rc = stream->get_schema(stream, &schema);

--- a/ext/duckdb/arrow_import.h
+++ b/ext/duckdb/arrow_import.h
@@ -1,0 +1,6 @@
+#ifndef RUBY_DUCKDB_ARROW_IMPORT_H
+#define RUBY_DUCKDB_ARROW_IMPORT_H
+
+void rbduckdb_init_arrow_import(void);
+
+#endif

--- a/ext/duckdb/data_chunk.c
+++ b/ext/duckdb/data_chunk.c
@@ -44,6 +44,16 @@ rubyDuckDBDataChunk *rbduckdb_get_struct_data_chunk(VALUE obj) {
     return ctx;
 }
 
+VALUE rbduckdb_create_data_chunk(duckdb_data_chunk chunk, bool owned) {
+    VALUE obj = allocate(cDuckDBDataChunk);
+    rubyDuckDBDataChunk *ctx;
+
+    TypedData_Get_Struct(obj, rubyDuckDBDataChunk, &data_chunk_data_type, ctx);
+    ctx->data_chunk = chunk;
+    ctx->owned = owned;
+    return obj;
+}
+
 static VALUE data_chunk_initialize(int argc, VALUE *argv, VALUE self) {
     rubyDuckDBDataChunk *ctx;
     VALUE logical_types;

--- a/ext/duckdb/data_chunk.h
+++ b/ext/duckdb/data_chunk.h
@@ -9,6 +9,7 @@ struct _rubyDuckDBDataChunk {
 typedef struct _rubyDuckDBDataChunk rubyDuckDBDataChunk;
 
 rubyDuckDBDataChunk *rbduckdb_get_struct_data_chunk(VALUE obj);
+VALUE rbduckdb_create_data_chunk(duckdb_data_chunk chunk, bool owned);
 void rbduckdb_init_data_chunk(void);
 
 #endif

--- a/ext/duckdb/duckdb.c
+++ b/ext/duckdb/duckdb.c
@@ -74,4 +74,5 @@ Init_duckdb_native(void) {
     rbduckdb_init_table_description();
 #endif
     rbduckdb_init_arrow_array_stream();
+    rbduckdb_init_arrow_import();
 }

--- a/ext/duckdb/ruby-duckdb.h
+++ b/ext/duckdb/ruby-duckdb.h
@@ -52,6 +52,7 @@
 #include "./table_function.h"
 #include "./table_description.h"
 #include "./arrow_array_stream.h"
+#include "./arrow_import.h"
 
 extern VALUE mDuckDB;
 extern VALUE cDuckDBDatabase;

--- a/lib/duckdb/connection.rb
+++ b/lib/duckdb/connection.rb
@@ -383,7 +383,61 @@ module DuckDB
       register_table_function(tf)
     end
 
+    # [EXPERIMENTAL] Appends an Arrow producer into an existing table.
+    #
+    # Reads +producer+ (any object responding to +#arrow_c_stream+, such as a
+    # ruby-polars +DataFrame+ or a +DuckDB::Result+) as an Arrow C stream and
+    # appends its chunks into the existing table +table+. The producer's Arrow
+    # columns must line up with the table's columns positionally and by count.
+    # DuckDB casts compatible column types (e.g. INTEGER into a BIGINT column);
+    # a type that cannot be cast (e.g. a non-numeric VARCHAR into an INTEGER
+    # column) or a column-count mismatch raises +DuckDB::Error+.
+    #
+    # This is not transactional: a schema mismatch fails before any rows are
+    # written, but a rarer mid-stream failure can leave earlier chunks
+    # appended. Wrap the call in your own transaction for all-or-nothing.
+    #
+    # This API is built on DuckDB's unstable Arrow C API and may change in any
+    # minor release.
+    #
+    # @param table [String] the name of the existing target table
+    # @param producer [#arrow_c_stream] the Arrow producer
+    # @raise [TypeError] if +producer+ does not respond to +#arrow_c_stream+
+    # @return [Integer] the number of rows appended
+    #
+    # @example Load a Polars DataFrame into a table
+    #   con.query('CREATE TABLE t (id INTEGER, name VARCHAR)')
+    #   con.append_arrow('t', polars_df)
+    #
+    def append_arrow(table, producer)
+      unless producer.respond_to?(:arrow_c_stream)
+        raise TypeError, "Arrow producer must respond to #arrow_c_stream, got #{producer.class}"
+      end
+
+      stream = producer.arrow_c_stream # keep the producer's stream alive for the duration
+      address = stream.to_i
+      begin
+        append_arrow_chunks(table, address)
+      ensure
+        _arrow_release(address)
+      end
+    end
+
     private
+
+    # Drives the Arrow stream at +address+ chunk by chunk into +table+,
+    # returning the number of rows appended.
+    def append_arrow_chunks(table, address)
+      converted_schema = _arrow_converted_schema(address)
+      rows = 0
+      appender(table) do |app|
+        while (chunk = _arrow_next_chunk(address, converted_schema))
+          rows += chunk.size
+          app.append_data_chunk(chunk)
+        end
+      end
+      rows
+    end
 
     def run_appender_block(appender, &)
       return appender unless block_given?

--- a/sample/arrow_polars_import.rb
+++ b/sample/arrow_polars_import.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+# Import a Polars DataFrame into a DuckDB table via the Arrow C stream
+# protocol (experimental).
+#
+# DuckDB::Connection#append_arrow reads any Arrow producer (an object
+# responding to #arrow_c_stream, such as a Polars::DataFrame) and appends its
+# chunks into an existing DuckDB table in columnar form — no per-row Ruby
+# object conversion. Once imported, the data can be queried with SQL.
+#
+#   gem install polars-df
+
+require 'duckdb'
+require 'polars-df'
+
+df = Polars::DataFrame.new(
+  {
+    'id' => [1, 2, 3],
+    'name' => %w[Alice Bob Cathy],
+    'score' => [89.5, 72.3, 95.1]
+  }
+)
+
+db = DuckDB::Database.open
+con = db.connect
+
+# The target table must already exist; DuckDB casts compatible column types.
+con.query('CREATE TABLE people (id BIGINT, name VARCHAR, score DOUBLE)')
+
+rows = con.append_arrow('people', df)
+puts "appended #{rows} rows"
+# => appended 3 rows
+
+result = con.query('SELECT name, score FROM people WHERE score > 80 ORDER BY score DESC').to_a
+p result
+# => [["Cathy", 95.1], ["Alice", 89.5]]
+
+con.close
+db.close

--- a/test/duckdb_test/append_arrow_test.rb
+++ b/test/duckdb_test/append_arrow_test.rb
@@ -49,6 +49,13 @@ module DuckDBTest
       assert_raises(DuckDB::Error) { @conn.append_arrow('bad', producer) }
     end
 
+    def test_append_arrow_raises_on_column_count_mismatch
+      @conn.query('CREATE TABLE narrow (id INTEGER)') # source has two columns
+      producer = @conn.query('SELECT * FROM source')
+
+      assert_raises(DuckDB::Error) { @conn.append_arrow('narrow', producer) }
+    end
+
     def test_append_arrow_appends_nothing_for_an_empty_producer
       producer = @conn.query('SELECT * FROM source WHERE id > 100')
 

--- a/test/duckdb_test/append_arrow_test.rb
+++ b/test/duckdb_test/append_arrow_test.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module DuckDBTest
+  class AppendArrowTest < Minitest::Test
+    def setup
+      @db = DuckDB::Database.open
+      @conn = @db.connect
+      @conn.query('CREATE TABLE source (id INTEGER, name VARCHAR)')
+      @conn.query("INSERT INTO source VALUES (1, 'Alice'), (2, 'Bob'), (3, 'Cathy')")
+      @conn.query('CREATE TABLE dest (id INTEGER, name VARCHAR)')
+    end
+
+    def teardown
+      @conn.disconnect
+      @db.close
+    end
+
+    def test_append_arrow_loads_an_arrow_producer_into_an_existing_table
+      producer = @conn.query('SELECT * FROM source ORDER BY id')
+
+      rows = @conn.append_arrow('dest', producer)
+
+      assert_equal 3, rows
+      assert_equal [[1, 'Alice'], [2, 'Bob'], [3, 'Cathy']],
+                   @conn.query('SELECT * FROM dest ORDER BY id').to_a
+    end
+
+    def test_append_arrow_raises_type_error_for_non_producer
+      assert_raises(TypeError) { @conn.append_arrow('dest', 'not a producer') }
+    end
+
+    def test_append_arrow_casts_compatible_column_types
+      @conn.query('CREATE TABLE widened (id BIGINT, name VARCHAR)') # source id is INTEGER
+      producer = @conn.query('SELECT * FROM source ORDER BY id')
+
+      rows = @conn.append_arrow('widened', producer)
+
+      assert_equal 3, rows
+      assert_equal [[1, 'Alice'], [2, 'Bob'], [3, 'Cathy']],
+                   @conn.query('SELECT * FROM widened ORDER BY id').to_a
+    end
+
+    def test_append_arrow_raises_on_incompatible_column_type
+      @conn.query('CREATE TABLE bad (id INTEGER, name INTEGER)') # name 'Alice' cannot cast to INTEGER
+      producer = @conn.query('SELECT * FROM source')
+
+      assert_raises(DuckDB::Error) { @conn.append_arrow('bad', producer) }
+    end
+
+    def test_append_arrow_appends_nothing_for_an_empty_producer
+      producer = @conn.query('SELECT * FROM source WHERE id > 100')
+
+      rows = @conn.append_arrow('dest', producer)
+
+      assert_equal 0, rows
+      assert_equal 0, @conn.query('SELECT COUNT(*) FROM dest').to_a.first.first
+    end
+
+    def test_append_arrow_consumes_a_result_producer_only_once
+      producer = @conn.query('SELECT * FROM source')
+      @conn.append_arrow('dest', producer)
+
+      assert_raises(DuckDB::Error) { @conn.append_arrow('dest', producer) }
+    end
+
+    def test_append_arrow_is_gc_safe
+      @conn.query('CREATE TABLE acc (id INTEGER, name VARCHAR)')
+
+      5.times do
+        @conn.append_arrow('acc', @conn.query('SELECT * FROM source'))
+        GC.start
+      end
+      GC.start
+
+      assert_equal 15, @conn.query('SELECT COUNT(*) FROM acc').to_a.first.first
+    end
+
+    def test_append_arrow_streams_multiple_chunks
+      @conn.query('CREATE TABLE big_src (id INTEGER)')
+      @conn.query('INSERT INTO big_src SELECT * FROM range(5000)') # > one 2048-row chunk
+      @conn.query('CREATE TABLE big_dest (id INTEGER)')
+      producer = @conn.query('SELECT * FROM big_src')
+
+      rows = @conn.append_arrow('big_dest', producer)
+
+      assert_equal 5000, rows
+      assert_equal 5000, @conn.query('SELECT COUNT(*) FROM big_dest').to_a.first.first
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds the import counterpart to `Result#arrow_c_stream` (#1373): `DuckDB::Connection#append_arrow(table, producer)` reads an Arrow producer and appends its data into an existing table.

```ruby
con.query('CREATE TABLE users (id BIGINT, name VARCHAR)')
rows = con.append_arrow('users', polars_df)   # => number of rows appended
con.append_arrow('users', con.query('SELECT * FROM other'))  # Result is also a producer
```

A `producer` is any object responding to `#arrow_c_stream` (ruby-polars `DataFrame`, `DuckDB::Result`, etc.); anything else raises `TypeError`.

## Design

- **No zero-copy scan available.** DuckDB's `arrow_scan`/`arrow_array_scan` are deprecated and the gem builds with `DUCKDB_API_NO_DEPRECATED`. The supported API only converts chunk-by-chunk (`duckdb_schema_from_arrow` → `duckdb_data_chunk_from_arrow`), so import **materializes via append**, not a live view.
- **Minimize-C split.** Ruby owns the loop, the appender lifecycle (reusing `#appender` + `#append_data_chunk`), and error handling. Only thin private C primitives do raw-pointer / unstable-C-API work: `_arrow_converted_schema`, `_arrow_next_chunk` (→ `DataChunk` | `nil`), `_arrow_release`. Mirrors the existing `_chunk_stream`/`each` and `_append_data_chunk` patterns. No Fiddle.
- **Stream lifetime.** The producer's stream is driven in place and released once via the C Data Interface's idempotent `release` (it nulls itself), so the producer's own GC won't double-release — no struct move-out needed.
- **Type handling.** The appender casts compatible column types (e.g. INTEGER → BIGINT) via `VectorOperations::DefaultTryCast`; an impossible cast or column-count mismatch raises `DuckDB::Error`.
- **Not transactional** (documented); a schema/cast error fails before any write, rarer mid-stream errors may leave earlier chunks appended.
- Experimental — tracks DuckDB's unstable Arrow C API.

## Test plan

- `test/duckdb_test/append_arrow_test.rb` (8 tests) uses `DuckDB::Result` as a self-contained producer (no external gems): round-trip into a matching table, compatible-type cast, incompatible-type error, `TypeError` for non-producers, empty producer, multi-chunk streaming (5000 rows), one-shot consumption, GC safety.
- `sample/arrow_polars_import.rb` verified end-to-end against ruby-polars 0.26.0.
- Full suite: 1167 runs, 0 failures. RuboCop: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added experimental `DuckDB::Connection#append_arrow(table, producer)` to append Arrow C stream data into an existing table and return the number of rows appended (supports chunked/streaming input).

* **Documentation**
  * Updated `CHANGELOG.md` and `README.md` with usage guidance, producer/column alignment requirements, type casting behavior, and notes about non-transactional operation.

* **Tests**
  * Added end-to-end coverage for success cases, type/column mismatch errors, empty producers, single-consumption semantics, and GC-safety/streaming behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->