### PR TITLE
Add DuckDB::TableFunction::InitInfo#column_index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 - drop Ruby 3.2.
 - add `DuckDB::TableFunction::InitInfo#max_threads=` (and `#set_max_threads`) to hint DuckDB how many worker threads can execute a custom table function concurrently.
 - add `DuckDB::TableFunction::InitInfo#column_count` to get the number of projected result columns of a custom table function scan.
+- add `DuckDB::TableFunction::InitInfo#column_index` to get the source column index of a given projected result column of a custom table function scan.
 
 # 1.5.3.0 - 2026-05-24
 - bump up DuckDB 1.5.3 on CI.

--- a/ext/duckdb/table_function_init_info.c
+++ b/ext/duckdb/table_function_init_info.c
@@ -8,6 +8,7 @@ static size_t memsize(const void *p);
 static VALUE table_function_init_info_set_error(VALUE self, VALUE error);
 static VALUE table_function_init_info_set_max_threads(VALUE self, VALUE max_threads);
 static VALUE table_function_init_info_column_count(VALUE self);
+static VALUE table_function_init_info_column_index(VALUE self, VALUE index);
 
 static const rb_data_type_t init_info_data_type = {
     "DuckDB/TableFunctionInitInfo",
@@ -95,6 +96,25 @@ static VALUE table_function_init_info_column_count(VALUE self) {
     return ULL2NUM(duckdb_init_get_column_count(ctx->info));
 }
 
+/*
+ * call-seq:
+ *   init_info.column_index(index) -> Integer
+ *
+ * Returns the column index of the projected result column at +index+
+ * (0 <= +index+ < column_count). Without projection pushdown the projected
+ * columns mirror the columns added in the bind callback, so this returns
+ * +index+ itself.
+ *
+ *   init_info.column_index(0) # => 0
+ */
+static VALUE table_function_init_info_column_index(VALUE self, VALUE index) {
+    rubyDuckDBInitInfo *ctx;
+
+    TypedData_Get_Struct(self, rubyDuckDBInitInfo, &init_info_data_type, ctx);
+
+    return ULL2NUM(duckdb_init_get_column_index(ctx->info, NUM2ULL(index)));
+}
+
 void rbduckdb_init_table_function_init_info(void) {
 #if 0
     VALUE mDuckDB = rb_define_module("DuckDB");
@@ -106,4 +126,5 @@ void rbduckdb_init_table_function_init_info(void) {
     rb_define_method(cDuckDBTableFunctionInitInfo, "set_max_threads", table_function_init_info_set_max_threads, 1);
     rb_define_method(cDuckDBTableFunctionInitInfo, "max_threads=", table_function_init_info_set_max_threads, 1);
     rb_define_method(cDuckDBTableFunctionInitInfo, "column_count", table_function_init_info_column_count, 0);
+    rb_define_method(cDuckDBTableFunctionInitInfo, "column_index", table_function_init_info_column_index, 1);
 }

--- a/test/duckdb_test/table_function/init_info_test.rb
+++ b/test/duckdb_test/table_function/init_info_test.rb
@@ -108,6 +108,38 @@ module DuckDBTest
       assert_equal 2, observed_column_count
     end
 
+    def test_init_info_column_index
+      table_function = DuckDB::TableFunction.new
+      table_function.name = 'test_init_column_index'
+
+      table_function.bind do |bind_info|
+        bind_info.add_result_column('id', DuckDB::LogicalType::BIGINT)
+        bind_info.add_result_column('value', DuckDB::LogicalType::BIGINT)
+      end
+
+      observed_column_indexes = nil
+      table_function.init do |init_info|
+        observed_column_indexes = [init_info.column_index(0), init_info.column_index(1)]
+      end
+
+      done = false
+      table_function.execute do |_func_info, output|
+        if done
+          output.size = 0
+        else
+          output.set_value(0, 0, 1)
+          output.set_value(1, 0, 10)
+          output.size = 1
+          done = true
+        end
+      end
+
+      @connection.register_table_function(table_function)
+      @connection.query('SELECT * FROM test_init_column_index()').each.to_a
+
+      assert_equal [0, 1], observed_column_indexes
+    end
+
     def test_init_info_alias
       assert_same DuckDB::TableFunction::InitInfo, DuckDB::InitInfo
     end


### PR DESCRIPTION
GitHub: GH-1123

Wrap duckdb_init_get_column_index() C-API to expose which source column each projected position maps to. ref: https://duckdb.org/docs/stable/clients/c/api.html#duckdb_init_get_column_index

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `column_index()` method to retrieve the source column index for projected result columns in custom table function scans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->