### PR TITLE
Fix method redefined warnings for ScalarFunction/AggregateFunction name=

### DIFF
--- a/ext/duckdb/aggregate_function.c
+++ b/ext/duckdb/aggregate_function.c
@@ -737,7 +737,6 @@ void rbduckdb_init_aggregate_function(void) {
     rb_define_alloc_func(cDuckDBAggregateFunction, allocate);
     rb_define_method(cDuckDBAggregateFunction, "initialize", aggregate_function_initialize, 0);
     rb_define_method(cDuckDBAggregateFunction, "set_name", aggregate_function_set_name, 1);
-    rb_define_method(cDuckDBAggregateFunction, "name=", aggregate_function_set_name, 1);
     rb_define_private_method(cDuckDBAggregateFunction, "_set_return_type", aggregate_function__set_return_type, 1);
     rb_define_private_method(cDuckDBAggregateFunction, "_add_parameter", aggregate_function__add_parameter, 1);
     rb_define_private_method(cDuckDBAggregateFunction, "_set_init", aggregate_function__set_init, 0);

--- a/ext/duckdb/scalar_function.c
+++ b/ext/duckdb/scalar_function.c
@@ -483,7 +483,6 @@ void rbduckdb_init_scalar_function(void) {
     rb_define_alloc_func(cDuckDBScalarFunction, allocate);
     rb_define_method(cDuckDBScalarFunction, "initialize", scalar_function_initialize, 0);
     rb_define_method(cDuckDBScalarFunction, "set_name", scalar_function_set_name, 1);
-    rb_define_method(cDuckDBScalarFunction, "name=", scalar_function_set_name, 1);
     rb_define_private_method(cDuckDBScalarFunction, "_set_return_type", scalar_function__set_return_type, 1);
     rb_define_private_method(cDuckDBScalarFunction, "_set_varargs", scalar_function__set_varargs, 1);
     rb_define_private_method(cDuckDBScalarFunction, "_set_special_handling", scalar_function__set_special_handling, 0);


### PR DESCRIPTION
## Summary

Loading the gem with warnings enabled emitted:

```
lib/duckdb/scalar_function.rb:89: warning: method redefined; discarding old name=
lib/duckdb/aggregate_function.rb:60: warning: method redefined; discarding old name=
```

The C extensions defined `name=` as an alias of `set_name`
(`rb_define_method(..., "name=", ...)`), while the Ruby wrappers redefine
`name=` to add String coercion (`set_name(value.to_s)`). The Ruby
redefinition over the C definition triggered the warnings.

This drops the redundant C `name=` definitions. `set_name` remains the C
primitive, and the Ruby wrapper is the sole public `name=`.

## Test plan

- [x] `rake compile`
- [x] No `name=` redefinition warnings on load (`ruby -w -Ilib -e 'require "duckdb"'`)
- [x] Scalar/aggregate function tests pass (133 runs, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Aggregate and scalar function APIs have been updated. The `name=` setter syntax has been replaced with the `set_name()` method for setting function names. Existing code will need to be updated accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->