### PR TITLE
Add DuckDB::PreparedStatement#param_logical_type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 # Unreleased
 - bump Ruby to 3.4.10 on CI.
 - add `DuckDB::Error#error_type` returning the DuckDB error category as a Symbol (e.g. `:constraint`, `:catalog`, `:parser`), or `nil` for errors not originating from a query result. Helps the ActiveRecord adapter map failures to `RecordNotUnique` / `NotNullViolation` etc. without parsing error messages.
+- add `DuckDB::PreparedStatement#param_logical_type(param_index)` returning the `DuckDB::LogicalType` of a bind parameter (1-based index), giving richer type information than `#param_type` (e.g. decimal width/scale, nested types).
 
 # 1.5.4.0 - 2026-06-20
 - bump up DuckDB 1.5.4 and 1.4.5 on CI.

--- a/ext/duckdb/prepared_statement.c
+++ b/ext/duckdb/prepared_statement.c
@@ -14,6 +14,7 @@ static idx_t check_index(VALUE vidx);
 
 static VALUE prepared_statement_bind_parameter_index(VALUE self, VALUE name);
 static VALUE prepared_statement_parameter_name(VALUE self, VALUE vidx);
+static VALUE prepared_statement_param_logical_type(VALUE self, VALUE vidx);
 static VALUE prepared_statement_clear_bindings(VALUE self);
 static VALUE prepared_statement_bind_bool(VALUE self, VALUE vidx, VALUE val);
 static VALUE prepared_statement_bind_int8(VALUE self, VALUE vidx, VALUE val);
@@ -202,6 +203,28 @@ static VALUE prepared_statement_parameter_name(VALUE self, VALUE vidx) {
     vname = rb_str_new2(name);
     duckdb_free((void *)name);
     return vname;
+}
+
+/*
+ *  call-seq:
+ *    prepared_statement.param_logical_type(param_index) -> DuckDB::LogicalType
+ *
+ *  Returns the logical type of the parameter at the given (1-based) index.
+ *  This provides richer type information than #param_type, e.g. decimal
+ *  width/scale, nested types.
+ */
+static VALUE prepared_statement_param_logical_type(VALUE self, VALUE vidx) {
+    rubyDuckDBPreparedStatement *ctx;
+    duckdb_logical_type logical_type;
+    idx_t idx = check_index(vidx);
+
+    TypedData_Get_Struct(self, rubyDuckDBPreparedStatement, &prepared_statement_data_type, ctx);
+
+    logical_type = duckdb_param_logical_type(ctx->prepared_statement, idx);
+    if (logical_type == NULL) {
+        rb_raise(eDuckDBError, "fail to get logical type of the parameter at %llu. parameter index is out of range.", (unsigned long long)idx);
+    }
+    return rbduckdb_create_logical_type(logical_type);
 }
 
 /*
@@ -611,6 +634,7 @@ void rbduckdb_init_prepared_statement(void) {
     rb_define_method(cDuckDBPreparedStatement, "nparams", prepared_statement_nparams, 0);
     rb_define_method(cDuckDBPreparedStatement, "bind_parameter_index", prepared_statement_bind_parameter_index, 1);
     rb_define_method(cDuckDBPreparedStatement, "parameter_name", prepared_statement_parameter_name, 1);
+    rb_define_method(cDuckDBPreparedStatement, "param_logical_type", prepared_statement_param_logical_type, 1);
     rb_define_method(cDuckDBPreparedStatement, "clear_bindings", prepared_statement_clear_bindings, 0);
     rb_define_method(cDuckDBPreparedStatement, "bind_bool", prepared_statement_bind_bool, 2);
     rb_define_method(cDuckDBPreparedStatement, "bind_int8", prepared_statement_bind_int8, 2);

--- a/test/duckdb_test/prepared_statement_param_logical_type_test.rb
+++ b/test/duckdb_test/prepared_statement_param_logical_type_test.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module DuckDBTest
+  class PreparedStatementParamLogicalTypeTest < Minitest::Test
+    def setup
+      @db = DuckDB::Database.open
+      @con = @db.connect
+      @con.query('CREATE TABLE users (id INTEGER, salary DECIMAL(9, 4))')
+    end
+
+    def teardown
+      @con.close
+      @db.close
+    end
+
+    def test_param_logical_type_integer
+      stmt = @con.prepared_statement('SELECT * FROM users WHERE id = ?')
+      logical_type = stmt.param_logical_type(1)
+
+      assert_equal(:integer, logical_type.type)
+    end
+
+    def test_param_logical_type_decimal
+      stmt = @con.prepared_statement('SELECT * FROM users WHERE salary = ?')
+      logical_type = stmt.param_logical_type(1)
+
+      assert_equal(:decimal, logical_type.type)
+      assert_equal(9, logical_type.width)
+      assert_equal(4, logical_type.scale)
+    end
+
+    def test_param_logical_type_out_of_range
+      stmt = @con.prepared_statement('SELECT * FROM users WHERE id = ?')
+
+      assert_raises(DuckDB::Error) { stmt.param_logical_type(2) }
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Adds `DuckDB::PreparedStatement#param_logical_type(param_index)`, wrapping `duckdb_param_logical_type` from the DuckDB C API.
- Returns a `DuckDB::LogicalType` for the bind parameter at the given 1-based index, giving richer type information than `#param_type` (e.g. decimal width/scale, nested types).
- Raises `DuckDB::Error` when the parameter index is out of range (the C API returns `NULL` in that case).

## Test plan
- [x] `bundle exec ruby -Ilib:test test/duckdb_test/prepared_statement_param_logical_type_test.rb` — verified it fails before the implementation (red), passes after (green).
- [x] `bundle exec rake test` — full suite passes (1182 runs, 0 failures, 0 errors).
- [x] `bundle exec rubocop` — no offenses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `DuckDB::PreparedStatement#param_logical_type(param_index)` to inspect the logical type of a bind parameter, including exact decimal precision and scale.
* **Bug Fixes**
  * Added parameter index validation and clearer errors when a logical type can’t be determined or the index is invalid.
* **Documentation**
  * Updated the changelog under **Unreleased** to describe the new API.
* **Tests**
  * Added coverage for integer/decimal logical type inference and error behavior for missing parameter indexes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->