### PR TITLE
Add SHA256 verification to Windows CI duckdb download

### DIFF
--- a/.github/workflows/test_on_windows.yml
+++ b/.github/workflows/test_on_windows.yml
@@ -53,6 +53,15 @@ jobs:
         DUCKDB_VERSION: ${{ matrix.duckdb }}
       run: |
         curl -OL https://github.com/duckdb/duckdb/releases/download/v${env:DUCKDB_VERSION}/libduckdb-windows-amd64.zip
+        switch ($env:DUCKDB_VERSION) {
+          "1.5.4" { $EXPECTED_SHA256 = "74e73afd3b010c6f310e14a961fff679f876952bc196f82584b0e2e76d11a91f" }
+          "1.4.5" { $EXPECTED_SHA256 = "f2079105369a2698f7d9663e5908a16919e7b03f4ff681ceb716b270a5903a11" }
+          default { Write-Error "No known SHA256 for DuckDB v$env:DUCKDB_VERSION"; exit 1 }
+        }
+        $ACTUAL_SHA256 = (Get-FileHash libduckdb-windows-amd64.zip -Algorithm SHA256).Hash
+        if ($ACTUAL_SHA256 -ne $EXPECTED_SHA256) {
+          Write-Error "SHA256 mismatch: expected $EXPECTED_SHA256, got $ACTUAL_SHA256"; exit 1
+        }
         mkdir libduckdb-windows-amd64
         unzip libduckdb-windows-amd64.zip -d libduckdb-windows-amd64
 


### PR DESCRIPTION
## Summary

Adds SHA256 checksum verification to the Windows CI workflow's DuckDB download step, mirroring what macOS and Ubuntu already do.

The Windows download step runs in PowerShell (note `$env:DUCKDB_VERSION`), so this uses `Get-FileHash` and a `switch` rather than the `sha256sum`/`shasum` + `case` approach used on the other platforms. Unknown versions hit the `default` branch and fail the job.

SHA256 values (verified against the DuckDB releases):
- `1.5.4` → `74e73afd3b010c6f310e14a961fff679f876952bc196f82584b0e2e76d11a91f`
- `1.4.5` → `f2079105369a2698f7d9663e5908a16919e7b03f4ff681ceb716b270a5903a11`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Windows build process with automated checksum validation for downloaded dependencies.
  * Added integrity verification to detect corrupted or tampered files during builds.
  * Improved error messaging for validation failures and unsupported versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->