### PR TITLE
Require Ruby >= 3.3

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -113,7 +113,7 @@ rubocop -a
 ### Ruby Code Style
 - Frozen string literals: `# frozen_string_literal: true` at top of all files
 - Line length: 120 characters max
-- Target Ruby version: 3.2+
+- Target Ruby version: 3.3+
 - Documentation: Inline for complex Ruby logic; C functions use comment blocks with `call-seq:`
 - RuboCop config excludes C extension, benchmarks, vendor, tmp, pkg
 
@@ -121,7 +121,7 @@ rubocop -a
 - Gem version: `lib/duckdb/version.rb` (`DuckDB::VERSION`)
 - Library version: Dynamically retrieved from DuckDB via `DuckDB.library_version`
 - Minimum DuckDB: 1.3.0 (enforced in `extconf.rb`)
-- Minimum Ruby: 3.2.0 (in gemspec)
+- Minimum Ruby: 3.3.0 (in gemspec)
 
 ### Performance
 - Use `Appender` for bulk inserts (10-50x faster than prepared statements)

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,7 @@ plugins:
 
 AllCops:
   NewCops: enable
-  TargetRubyVersion: 3.2
+  TargetRubyVersion: 3.3
   Exclude:
     - 'vendor/**/*'
     - 'tmp/**/*'

--- a/duckdb.gemspec
+++ b/duckdb.gemspec
@@ -32,6 +32,6 @@ Gem::Specification.new do |spec|
 
   spec.require_paths = ['lib']
   spec.extensions = ['ext/duckdb/extconf.rb']
-  spec.required_ruby_version = '>= 3.2.0'
+  spec.required_ruby_version = '>= 3.3.0'
   spec.add_dependency 'bigdecimal', '>= 3.1.4'
 end


### PR DESCRIPTION
Bump minimum Ruby from 3.2 to 3.3.

- `duckdb.gemspec`: `required_ruby_version >= 3.3.0`
- `.rubocop.yml`: `TargetRubyVersion: 3.3`
- `.github/copilot-instructions.md`: doc mentions

CI already runs Ruby 3.3+, and CHANGELOG already notes "drop Ruby 3.2."

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated minimum Ruby version requirement from 3.2 to 3.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->