### PR TITLE
Add append_uuid and bind_uuid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ All notable changes to this project will be documented in this file.
 - add `DuckDB::TableFunction::InitInfo#max_threads=` (and `#set_max_threads`) to hint DuckDB how many worker threads can execute a custom table function concurrently.
 - add `DuckDB::TableFunction::InitInfo#column_count` to get the number of projected result columns of a custom table function scan.
 - add `DuckDB::TableFunction::InitInfo#column_index` to get the source column index of a given projected result column of a custom table function scan.
+- add `DuckDB::Appender#append_uuid(value)` to append a UUID value to a `UUID` column. `value` must be a String in canonical UUID format (`xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`).
+- add `DuckDB::PreparedStatement#bind_uuid(index, value)` to bind a UUID parameter. `value` must be a String in canonical UUID format.
 
 # 1.5.3.0 - 2026-05-24
 - bump up DuckDB 1.5.3 on CI.

--- a/ext/duckdb/appender.c
+++ b/ext/duckdb/appender.c
@@ -35,6 +35,7 @@ static VALUE appender__append_time(VALUE self, VALUE hour, VALUE min, VALUE sec,
 static VALUE appender__append_timestamp(VALUE self, VALUE year, VALUE month, VALUE day, VALUE hour, VALUE min, VALUE sec, VALUE micros);
 static VALUE appender__append_hugeint(VALUE self, VALUE lower, VALUE upper);
 static VALUE appender__append_uhugeint(VALUE self, VALUE lower, VALUE upper);
+static VALUE appender__append_uuid(VALUE self, VALUE val);
 static VALUE appender__append_value(VALUE self, VALUE val);
 static VALUE appender__append_data_chunk(VALUE self, VALUE chunk);
 static VALUE appender__append_default_to_chunk(VALUE self, VALUE chunk, VALUE col, VALUE row);
@@ -454,6 +455,21 @@ static VALUE appender__append_uhugeint(VALUE self, VALUE lower, VALUE upper) {
 }
 
 /* :nodoc: */
+static VALUE appender__append_uuid(VALUE self, VALUE val) {
+    rubyDuckDBAppender *ctx;
+    duckdb_uhugeint uhugeint;
+    duckdb_value uuid_val;
+    duckdb_state state;
+
+    TypedData_Get_Struct(self, rubyDuckDBAppender, &appender_data_type, ctx);
+    rbduckdb_uuid_str_to_uhugeint(val, &uhugeint);
+    uuid_val = duckdb_create_uuid(uhugeint);
+    state = duckdb_append_value(ctx->appender, uuid_val);
+    duckdb_destroy_value(&uuid_val);
+    return state_to_rbool(state);
+}
+
+/* :nodoc: */
 static VALUE appender__append_value(VALUE self, VALUE val) {
     rubyDuckDBAppender *ctx;
     rubyDuckDBValue *value_ctx;
@@ -578,6 +594,7 @@ void rbduckdb_init_appender(void) {
     rb_define_private_method(cDuckDBAppender, "_append_timestamp", appender__append_timestamp, 7);
     rb_define_private_method(cDuckDBAppender, "_append_hugeint", appender__append_hugeint, 2);
     rb_define_private_method(cDuckDBAppender, "_append_uhugeint", appender__append_uhugeint, 2);
+    rb_define_private_method(cDuckDBAppender, "_append_uuid", appender__append_uuid, 1);
     rb_define_private_method(cDuckDBAppender, "_append_value", appender__append_value, 1);
     rb_define_private_method(cDuckDBAppender, "_append_data_chunk", appender__append_data_chunk, 1);
     rb_define_private_method(cDuckDBAppender, "_append_default_to_chunk", appender__append_default_to_chunk, 3);

--- a/ext/duckdb/converter.h
+++ b/ext/duckdb/converter.h
@@ -19,6 +19,7 @@ extern ID id__decimal_to_unscaled;
 VALUE rbduckdb_uuid_to_ruby(duckdb_hugeint h);
 VALUE rbduckdb_uuid_uhugeint_to_ruby(duckdb_uhugeint h);
 void rbduckdb_uuid_str_to_hugeint(VALUE uuid_str, duckdb_hugeint *out);
+void rbduckdb_uuid_str_to_uhugeint(VALUE uuid_str, duckdb_uhugeint *out);
 VALUE rbduckdb_interval_to_ruby(duckdb_interval i);
 VALUE rbduckdb_hugeint_to_ruby(duckdb_hugeint h);
 VALUE rbduckdb_uhugeint_to_ruby(duckdb_uhugeint h);

--- a/ext/duckdb/conveter.c
+++ b/ext/duckdb/conveter.c
@@ -153,22 +153,21 @@ static int hex_nibble(unsigned char c)
 
 /*
  * Parse a canonical UUID string ("xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx") into
- * a duckdb_hugeint. Returns true on success, false on invalid input.
+ * two uint64_t halves. Returns true on success, false on invalid input.
  *
  * Iterates the 36-character string, skipping the four dash positions. The 32
- * hex nibbles are accumulated directly into two uint64_t halves (hi, lo) with
- * no bignum arithmetic or intermediate allocation. The sign-bit flip is applied
- * to hi before storing in upper, matching DuckDB's internal UUID representation.
+ * hex nibbles are accumulated directly into hi (upper 64 bits) and lo (lower
+ * 64 bits) with no bignum arithmetic or intermediate allocation.
  */
-static bool uuid_str_to_hugeint(const char *str, long len, duckdb_hugeint *out)
+static bool parse_uuid_string(const char *str, long len, uint64_t *hi, uint64_t *lo)
 {
-    // Expected format: 8-4-4-4-12 = 36 characters with dashes at fixed positions
     if (len != 36 ||
         str[8] != '-' || str[13] != '-' || str[18] != '-' || str[23] != '-') {
         return false;
     }
 
-    uint64_t hi = 0, lo = 0;
+    *hi = 0;
+    *lo = 0;
     int nibble_idx = 0;
 
     for (int string_idx = 0; string_idx < 36; string_idx++) {
@@ -176,13 +175,27 @@ static bool uuid_str_to_hugeint(const char *str, long len, duckdb_hugeint *out)
         int nib = hex_nibble((unsigned char)str[string_idx]);
         if (nib < 0) return false;
         if (nibble_idx < 16) {
-            hi = (hi << 4) | (uint64_t)nib;
+            *hi = (*hi << 4) | (uint64_t)nib;
         } else {
-            lo = (lo << 4) | (uint64_t)nib;
+            *lo = (*lo << 4) | (uint64_t)nib;
         }
         nibble_idx++;
     }
 
+    return true;
+}
+
+/*
+ * Parse a canonical UUID string ("xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx") into
+ * a duckdb_hugeint. Returns true on success, false on invalid input.
+ *
+ * The sign-bit flip is applied to hi before storing in upper, matching
+ * DuckDB's internal UUID representation.
+ */
+static bool uuid_str_to_hugeint(const char *str, long len, duckdb_hugeint *out)
+{
+    uint64_t hi, lo;
+    if (!parse_uuid_string(str, len, &hi, &lo)) return false;
     // Apply the sign-bit flip to match DuckDB's internal UUID representation
     out->upper = (int64_t)(hi ^ DUCKDB_UUID_SIGN_BIT);
     out->lower = lo;
@@ -212,19 +225,9 @@ void rbduckdb_uuid_str_to_uhugeint(VALUE uuid_str, duckdb_uhugeint *out)
     StringValue(uuid_str);
     const char *str = RSTRING_PTR(uuid_str);
     long len = RSTRING_LEN(uuid_str);
-    if (len != 36 ||
-        str[8] != '-' || str[13] != '-' || str[18] != '-' || str[23] != '-') {
+    uint64_t hi, lo;
+    if (!parse_uuid_string(str, len, &hi, &lo)) {
         rb_raise(rb_eArgError, "Invalid UUID format: %"PRIsVALUE, uuid_str);
-    }
-    uint64_t hi = 0, lo = 0;
-    int nibble_idx = 0;
-    for (int string_idx = 0; string_idx < 36; string_idx++) {
-        if (string_idx == 8 || string_idx == 13 || string_idx == 18 || string_idx == 23) continue;
-        int nib = hex_nibble((unsigned char)str[string_idx]);
-        if (nib < 0) rb_raise(rb_eArgError, "Invalid UUID format: %"PRIsVALUE, uuid_str);
-        if (nibble_idx < 16) hi = (hi << 4) | (uint64_t)nib;
-        else lo = (lo << 4) | (uint64_t)nib;
-        nibble_idx++;
     }
     out->upper = hi;
     out->lower = lo;

--- a/ext/duckdb/conveter.c
+++ b/ext/duckdb/conveter.c
@@ -203,6 +203,33 @@ void rbduckdb_uuid_str_to_hugeint(VALUE uuid_str, duckdb_hugeint *out)
     }
 }
 
+/*
+ * Ruby-callable wrapper: parse a UUID string VALUE into a duckdb_uhugeint
+ * (no sign-bit flip), raising ArgumentError on invalid input.
+ */
+void rbduckdb_uuid_str_to_uhugeint(VALUE uuid_str, duckdb_uhugeint *out)
+{
+    StringValue(uuid_str);
+    const char *str = RSTRING_PTR(uuid_str);
+    long len = RSTRING_LEN(uuid_str);
+    if (len != 36 ||
+        str[8] != '-' || str[13] != '-' || str[18] != '-' || str[23] != '-') {
+        rb_raise(rb_eArgError, "Invalid UUID format: %"PRIsVALUE, uuid_str);
+    }
+    uint64_t hi = 0, lo = 0;
+    int nibble_idx = 0;
+    for (int string_idx = 0; string_idx < 36; string_idx++) {
+        if (string_idx == 8 || string_idx == 13 || string_idx == 18 || string_idx == 23) continue;
+        int nib = hex_nibble((unsigned char)str[string_idx]);
+        if (nib < 0) rb_raise(rb_eArgError, "Invalid UUID format: %"PRIsVALUE, uuid_str);
+        if (nibble_idx < 16) hi = (hi << 4) | (uint64_t)nib;
+        else lo = (lo << 4) | (uint64_t)nib;
+        nibble_idx++;
+    }
+    out->upper = hi;
+    out->lower = lo;
+}
+
 VALUE rbduckdb_interval_to_ruby(duckdb_interval i) {
     return rb_funcall(mDuckDBConverter, id__to_interval_from_vector, 3,
                       INT2NUM(i.months),

--- a/ext/duckdb/prepared_statement.c
+++ b/ext/duckdb/prepared_statement.c
@@ -38,6 +38,7 @@ static VALUE prepared_statement__bind_timestamp_tz(VALUE self, VALUE vidx, VALUE
 static VALUE prepared_statement__bind_interval(VALUE self, VALUE vidx, VALUE months, VALUE days, VALUE micros);
 static VALUE prepared_statement__bind_hugeint(VALUE self, VALUE vidx, VALUE lower, VALUE upper);
 static VALUE prepared_statement__bind_uhugeint(VALUE self, VALUE vidx, VALUE lower, VALUE upper);
+static VALUE prepared_statement__bind_uuid(VALUE self, VALUE vidx, VALUE val);
 static VALUE prepared_statement__bind_decimal(VALUE self, VALUE vidx, VALUE lower, VALUE upper, VALUE width, VALUE scale);
 static VALUE prepared_statement__bind_value(VALUE self, VALUE vidx, VALUE val);
 
@@ -559,6 +560,25 @@ static VALUE prepared_statement__bind_decimal(VALUE self, VALUE vidx, VALUE lowe
 }
 
 /* :nodoc: */
+static VALUE prepared_statement__bind_uuid(VALUE self, VALUE vidx, VALUE val) {
+    rubyDuckDBPreparedStatement *ctx;
+    duckdb_uhugeint uhugeint;
+    duckdb_value uuid_val;
+    duckdb_state state;
+    idx_t idx = check_index(vidx);
+
+    TypedData_Get_Struct(self, rubyDuckDBPreparedStatement, &prepared_statement_data_type, ctx);
+    rbduckdb_uuid_str_to_uhugeint(val, &uhugeint);
+    uuid_val = duckdb_create_uuid(uhugeint);
+    state = duckdb_bind_value(ctx->prepared_statement, idx, uuid_val);
+    duckdb_destroy_value(&uuid_val);
+    if (state == DuckDBError) {
+        rb_raise(eDuckDBError, "fail to bind %llu parameter", (unsigned long long)idx);
+    }
+    return self;
+}
+
+/* :nodoc: */
 static VALUE prepared_statement__bind_value(VALUE self, VALUE vidx, VALUE val) {
     rubyDuckDBPreparedStatement *ctx;
     rubyDuckDBValue *val_ctx;
@@ -617,6 +637,7 @@ void rbduckdb_init_prepared_statement(void) {
     rb_define_private_method(cDuckDBPreparedStatement, "_bind_interval", prepared_statement__bind_interval, 4);
     rb_define_private_method(cDuckDBPreparedStatement, "_bind_hugeint", prepared_statement__bind_hugeint, 3);
     rb_define_private_method(cDuckDBPreparedStatement, "_bind_uhugeint", prepared_statement__bind_uhugeint, 3);
+    rb_define_private_method(cDuckDBPreparedStatement, "_bind_uuid", prepared_statement__bind_uuid, 2);
     rb_define_private_method(cDuckDBPreparedStatement, "_bind_decimal", prepared_statement__bind_decimal, 5);
     rb_define_private_method(cDuckDBPreparedStatement, "_bind_value", prepared_statement__bind_value, 2);
 }

--- a/lib/duckdb/appender.rb
+++ b/lib/duckdb/appender.rb
@@ -558,6 +558,29 @@ module DuckDB
       raise_appender_error('failed to append_uhugeint')
     end
 
+    # :call-seq:
+    #   appender.append_uuid(val) -> self
+    #
+    # Appends a UUID value to the current row in the appender.
+    # +val+ must be a String in canonical UUID format
+    # (<tt>xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx</tt>).
+    # Raises ArgumentError if +val+ is not a valid UUID string.
+    #
+    #   require 'duckdb'
+    #   db = DuckDB::Database.open
+    #   con = db.connect
+    #   con.query('CREATE TABLE uuids (id UUID)')
+    #   appender = con.appender('uuids')
+    #   appender
+    #     .append_uuid('550e8400-e29b-41d4-a716-446655440000')
+    #     .end_row
+    #     .flush
+    def append_uuid(value)
+      return self if _append_uuid(value)
+
+      raise_appender_error('failed to append_uuid')
+    end
+
     # call-seq:
     #   appender.append_date(val) -> self
     #

--- a/lib/duckdb/prepared_statement.rb
+++ b/lib/duckdb/prepared_statement.rb
@@ -193,6 +193,23 @@ module DuckDB
       _bind_uhugeint(index, lower, upper)
     end
 
+    # binds i-th parameter with a UUID value.
+    # The first argument is the index of the parameter (1-based).
+    # The second argument must be a String in canonical UUID format
+    # (<tt>xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx</tt>).
+    # Raises ArgumentError if the value is not a valid UUID string.
+    #
+    #   require 'duckdb'
+    #   db = DuckDB::Database.open
+    #   con = db.connect
+    #   con.query('CREATE TABLE uuids (id UUID)')
+    #   stmt = DuckDB::PreparedStatement.new(con, 'INSERT INTO uuids(id) VALUES ($1)')
+    #   stmt.bind_uuid(1, '550e8400-e29b-41d4-a716-446655440000')
+    #   stmt.execute
+    def bind_uuid(index, value)
+      _bind_uuid(index, value)
+    end
+
     # binds i-th parameter with SQL prepared statement.
     # The first argument is index of parameter.
     # The index of first parameter is 1 not 0.

--- a/test/duckdb_test/appender_test.rb
+++ b/test/duckdb_test/appender_test.rb
@@ -451,6 +451,12 @@ module DuckDBTest
       assert_equal('The argument `18.555` must be Integer.', e.message)
     end
 
+    def test_append_uuid
+      assert_duckdb_appender('550e8400-e29b-41d4-a716-446655440000', 'UUID') do |appender|
+        appender.append_uuid('550e8400-e29b-41d4-a716-446655440000')
+      end
+    end
+
     def test_append_varchar
       assert_duckdb_appender('foobarbaz', 'VARCHAR') { |a| a.append_varchar('foobarbaz') }
     end

--- a/test/duckdb_test/appender_test.rb
+++ b/test/duckdb_test/appender_test.rb
@@ -459,6 +459,7 @@ module DuckDBTest
 
     def test_append_uuid_returns_self
       create_appender('col UUID')
+
       assert_same @appender, @appender.append_uuid('550e8400-e29b-41d4-a716-446655440000')
     ensure
       safe_drop_table

--- a/test/duckdb_test/appender_test.rb
+++ b/test/duckdb_test/appender_test.rb
@@ -457,6 +457,20 @@ module DuckDBTest
       end
     end
 
+    def test_append_uuid_returns_self
+      create_appender('col UUID')
+      assert_same @appender, @appender.append_uuid('550e8400-e29b-41d4-a716-446655440000')
+    ensure
+      safe_drop_table
+    end
+
+    def test_append_uuid_with_invalid_uuid_string
+      create_appender('col UUID')
+      assert_raises(ArgumentError) { @appender.append_uuid('not-a-uuid') }
+    ensure
+      safe_drop_table
+    end
+
     def test_append_varchar
       assert_duckdb_appender('foobarbaz', 'VARCHAR') { |a| a.append_varchar('foobarbaz') }
     end

--- a/test/duckdb_test/prepared_statement_test.rb
+++ b/test/duckdb_test/prepared_statement_test.rb
@@ -465,6 +465,7 @@ module DuckDBTest
 
     def test_bind_uuid_returns_self
       stmt = DuckDB::PreparedStatement.new(@con, 'SELECT $1::UUID')
+
       assert_same stmt, stmt.bind_uuid(1, '550e8400-e29b-41d4-a716-446655440000')
     end
 

--- a/test/duckdb_test/prepared_statement_test.rb
+++ b/test/duckdb_test/prepared_statement_test.rb
@@ -449,6 +449,30 @@ module DuckDBTest
       assert_equal(value, stmt.execute.each.first[0])
     end
 
+    def test_bind_uuid
+      uuid = '550e8400-e29b-41d4-a716-446655440000'
+      @con.query('CREATE TABLE uuids (id UUID)')
+
+      stmt = DuckDB::PreparedStatement.new(@con, 'INSERT INTO uuids(id) VALUES ($1)')
+      stmt.bind_uuid(1, uuid)
+      stmt.execute
+
+      stmt = DuckDB::PreparedStatement.new(@con, 'SELECT * FROM uuids WHERE id = $1')
+      stmt.bind_uuid(1, uuid)
+
+      assert_equal(uuid, stmt.execute.each.first[0])
+    end
+
+    def test_bind_uuid_returns_self
+      stmt = DuckDB::PreparedStatement.new(@con, 'SELECT $1::UUID')
+      assert_same stmt, stmt.bind_uuid(1, '550e8400-e29b-41d4-a716-446655440000')
+    end
+
+    def test_bind_uuid_with_invalid_uuid_string
+      stmt = DuckDB::PreparedStatement.new(@con, 'SELECT $1::UUID')
+      assert_raises(ArgumentError) { stmt.bind_uuid(1, 'not-a-uuid') }
+    end
+
     def test_bind_float
       stmt = DuckDB::PreparedStatement.new(@con, 'SELECT * FROM a WHERE col_real = $1')
 


### PR DESCRIPTION
## Summary

Add `DuckDB::Appender#append_uuid` and `DuckDB::PreparedStatement#bind_uuid` for type-correct UUID writes.

## Changes

- **`ext/duckdb/conveter.c`**: add `rbduckdb_uuid_str_to_uhugeint()` — parses a 36-char hyphenated UUID string into `duckdb_uhugeint` (no sign-bit flip), raising `ArgumentError` on invalid input.
- **`ext/duckdb/appender.c`**: add `_append_uuid` — uses `duckdb_create_uuid` + `duckdb_append_value` for type-correct UUID appending.
- **`lib/duckdb/appender.rb`**: add public `append_uuid(value)`.
- **`ext/duckdb/prepared_statement.c`**: add `_bind_uuid` — uses `duckdb_create_uuid` + `duckdb_bind_value`.
- **`lib/duckdb/prepared_statement.rb`**: add public `bind_uuid(index, value)`.
- **Tests**: roundtrip, returns-self, invalid-input for both methods.
- **CHANGELOG**: updated.

## Interface

```ruby
# Appender
appender.append_uuid('550e8400-e29b-41d4-a716-446655440000')

# PreparedStatement
stmt.bind_uuid(1, '550e8400-e29b-41d4-a716-446655440000')
```

Both methods accept a `String` in canonical UUID format (`xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`) and raise `ArgumentError` on invalid input. The generic `append` / `bind` methods continue to route all strings through varchar — UUID strings require explicit `append_uuid` / `bind_uuid` calls.

## Notes

- Uses `duckdb_create_uuid` (available since DuckDB 1.2.0, well below the gem's 1.4.0 minimum).
- No version guard needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `append_uuid(value)` to `DuckDB::Appender` for appending UUIDs using the canonical UUID string format.
  * Added `bind_uuid(index, value)` to `DuckDB::PreparedStatement` to bind UUID parameters using the canonical UUID string format.
* **Tests**
  * Added coverage for successful UUID append/bind, method chaining return values, and `ArgumentError` on invalid UUID strings.
* **Documentation**
  * Updated the changelog’s **Unreleased** section with experimental notes for the new UUID appender and binder APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->