### PR TITLE
Bump Ruby to 3.4.10 on CI

### DIFF
--- a/.github/workflows/test_on_macos.yml
+++ b/.github/workflows/test_on_macos.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['3.3.11', '3.4.9', '4.0.5', 'head']
+        ruby: ['3.3.11', '3.4.10', '4.0.5', 'head']
         duckdb: ['1.4.5', '1.5.4']
     env:
       # Released Bundler is broken on ruby-head due to ruby/ruby#16895.

--- a/.github/workflows/test_on_ubuntu.yml
+++ b/.github/workflows/test_on_ubuntu.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['3.3.11', '3.4.9', '4.0.5', 'head']
+        ruby: ['3.3.11', '3.4.10', '4.0.5', 'head']
         duckdb: ['1.4.5', '1.5.4']
     env:
       # Released Bundler is broken on ruby-head due to ruby/ruby#16895.

--- a/.github/workflows/test_on_windows.yml
+++ b/.github/workflows/test_on_windows.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['3.3.10', '3.4.8', '4.0.5', 'ucrt', 'mingw', 'mswin', 'head']
+        ruby: ['3.3.10', '3.4.10', '4.0.5', 'ucrt', 'mingw', 'mswin', 'head']
         duckdb: ['1.4.5', '1.5.4']
     env:
       # Released Bundler is broken on ruby-head due to ruby/ruby#16895.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 # Unreleased
+- bump Ruby to 3.4.10 on CI.
 - add `DuckDB::Error#error_type` returning the DuckDB error category as a Symbol (e.g. `:constraint`, `:catalog`, `:parser`), or `nil` for errors not originating from a query result. Helps the ActiveRecord adapter map failures to `RecordNotUnique` / `NotNullViolation` etc. without parsing error messages.
 
 # 1.5.4.0 - 2026-06-20


### PR DESCRIPTION
Bump Ruby 3.4.9 (ubuntu/macos) and 3.4.8 (windows) to 3.4.10 in the CI test matrices. RubyInstaller 3.4.10-1 is released, so all three platforms are covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the CI test matrix to use Ruby 3.4.10 on macOS, Ubuntu, and Windows.
  * Kept the rest of the workflow and test coverage unchanged.
* **Documentation**
  * Added a changelog entry for the Ruby version update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->