### PR TITLE
Add prepared statement result column metadata methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 # Unreleased
 - bump Ruby to 3.4.10 on CI.
+- add `DuckDB::PreparedStatement#column_count`, `#column_name(col_index)`, `#column_type(col_index)` and `#column_logical_type(col_index)` to get the result-set column metadata of a prepared statement without executing it (column index is 0-based). Useful for PG-style statement caching where column types must be known before execution.
 - add `DuckDB::Error#error_type` returning the DuckDB error category as a Symbol (e.g. `:constraint`, `:catalog`, `:parser`), or `nil` for errors not originating from a query result. Helps the ActiveRecord adapter map failures to `RecordNotUnique` / `NotNullViolation` etc. without parsing error messages.
 
 # 1.5.4.0 - 2026-06-20

--- a/ext/duckdb/prepared_statement.c
+++ b/ext/duckdb/prepared_statement.c
@@ -27,6 +27,10 @@ static VALUE prepared_statement_bind_blob(VALUE self, VALUE vidx, VALUE blob);
 static VALUE prepared_statement_bind_null(VALUE self, VALUE vidx);
 static VALUE prepared_statement__statement_type(VALUE self);
 static VALUE prepared_statement__param_type(VALUE self, VALUE vidx);
+static VALUE prepared_statement_column_count(VALUE self);
+static VALUE prepared_statement_column_name(VALUE self, VALUE vidx);
+static VALUE prepared_statement__column_type(VALUE self, VALUE vidx);
+static VALUE prepared_statement_column_logical_type(VALUE self, VALUE vidx);
 static VALUE prepared_statement__bind_uint8(VALUE self, VALUE vidx, VALUE val);
 static VALUE prepared_statement__bind_uint16(VALUE self, VALUE vidx, VALUE val);
 static VALUE prepared_statement__bind_uint32(VALUE self, VALUE vidx, VALUE val);
@@ -358,6 +362,91 @@ static VALUE prepared_statement__statement_type(VALUE self) {
     return INT2FIX(duckdb_prepared_statement_type(ctx->prepared_statement));
 }
 
+/*
+ *  call-seq:
+ *    prepared_statement.column_count -> Integer
+ *
+ *  Returns the number of columns in the result set of the prepared statement
+ *  without executing it.
+ *
+ *    require 'duckdb'
+ *    db = DuckDB::Database.open
+ *    con = db.connect
+ *    stmt = con.prepared_statement('SELECT 1 AS a, 2 AS b')
+ *    stmt.column_count # => 2
+ */
+static VALUE prepared_statement_column_count(VALUE self) {
+    rubyDuckDBPreparedStatement *ctx;
+    TypedData_Get_Struct(self, rubyDuckDBPreparedStatement, &prepared_statement_data_type, ctx);
+    return ULL2NUM(duckdb_prepared_statement_column_count(ctx->prepared_statement));
+}
+
+/*
+ *  call-seq:
+ *    prepared_statement.column_name(col_index) -> String
+ *
+ *  Returns the name of the column at the specified index (0-based) of the
+ *  result set of the prepared statement without executing it.
+ *  Raises DuckDB::Error if the column index is out of range.
+ *
+ *    require 'duckdb'
+ *    db = DuckDB::Database.open
+ *    con = db.connect
+ *    stmt = con.prepared_statement('SELECT 1 AS a, 2 AS b')
+ *    stmt.column_name(1) # => 'b'
+ */
+static VALUE prepared_statement_column_name(VALUE self, VALUE vidx) {
+    rubyDuckDBPreparedStatement *ctx;
+    VALUE vname;
+    const char *name;
+    idx_t idx = NUM2ULL(vidx);
+
+    TypedData_Get_Struct(self, rubyDuckDBPreparedStatement, &prepared_statement_data_type, ctx);
+
+    name = duckdb_prepared_statement_column_name(ctx->prepared_statement, idx);
+    if (name == NULL) {
+        rb_raise(eDuckDBError, "fail to get column name at %llu. column index is out of range.", (unsigned long long)idx);
+    }
+    vname = rb_str_new2(name);
+    duckdb_free((void *)name);
+    return vname;
+}
+
+/* :nodoc: */
+static VALUE prepared_statement__column_type(VALUE self, VALUE vidx) {
+    rubyDuckDBPreparedStatement *ctx;
+    TypedData_Get_Struct(self, rubyDuckDBPreparedStatement, &prepared_statement_data_type, ctx);
+    return INT2FIX(duckdb_prepared_statement_column_type(ctx->prepared_statement, NUM2ULL(vidx)));
+}
+
+/*
+ *  call-seq:
+ *    prepared_statement.column_logical_type(col_index) -> DuckDB::LogicalType
+ *
+ *  Returns the logical type of the column at the specified index (0-based) of
+ *  the result set of the prepared statement without executing it.
+ *  Raises DuckDB::Error if the column index is out of range.
+ *
+ *    require 'duckdb'
+ *    db = DuckDB::Database.open
+ *    con = db.connect
+ *    stmt = con.prepared_statement('SELECT 1.5::DECIMAL(9, 4) AS a')
+ *    stmt.column_logical_type(0).type # => :decimal
+ */
+static VALUE prepared_statement_column_logical_type(VALUE self, VALUE vidx) {
+    rubyDuckDBPreparedStatement *ctx;
+    duckdb_logical_type logical_type;
+    idx_t idx = NUM2ULL(vidx);
+
+    TypedData_Get_Struct(self, rubyDuckDBPreparedStatement, &prepared_statement_data_type, ctx);
+
+    logical_type = duckdb_prepared_statement_column_logical_type(ctx->prepared_statement, idx);
+    if (logical_type == NULL) {
+        rb_raise(eDuckDBError, "fail to get column logical type at %llu. column index is out of range.", (unsigned long long)idx);
+    }
+    return rbduckdb_create_logical_type(logical_type);
+}
+
 /* :nodoc: */
 static VALUE prepared_statement__param_type(VALUE self, VALUE vidx) {
     rubyDuckDBPreparedStatement *ctx;
@@ -612,6 +701,9 @@ void rbduckdb_init_prepared_statement(void) {
     rb_define_method(cDuckDBPreparedStatement, "bind_parameter_index", prepared_statement_bind_parameter_index, 1);
     rb_define_method(cDuckDBPreparedStatement, "parameter_name", prepared_statement_parameter_name, 1);
     rb_define_method(cDuckDBPreparedStatement, "clear_bindings", prepared_statement_clear_bindings, 0);
+    rb_define_method(cDuckDBPreparedStatement, "column_count", prepared_statement_column_count, 0);
+    rb_define_method(cDuckDBPreparedStatement, "column_name", prepared_statement_column_name, 1);
+    rb_define_method(cDuckDBPreparedStatement, "column_logical_type", prepared_statement_column_logical_type, 1);
     rb_define_method(cDuckDBPreparedStatement, "bind_bool", prepared_statement_bind_bool, 2);
     rb_define_method(cDuckDBPreparedStatement, "bind_int8", prepared_statement_bind_int8, 2);
     rb_define_method(cDuckDBPreparedStatement, "bind_int16", prepared_statement_bind_int16, 2);
@@ -628,6 +720,7 @@ void rbduckdb_init_prepared_statement(void) {
     rb_define_private_method(cDuckDBPreparedStatement, "_bind_uint64", prepared_statement__bind_uint64, 2);
     rb_define_private_method(cDuckDBPreparedStatement, "_statement_type", prepared_statement__statement_type, 0);
     rb_define_private_method(cDuckDBPreparedStatement, "_param_type", prepared_statement__param_type, 1);
+    rb_define_private_method(cDuckDBPreparedStatement, "_column_type", prepared_statement__column_type, 1);
     rb_define_private_method(cDuckDBPreparedStatement, "_bind_date", prepared_statement__bind_date, 4);
     rb_define_private_method(cDuckDBPreparedStatement, "_bind_time", prepared_statement__bind_time, 5);
     rb_define_private_method(cDuckDBPreparedStatement, "_bind_timestamp", prepared_statement__bind_timestamp, 8);

--- a/lib/duckdb/prepared_statement.rb
+++ b/lib/duckdb/prepared_statement.rb
@@ -76,6 +76,21 @@ module DuckDB
       Converter::IntToSym.type_to_sym(i)
     end
 
+    # returns the column type of the result set of the prepared statement
+    # without executing it. The argument is the column index (0-based).
+    # Returns :invalid if the column index is out of range.
+    #
+    #   require 'duckdb'
+    #   db = DuckDB::Database.open
+    #   con = db.connect
+    #   con.execute('CREATE TABLE users (id INTEGER, name VARCHAR(255))')
+    #   stmt = con.prepared_statement('SELECT * FROM users')
+    #   stmt.column_type(0) # => :integer
+    def column_type(index)
+      i = _column_type(index)
+      Converter::IntToSym.type_to_sym(i)
+    end
+
     # binds all parameters with SQL prepared statement.
     #
     #   require 'duckdb'

--- a/test/duckdb_test/prepared_statement_column_metadata_test.rb
+++ b/test/duckdb_test/prepared_statement_column_metadata_test.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module DuckDBTest
+  class PreparedStatementColumnMetadataTest < Minitest::Test
+    def setup
+      @db = DuckDB::Database.open
+      @con = @db.connect
+      @con.query('CREATE TABLE users (id INTEGER, name VARCHAR, salary DECIMAL(9, 4))')
+    end
+
+    def teardown
+      @con&.close
+      @db&.close
+    end
+
+    def test_column_count
+      stmt = @con.prepared_statement('SELECT id, name FROM users WHERE id = ?')
+
+      assert_equal 2, stmt.column_count
+    end
+
+    def test_column_name
+      stmt = @con.prepared_statement('SELECT id, name AS user_name FROM users WHERE id = ?')
+
+      assert_equal 'id', stmt.column_name(0)
+      assert_equal 'user_name', stmt.column_name(1)
+    end
+
+    def test_column_name_out_of_range
+      stmt = @con.prepared_statement('SELECT id FROM users')
+      assert_raises(DuckDB::Error) { stmt.column_name(1) }
+    end
+
+    def test_column_type
+      stmt = @con.prepared_statement('SELECT id, name, salary FROM users WHERE id = ?')
+
+      assert_equal :integer, stmt.column_type(0)
+      assert_equal :varchar, stmt.column_type(1)
+      assert_equal :decimal, stmt.column_type(2)
+    end
+
+    def test_column_type_out_of_range
+      stmt = @con.prepared_statement('SELECT id FROM users')
+
+      assert_equal :invalid, stmt.column_type(1)
+    end
+
+    def test_column_logical_type
+      stmt = @con.prepared_statement('SELECT salary FROM users WHERE id = ?')
+      logical_type = stmt.column_logical_type(0)
+
+      assert_equal :decimal, logical_type.type
+      assert_equal 9, logical_type.width
+      assert_equal 4, logical_type.scale
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Adds result-set column metadata methods to `DuckDB::PreparedStatement`, available **without executing** the statement — useful for PG-style statement caching where column types must be known up front.

- `#column_count` → Integer
- `#column_name(col_index)` → String (raises `DuckDB::Error` if out of range)
- `#column_type(col_index)` → Symbol (e.g. `:integer`; `:invalid` if out of range)
- `#column_logical_type(col_index)` → `DuckDB::LogicalType` (raises `DuckDB::Error` if out of range)

Column index is 0-based, mirroring the C API (`duckdb_prepared_statement_column_count/name/type/logical_type`, all available since DuckDB 1.4.0 — no feature guard needed).

`column_type`/`column_logical_type` follow the existing `param_type` pattern: private `_column_type` in C + Symbol conversion via `Converter::IntToSym` in Ruby.

## Test plan
- New `test/duckdb_test/prepared_statement_column_metadata_test.rb` covering count, names (incl. alias), type symbols (incl. DECIMAL), logical type width/scale, and out-of-range behavior.
- Full suite: 1185 runs, 0 failures. RuboCop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ways to inspect prepared statement result-set metadata without executing it, including column count, column names, column types, and logical types.
  * Introduced support for detecting out-of-range column indexes with clear error handling or an `:invalid` result where applicable.

* **Tests**
  * Added coverage for column metadata lookup, alias handling, type mapping, and logical type details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->