### PR TITLE
Bump DuckDB on CI to 1.5.4 and 1.4.5

### DIFF
--- a/.github/workflows/test_on_macos.yml
+++ b/.github/workflows/test_on_macos.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby: ['3.3.11', '3.4.9', '4.0.5', 'head']
-        duckdb: ['1.4.4', '1.5.3']
+        duckdb: ['1.4.5', '1.5.4']
     env:
       # Released Bundler is broken on ruby-head due to ruby/ruby#16895.
       # Use Ruby's bundled Bundler until rubygems/rubygems#9529 is released.
@@ -54,8 +54,8 @@ jobs:
       run: |
         curl -OL https://github.com/duckdb/duckdb/releases/download/v${DUCKDB_VERSION}/libduckdb-osx-universal.zip
         case "${DUCKDB_VERSION}" in
-          "1.5.3") EXPECTED_SHA256="386f8e8b3b4bc8d128762327121e22065ce45f2ee55ef1b1f412ce11e0e6c51f" ;;
-          "1.4.4") EXPECTED_SHA256="5e6d79f5fb86bbd4f24d59cee3bc38f113d1433761df35337e3c01c62eeafe26" ;;
+          "1.5.4") EXPECTED_SHA256="3f3c52970ad1407ec5037062e1a5e575b24bd5b993c889f89fe5876eff47782c" ;;
+          "1.4.5") EXPECTED_SHA256="33f840404e3b420600936d5b59d342680aa4af41cc06d9a5589711e43cd75766" ;;
           *) echo "No known SHA256 for DuckDB v${DUCKDB_VERSION}"; exit 1 ;;
         esac
         echo "${EXPECTED_SHA256}  libduckdb-osx-universal.zip" | shasum -a 256 -c

--- a/.github/workflows/test_on_ubuntu.yml
+++ b/.github/workflows/test_on_ubuntu.yml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby: ['3.3.11', '3.4.9', '4.0.5', 'head']
-        duckdb: ['1.4.4', '1.5.3']
+        duckdb: ['1.4.5', '1.5.4']
     env:
       # Released Bundler is broken on ruby-head due to ruby/ruby#16895.
       # Use Ruby's bundled Bundler until rubygems/rubygems#9529 is released.
@@ -67,8 +67,8 @@ jobs:
       run: |
         curl -OL https://github.com/duckdb/duckdb/releases/download/v${DUCKDB_VERSION}/libduckdb-linux-amd64.zip
         case "${DUCKDB_VERSION}" in
-          "1.5.3") EXPECTED_SHA256="0a926eba5bce0abc0010f4b9109133e4440cb74e97bd10fd2d0fc2a721621b05" ;;
-          "1.4.4") EXPECTED_SHA256="09cc288295964d897b47665d1898e16e8ef176cae9ea615797fc136eae15bd5d" ;;
+          "1.5.4") EXPECTED_SHA256="838d98a85e697bab9935010c88a8c67d3312ccedcab4cb4a0ba01da65113bb70" ;;
+          "1.4.5") EXPECTED_SHA256="291efb2e127492ec5b652fb728a29587837763dac1d96bf211dc6429f10149b5" ;;
           *) echo "No known SHA256 for DuckDB v${DUCKDB_VERSION}"; exit 1 ;;
         esac
         echo "${EXPECTED_SHA256}  libduckdb-linux-amd64.zip" | sha256sum -c

--- a/.github/workflows/test_on_windows.yml
+++ b/.github/workflows/test_on_windows.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby: ['3.3.10', '3.4.8', '4.0.5', 'ucrt', 'mingw', 'mswin', 'head']
-        duckdb: ['1.4.4', '1.5.3']
+        duckdb: ['1.4.5', '1.5.4']
     env:
       # Released Bundler is broken on ruby-head due to ruby/ruby#16895.
       # Use Ruby's bundled Bundler until rubygems/rubygems#9529 is released.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 # Unreleased
+- bump up DuckDB 1.5.4 and 1.4.5 on CI.
 - add experimental `DuckDB::Result#arrow_c_stream` returning `DuckDB::ArrowArrayStream` to export a query result as an Arrow C stream (Arrow C Data Interface). The stream can be consumed directly by ruby-polars (`Polars::DataFrame.new(result)`) and red-arrow (`Arrow::RecordBatchReader.import(stream.to_i)`).
 - add experimental `DuckDB::Connection#append_arrow(table, producer)` to import an Arrow producer (any object responding to `#arrow_c_stream`, such as a Polars `DataFrame` or a `DuckDB::Result`) into an existing table, returning the number of rows appended.
 - drop Ruby 3.2.


### PR DESCRIPTION
## Summary
- Bump DuckDB versions on CI from 1.5.3/1.4.4 to 1.5.4/1.4.5.
- Update the test matrices in the Ubuntu, macOS, and Windows workflows.
- Update the expected SHA256 checksums (Ubuntu & macOS) using the digests published on the GitHub releases (`v1.5.4`, `v1.4.5`).
- Add a CHANGELOG entry under Unreleased.

## Release references
- https://github.com/duckdb/duckdb/releases/tag/v1.5.4
- https://github.com/duckdb/duckdb/releases/tag/v1.4.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated testing infrastructure to validate compatibility with newer DuckDB releases across multiple platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->