### PR TITLE
Add LIST/ARRAY composite value creation and getters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 # Unreleased
 - bump Ruby to 3.4.10 on CI.
-- add `DuckDB::Value.create_list(child_type, values)` and `DuckDB::Value.create_array(child_type, values)` to create LIST/ARRAY values from a `DuckDB::LogicalType` and an Array of `DuckDB::Value` elements. The created values can be bound to prepared statements with `#bind_value`.
+- add `DuckDB::Value.create_list(child_type, values)` and `DuckDB::Value.create_array(child_type, values)` to create LIST/ARRAY values from an element type (a Symbol like `:integer` or a `DuckDB::LogicalType`) and an Array of `DuckDB::Value` elements. The created values can be bound to prepared statements with `#bind_value`.
 - add `DuckDB::Value#list_size` and `DuckDB::Value#list_child(index)` to read LIST value elements as `DuckDB::Value`.
 - add `DuckDB::Value#to_ruby` converting a `DuckDB::Value` to a Ruby object. LIST/ARRAY values are converted to Ruby Arrays recursively; NULL becomes `nil`.
 - add `DuckDB::PreparedStatement#column_count`, `#column_name(col_index)`, `#column_type(col_index)` and `#column_logical_type(col_index)` to get the result-set column metadata of a prepared statement without executing it (column index is 0-based). Useful for PG-style statement caching where column types must be known before execution.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 # Unreleased
 - bump Ruby to 3.4.10 on CI.
+- add `DuckDB::Value.create_list(child_type, values)` and `DuckDB::Value.create_array(child_type, values)` to create LIST/ARRAY values from a `DuckDB::LogicalType` and an Array of `DuckDB::Value` elements. The created values can be bound to prepared statements with `#bind_value`.
+- add `DuckDB::Value#list_size` and `DuckDB::Value#list_child(index)` to read LIST value elements as `DuckDB::Value`.
+- add `DuckDB::Value#to_ruby` converting a `DuckDB::Value` to a Ruby object. LIST/ARRAY values are converted to Ruby Arrays recursively; NULL becomes `nil`.
 - add `DuckDB::Error#error_type` returning the DuckDB error category as a Symbol (e.g. `:constraint`, `:catalog`, `:parser`), or `nil` for errors not originating from a query result. Helps the ActiveRecord adapter map failures to `RecordNotUnique` / `NotNullViolation` etc. without parsing error messages.
 
 # 1.5.4.0 - 2026-06-20

--- a/ext/duckdb/value.c
+++ b/ext/duckdb/value.c
@@ -22,6 +22,12 @@ static VALUE value_s__create_hugeint(VALUE klass, VALUE lower, VALUE upper);
 static VALUE value_s__create_uhugeint(VALUE klass, VALUE lower, VALUE upper);
 static VALUE value_s__create_decimal(VALUE klass, VALUE lower, VALUE upper, VALUE width, VALUE scale);
 static VALUE value_s_create_null(VALUE klass);
+static idx_t marshal_values(VALUE ary, duckdb_value **out, volatile VALUE *guard);
+static VALUE value_s__create_list(VALUE klass, VALUE ltype, VALUE values);
+static VALUE value_s__create_array(VALUE klass, VALUE ltype, VALUE values);
+static VALUE value_list_size(VALUE self);
+static VALUE value_list_child(VALUE self, VALUE vidx);
+static VALUE value_to_ruby(VALUE self);
 
 static const rb_data_type_t value_data_type = {
     "DuckDB/Value",
@@ -154,6 +160,96 @@ static VALUE value_s_create_null(VALUE klass) {
     return rbduckdb_value_new(value);
 }
 
+/*
+ * Fills *out with the unwrapped duckdb_values of a Ruby Array of
+ * DuckDB::Value objects and returns the array length. The buffer is
+ * an ALLOCV tmpbuf; the caller must call ALLOCV_END(*guard) after use.
+ * The buffer is non-NULL even for an empty array because
+ * duckdb_create_*_value functions reject a NULL values pointer.
+ */
+static idx_t marshal_values(VALUE ary, duckdb_value **out, volatile VALUE *guard) {
+    idx_t n = (idx_t)RARRAY_LEN(ary);
+    duckdb_value *buf = ALLOCV_N(duckdb_value, *guard, n == 0 ? 1 : n);
+    idx_t i;
+
+    for (i = 0; i < n; i++) {
+        buf[i] = rbduckdb_get_struct_value(RARRAY_AREF(ary, i))->value;
+    }
+    *out = buf;
+    return n;
+}
+
+/* :nodoc: */
+static VALUE value_s__create_list(VALUE klass, VALUE ltype, VALUE values) {
+    duckdb_logical_type type = rbduckdb_get_struct_logical_type(ltype)->logical_type;
+    duckdb_value *buf;
+    volatile VALUE guard;
+    idx_t n = marshal_values(values, &buf, &guard);
+    duckdb_value value = duckdb_create_list_value(type, buf, n);
+
+    RB_GC_GUARD(values);
+    ALLOCV_END(guard);
+    if (value == NULL) {
+        rb_raise(eDuckDBError, "failed to create LIST value");
+    }
+    return rbduckdb_value_new(value);
+}
+
+/* :nodoc: */
+static VALUE value_s__create_array(VALUE klass, VALUE ltype, VALUE values) {
+    duckdb_logical_type type = rbduckdb_get_struct_logical_type(ltype)->logical_type;
+    duckdb_value *buf;
+    volatile VALUE guard;
+    idx_t n = marshal_values(values, &buf, &guard);
+    duckdb_value value = duckdb_create_array_value(type, buf, n);
+
+    RB_GC_GUARD(values);
+    ALLOCV_END(guard);
+    if (value == NULL) {
+        rb_raise(eDuckDBError, "failed to create ARRAY value");
+    }
+    return rbduckdb_value_new(value);
+}
+
+/*
+ *  call-seq:
+ *    value.list_size -> Integer
+ *
+ *  Returns the number of elements of a LIST value.
+ *
+ *    require 'duckdb'
+ *    child_type = DuckDB::LogicalType.resolve(:integer)
+ *    values = [1, 2, 3].map { |i| DuckDB::Value.create_int32(i) }
+ *    list = DuckDB::Value.create_list(child_type, values)
+ *    list.list_size # => 3
+ */
+static VALUE value_list_size(VALUE self) {
+    return ULL2NUM(duckdb_get_list_size(rbduckdb_get_struct_value(self)->value));
+}
+
+/*
+ *  call-seq:
+ *    value.list_child(index) -> DuckDB::Value
+ *
+ *  Returns the element at the specified index (0-based) of a LIST value
+ *  as a DuckDB::Value.
+ *  Raises IndexError if the index is out of range or the value is not a LIST.
+ *
+ *    require 'duckdb'
+ *    child_type = DuckDB::LogicalType.resolve(:integer)
+ *    values = [1, 2, 3].map { |i| DuckDB::Value.create_int32(i) }
+ *    list = DuckDB::Value.create_list(child_type, values)
+ *    list.list_child(0) # => DuckDB::Value
+ */
+static VALUE value_list_child(VALUE self, VALUE vidx) {
+    duckdb_value child = duckdb_get_list_child(rbduckdb_get_struct_value(self)->value, (idx_t)NUM2ULL(vidx));
+
+    if (child == NULL) {
+        rb_raise(rb_eIndexError, "list index out of range (or the value is not a LIST)");
+    }
+    return rbduckdb_value_new(child);
+}
+
 VALUE rbduckdb_value_new(duckdb_value value) {
     rubyDuckDBValue *ctx;
     VALUE obj = allocate(cDuckDBValue);
@@ -173,6 +269,12 @@ VALUE rbduckdb_duckdb_value_to_ruby(duckdb_value val) {
     duckdb_type type_id;
     VALUE result;
     char *str;
+    idx_t i;
+    idx_t size;
+
+    if (duckdb_is_null_value(val)) {
+        return Qnil;
+    }
 
     logical_type = duckdb_get_value_type(val);
     type_id = duckdb_get_type_id(logical_type);
@@ -255,12 +357,58 @@ VALUE rbduckdb_duckdb_value_to_ruby(duckdb_value val) {
         case DUCKDB_TYPE_UUID:
             result = rbduckdb_uuid_uhugeint_to_ruby(duckdb_get_uuid(val));
             break;
+        case DUCKDB_TYPE_LIST:
+            size = duckdb_get_list_size(val);
+            result = rb_ary_new_capa(size);
+            for (i = 0; i < size; i++) {
+                duckdb_value child = duckdb_get_list_child(val, i);
+                VALUE elem = rbduckdb_duckdb_value_to_ruby(child);
+                duckdb_destroy_value(&child);
+                rb_ary_push(result, elem);
+            }
+            break;
+        case DUCKDB_TYPE_ARRAY: {
+            /* the C API has no duckdb_get_array_size/child; read via a vector */
+            duckdb_logical_type child_type = duckdb_array_type_child_type(logical_type);
+            duckdb_vector vec = duckdb_create_vector(logical_type, 1);
+            duckdb_vector child;
+
+            size = duckdb_array_type_array_size(logical_type);
+            duckdb_vector_reference_value(vec, val);
+            child = duckdb_array_vector_get_child(vec);
+            result = rb_ary_new_capa(size);
+            for (i = 0; i < size; i++) {
+                rb_ary_push(result, rbduckdb_vector_value_at(child, child_type, i));
+            }
+            duckdb_destroy_logical_type(&child_type);
+            duckdb_destroy_vector(&vec);
+            break;
+        }
         default:
             result = Qnil;
             break;
     }
 
+    /* logical_type from duckdb_get_value_type is borrowed and must not be destroyed */
     return result;
+}
+
+/*
+ *  call-seq:
+ *    value.to_ruby -> Object
+ *
+ *  Converts the DuckDB::Value to a Ruby object. Scalar types are converted
+ *  to their natural Ruby classes. LIST values are converted to Array
+ *  recursively. NULL is converted to nil. Returns nil for unsupported types.
+ *
+ *    require 'duckdb'
+ *    child_type = DuckDB::LogicalType.resolve(:integer)
+ *    values = [1, 2, 3].map { |i| DuckDB::Value.create_int32(i) }
+ *    list = DuckDB::Value.create_list(child_type, values)
+ *    list.to_ruby # => [1, 2, 3]
+ */
+static VALUE value_to_ruby(VALUE self) {
+    return rbduckdb_duckdb_value_to_ruby(rbduckdb_get_struct_value(self)->value);
 }
 
 void rbduckdb_init_value(void) {
@@ -286,6 +434,11 @@ void rbduckdb_init_value(void) {
     rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_hugeint", value_s__create_hugeint, 2);
     rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_uhugeint", value_s__create_uhugeint, 2);
     rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_decimal", value_s__create_decimal, 4);
+    rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_list", value_s__create_list, 2);
+    rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_array", value_s__create_array, 2);
     rb_define_singleton_method(cDuckDBValue, "create_null", value_s_create_null, 0);
-}
 
+    rb_define_method(cDuckDBValue, "list_size", value_list_size, 0);
+    rb_define_method(cDuckDBValue, "list_child", value_list_child, 1);
+    rb_define_method(cDuckDBValue, "to_ruby", value_to_ruby, 0);
+}

--- a/ext/duckdb/value.c
+++ b/ext/duckdb/value.c
@@ -167,7 +167,7 @@ static VALUE value_s_create_null(VALUE klass) {
  * The buffer is non-NULL even for an empty array because
  * duckdb_create_*_value functions reject a NULL values pointer.
  *
- * This always allocates via rb_alloc_tmp_buffer_with_count (heap-backed)
+ * This always allocates via rb_alloc_tmp_buffer2 (heap-backed)
  * rather than the ALLOCV_N macro, because that macro's small-size fast
  * path uses alloca() in *this* function's stack frame: the returned
  * pointer would dangle once marshal_values returns, and a second call
@@ -177,7 +177,7 @@ static VALUE value_s_create_null(VALUE klass) {
 static idx_t marshal_values(VALUE ary, duckdb_value **out, volatile VALUE *guard) {
     idx_t n = (idx_t)RARRAY_LEN(ary);
     idx_t count = n == 0 ? 1 : n;
-    duckdb_value *buf = (duckdb_value *)rb_alloc_tmp_buffer_with_count(guard, count * sizeof(duckdb_value), count);
+    duckdb_value *buf = (duckdb_value *)rb_alloc_tmp_buffer2(guard, (long)count, sizeof(duckdb_value));
     idx_t i;
 
     for (i = 0; i < n; i++) {

--- a/ext/duckdb/value.c
+++ b/ext/duckdb/value.c
@@ -166,10 +166,18 @@ static VALUE value_s_create_null(VALUE klass) {
  * an ALLOCV tmpbuf; the caller must call ALLOCV_END(*guard) after use.
  * The buffer is non-NULL even for an empty array because
  * duckdb_create_*_value functions reject a NULL values pointer.
+ *
+ * This always allocates via rb_alloc_tmp_buffer_with_count (heap-backed)
+ * rather than the ALLOCV_N macro, because that macro's small-size fast
+ * path uses alloca() in *this* function's stack frame: the returned
+ * pointer would dangle once marshal_values returns, and a second call
+ * (e.g. keys then values for MAP) would silently reuse and clobber the
+ * same stack slot as the first call's "buffer".
  */
 static idx_t marshal_values(VALUE ary, duckdb_value **out, volatile VALUE *guard) {
     idx_t n = (idx_t)RARRAY_LEN(ary);
-    duckdb_value *buf = ALLOCV_N(duckdb_value, *guard, n == 0 ? 1 : n);
+    idx_t count = n == 0 ? 1 : n;
+    duckdb_value *buf = (duckdb_value *)rb_alloc_tmp_buffer_with_count(guard, count * sizeof(duckdb_value), count);
     idx_t i;
 
     for (i = 0; i < n; i++) {

--- a/ext/duckdb/value.c
+++ b/ext/duckdb/value.c
@@ -274,8 +274,13 @@ rubyDuckDBValue *rbduckdb_get_struct_value(VALUE obj) {
 
 VALUE rbduckdb_duckdb_value_to_ruby(duckdb_value val) {
     duckdb_logical_type logical_type;
+    duckdb_logical_type child_type;
     duckdb_type type_id;
+    duckdb_value child_value;
+    duckdb_vector vec;
+    duckdb_vector child_vec;
     VALUE result;
+    VALUE elem;
     char *str;
     idx_t i;
     idx_t size;
@@ -284,6 +289,7 @@ VALUE rbduckdb_duckdb_value_to_ruby(duckdb_value val) {
         return Qnil;
     }
 
+    /* logical_type from duckdb_get_value_type is borrowed and must not be destroyed */
     logical_type = duckdb_get_value_type(val);
     type_id = duckdb_get_type_id(logical_type);
 
@@ -369,35 +375,31 @@ VALUE rbduckdb_duckdb_value_to_ruby(duckdb_value val) {
             size = duckdb_get_list_size(val);
             result = rb_ary_new_capa(size);
             for (i = 0; i < size; i++) {
-                duckdb_value child = duckdb_get_list_child(val, i);
-                VALUE elem = rbduckdb_duckdb_value_to_ruby(child);
-                duckdb_destroy_value(&child);
+                child_value = duckdb_get_list_child(val, i);
+                elem = rbduckdb_duckdb_value_to_ruby(child_value);
+                duckdb_destroy_value(&child_value);
                 rb_ary_push(result, elem);
             }
             break;
-        case DUCKDB_TYPE_ARRAY: {
+        case DUCKDB_TYPE_ARRAY:
             /* the C API has no duckdb_get_array_size/child; read via a vector */
-            duckdb_logical_type child_type = duckdb_array_type_child_type(logical_type);
-            duckdb_vector vec = duckdb_create_vector(logical_type, 1);
-            duckdb_vector child;
-
+            child_type = duckdb_array_type_child_type(logical_type);
+            vec = duckdb_create_vector(logical_type, 1);
             size = duckdb_array_type_array_size(logical_type);
             duckdb_vector_reference_value(vec, val);
-            child = duckdb_array_vector_get_child(vec);
+            child_vec = duckdb_array_vector_get_child(vec);
             result = rb_ary_new_capa(size);
             for (i = 0; i < size; i++) {
-                rb_ary_push(result, rbduckdb_vector_value_at(child, child_type, i));
+                rb_ary_push(result, rbduckdb_vector_value_at(child_vec, child_type, i));
             }
             duckdb_destroy_logical_type(&child_type);
             duckdb_destroy_vector(&vec);
             break;
-        }
         default:
             result = Qnil;
             break;
     }
 
-    /* logical_type from duckdb_get_value_type is borrowed and must not be destroyed */
     return result;
 }
 
@@ -406,8 +408,9 @@ VALUE rbduckdb_duckdb_value_to_ruby(duckdb_value val) {
  *    value.to_ruby -> Object
  *
  *  Converts the DuckDB::Value to a Ruby object. Scalar types are converted
- *  to their natural Ruby classes. LIST values are converted to Array
- *  recursively. NULL is converted to nil. Returns nil for unsupported types.
+ *  to their natural Ruby classes. LIST and ARRAY values are converted to
+ *  Array recursively. NULL is converted to nil. Returns nil for unsupported
+ *  types.
  *
  *    require 'duckdb'
  *    child_type = DuckDB::LogicalType.resolve(:integer)

--- a/lib/duckdb/value.rb
+++ b/lib/duckdb/value.rb
@@ -238,7 +238,53 @@ module DuckDB
         _create_decimal(lower, upper, width, value.scale)
       end
 
+      # Creates a DuckDB::Value of LIST type.
+      # The first argument is the DuckDB::LogicalType of the list elements.
+      # The second argument is an Array of DuckDB::Value elements.
+      #
+      #   child_type = DuckDB::LogicalType.resolve(:integer)
+      #   values = [1, 2, 3].map { |i| DuckDB::Value.create_int32(i) }
+      #   list = DuckDB::Value.create_list(child_type, values)
+      #
+      # @param child_type [DuckDB::LogicalType] the element logical type.
+      # @param values [Array<DuckDB::Value>] the list elements.
+      # @return [DuckDB::Value] the created Value object.
+      # @raise [ArgumentError] if child_type is not a DuckDB::LogicalType or
+      #   values is not an Array of DuckDB::Value.
+      def create_list(child_type, values)
+        check_type!(child_type, DuckDB::LogicalType)
+        check_value_array!(values)
+
+        _create_list(child_type, values)
+      end
+
+      # Creates a DuckDB::Value of ARRAY type. The array size is the number
+      # of elements given.
+      # The first argument is the DuckDB::LogicalType of the array elements.
+      # The second argument is an Array of DuckDB::Value elements.
+      #
+      #   child_type = DuckDB::LogicalType.resolve(:integer)
+      #   values = [1, 2, 3].map { |i| DuckDB::Value.create_int32(i) }
+      #   array = DuckDB::Value.create_array(child_type, values)
+      #
+      # @param child_type [DuckDB::LogicalType] the element logical type.
+      # @param values [Array<DuckDB::Value>] the array elements.
+      # @return [DuckDB::Value] the created Value object.
+      # @raise [ArgumentError] if child_type is not a DuckDB::LogicalType or
+      #   values is not an Array of DuckDB::Value.
+      def create_array(child_type, values)
+        check_type!(child_type, DuckDB::LogicalType)
+        check_value_array!(values)
+
+        _create_array(child_type, values)
+      end
+
       private
+
+      def check_value_array!(values)
+        check_type!(values, Array)
+        values.each { |value| check_type!(value, DuckDB::Value) }
+      end
 
       def check_range!(value, range, type_name)
         raise ArgumentError, "value out of range for #{type_name} (#{range})" unless range.cover?(value)

--- a/lib/duckdb/value.rb
+++ b/lib/duckdb/value.rb
@@ -239,44 +239,44 @@ module DuckDB
       end
 
       # Creates a DuckDB::Value of LIST type.
-      # The first argument is the DuckDB::LogicalType of the list elements.
+      # The first argument is the element type: a Symbol (e.g. :integer) or a
+      # DuckDB::LogicalType.
       # The second argument is an Array of DuckDB::Value elements.
       #
-      #   child_type = DuckDB::LogicalType.resolve(:integer)
       #   values = [1, 2, 3].map { |i| DuckDB::Value.create_int32(i) }
-      #   list = DuckDB::Value.create_list(child_type, values)
+      #   list = DuckDB::Value.create_list(:integer, values)
       #
-      # @param child_type [DuckDB::LogicalType] the element logical type.
+      # @param child_type [Symbol, DuckDB::LogicalType] the element logical type.
       # @param values [Array<DuckDB::Value>] the list elements.
       # @return [DuckDB::Value] the created Value object.
-      # @raise [ArgumentError] if child_type is not a DuckDB::LogicalType or
-      #   values is not an Array of DuckDB::Value.
+      # @raise [DuckDB::Error] if child_type cannot be resolved to a
+      #   DuckDB::LogicalType.
+      # @raise [ArgumentError] if values is not an Array of DuckDB::Value.
       def create_list(child_type, values)
-        check_type!(child_type, DuckDB::LogicalType)
         check_value_array!(values)
 
-        _create_list(child_type, values)
+        _create_list(DuckDB::LogicalType.resolve(child_type), values)
       end
 
       # Creates a DuckDB::Value of ARRAY type. The array size is the number
       # of elements given.
-      # The first argument is the DuckDB::LogicalType of the array elements.
+      # The first argument is the element type: a Symbol (e.g. :integer) or a
+      # DuckDB::LogicalType.
       # The second argument is an Array of DuckDB::Value elements.
       #
-      #   child_type = DuckDB::LogicalType.resolve(:integer)
       #   values = [1, 2, 3].map { |i| DuckDB::Value.create_int32(i) }
-      #   array = DuckDB::Value.create_array(child_type, values)
+      #   array = DuckDB::Value.create_array(:integer, values)
       #
-      # @param child_type [DuckDB::LogicalType] the element logical type.
+      # @param child_type [Symbol, DuckDB::LogicalType] the element logical type.
       # @param values [Array<DuckDB::Value>] the array elements.
       # @return [DuckDB::Value] the created Value object.
-      # @raise [ArgumentError] if child_type is not a DuckDB::LogicalType or
-      #   values is not an Array of DuckDB::Value.
+      # @raise [DuckDB::Error] if child_type cannot be resolved to a
+      #   DuckDB::LogicalType.
+      # @raise [ArgumentError] if values is not an Array of DuckDB::Value.
       def create_array(child_type, values)
-        check_type!(child_type, DuckDB::LogicalType)
         check_value_array!(values)
 
-        _create_array(child_type, values)
+        _create_array(DuckDB::LogicalType.resolve(child_type), values)
       end
 
       private

--- a/test/duckdb_test/table_function/bind_info_test.rb
+++ b/test/duckdb_test/table_function/bind_info_test.rb
@@ -78,6 +78,29 @@ module DuckDBTest
       assert_equal table_function, result
     end
 
+    def test_bind_get_parameter_returns_nil_for_null_argument
+      table_function = DuckDB::TableFunction.new
+      table_function.name = 'test_get_param_null'
+      table_function.add_parameter(DuckDB::LogicalType::BIGINT)
+
+      observed_parameter = :unset
+      table_function.bind do |bind_info|
+        observed_parameter = bind_info.get_parameter(0)
+        bind_info.add_result_column('value', DuckDB::LogicalType::BIGINT)
+      end
+
+      table_function.init { |_init_info| nil }
+
+      table_function.execute do |_func_info, output|
+        output.size = 0
+      end
+
+      @conn.register_table_function(table_function)
+      @conn.query('SELECT * FROM test_get_param_null(NULL)').each.to_a
+
+      assert_nil observed_parameter
+    end
+
     def test_bind_get_named_parameter
       table_function = DuckDB::TableFunction.new
       table_function.name = 'test_named_param'

--- a/test/duckdb_test/value_list_array_test.rb
+++ b/test/duckdb_test/value_list_array_test.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module DuckDBTest
+  class ValueListArrayTest < Minitest::Test
+    def int_values(*nums)
+      nums.map { |n| DuckDB::Value.create_int32(n) }
+    end
+
+    def integer_type
+      DuckDB::LogicalType.resolve(:integer)
+    end
+
+    def test_create_list
+      list = DuckDB::Value.create_list(integer_type, int_values(1, 2, 3))
+
+      assert_instance_of(DuckDB::Value, list)
+      assert_equal(3, list.list_size)
+    end
+
+    def test_list_child
+      list = DuckDB::Value.create_list(integer_type, int_values(10, 20))
+      child = list.list_child(1)
+
+      assert_instance_of(DuckDB::Value, child)
+    end
+
+    def test_list_child_out_of_range
+      list = DuckDB::Value.create_list(integer_type, int_values(10, 20))
+
+      assert_raises(IndexError) { list.list_child(2) }
+    end
+
+    def test_list_to_ruby
+      list = DuckDB::Value.create_list(integer_type, int_values(1, 2, 3))
+
+      assert_equal([1, 2, 3], list.to_ruby)
+    end
+
+    def test_scalar_to_ruby
+      assert_equal(42, DuckDB::Value.create_int32(42).to_ruby)
+    end
+
+    def test_empty_list_to_ruby
+      list = DuckDB::Value.create_list(integer_type, [])
+
+      assert_empty(list.to_ruby)
+    end
+
+    def test_list_with_null_element_to_ruby
+      values = [DuckDB::Value.create_int32(1), DuckDB::Value.create_null]
+      list = DuckDB::Value.create_list(integer_type, values)
+
+      assert_equal([1, nil], list.to_ruby)
+    end
+
+    def test_create_array
+      array = DuckDB::Value.create_array(integer_type, int_values(10, 20, 30))
+
+      assert_instance_of(DuckDB::Value, array)
+      assert_equal([10, 20, 30], array.to_ruby)
+    end
+
+    def test_array_with_null_element_to_ruby
+      values = [DuckDB::Value.create_int32(1), DuckDB::Value.create_null]
+      array = DuckDB::Value.create_array(integer_type, values)
+
+      assert_equal([1, nil], array.to_ruby)
+    end
+
+    def test_array_of_list_to_ruby
+      list_type = DuckDB::LogicalType.create_list(:integer)
+      inner1 = DuckDB::Value.create_list(integer_type, int_values(1))
+      inner2 = DuckDB::Value.create_list(integer_type, int_values(2, 3))
+      array = DuckDB::Value.create_array(list_type, [inner1, inner2])
+
+      assert_equal([[1], [2, 3]], array.to_ruby)
+    end
+
+    def test_create_list_with_invalid_element
+      assert_raises(ArgumentError) { DuckDB::Value.create_list(integer_type, [1, 2]) }
+    end
+
+    def test_create_list_with_invalid_type
+      assert_raises(ArgumentError) { DuckDB::Value.create_list(:integer, int_values(1)) }
+    end
+
+    def test_create_array_with_invalid_element
+      assert_raises(ArgumentError) { DuckDB::Value.create_array(integer_type, [1]) }
+    end
+
+    def test_bind_list_value_to_prepared_statement
+      db = DuckDB::Database.open
+      con = db.connect
+      list = DuckDB::Value.create_list(integer_type, int_values(1, 2, 3))
+      stmt = con.prepared_statement('SELECT list_sum(?::INTEGER[]) AS s')
+      stmt.bind_value(1, list)
+
+      assert_equal(6, stmt.execute.first.first)
+    ensure
+      con&.close
+      db&.close
+    end
+
+    def test_nested_list_to_ruby
+      list_type = DuckDB::LogicalType.create_list(:integer)
+      inner1 = DuckDB::Value.create_list(integer_type, int_values(1))
+      inner2 = DuckDB::Value.create_list(integer_type, int_values(2, 3))
+      list = DuckDB::Value.create_list(list_type, [inner1, inner2])
+
+      assert_equal([[1], [2, 3]], list.to_ruby)
+    end
+  end
+end

--- a/test/duckdb_test/value_list_array_test.rb
+++ b/test/duckdb_test/value_list_array_test.rb
@@ -32,6 +32,20 @@ module DuckDBTest
       assert_raises(IndexError) { list.list_child(2) }
     end
 
+    def test_list_size_on_non_list_value
+      assert_equal(0, DuckDB::Value.create_int32(42).list_size)
+    end
+
+    def test_list_child_on_non_list_value
+      assert_raises(IndexError) { DuckDB::Value.create_int32(42).list_child(0) }
+    end
+
+    def test_create_list_with_mismatched_element_type
+      values = [DuckDB::Value.create_varchar('x')]
+
+      assert_raises(DuckDB::Error) { DuckDB::Value.create_list(integer_type, values) }
+    end
+
     def test_list_to_ruby
       list = DuckDB::Value.create_list(integer_type, int_values(1, 2, 3))
 
@@ -60,6 +74,12 @@ module DuckDBTest
 
       assert_instance_of(DuckDB::Value, array)
       assert_equal([10, 20, 30], array.to_ruby)
+    end
+
+    def test_empty_array_to_ruby
+      array = DuckDB::Value.create_array(integer_type, [])
+
+      assert_empty(array.to_ruby)
     end
 
     def test_array_with_null_element_to_ruby
@@ -98,6 +118,19 @@ module DuckDBTest
       stmt.bind_value(1, list)
 
       assert_equal(6, stmt.execute.first.first)
+    ensure
+      con&.close
+      db&.close
+    end
+
+    def test_bind_array_value_to_prepared_statement
+      db = DuckDB::Database.open
+      con = db.connect
+      array = DuckDB::Value.create_array(integer_type, int_values(1, 2, 3))
+      stmt = con.prepared_statement('SELECT ?::INTEGER[3] AS a')
+      stmt.bind_value(1, array)
+
+      assert_equal([1, 2, 3], stmt.execute.first.first)
     ensure
       con&.close
       db&.close

--- a/test/duckdb_test/value_list_array_test.rb
+++ b/test/duckdb_test/value_list_array_test.rb
@@ -102,12 +102,28 @@ module DuckDBTest
       assert_raises(ArgumentError) { DuckDB::Value.create_list(integer_type, [1, 2]) }
     end
 
-    def test_create_list_with_invalid_type
-      assert_raises(ArgumentError) { DuckDB::Value.create_list(:integer, int_values(1)) }
+    def test_create_list_with_symbol_child_type
+      list = DuckDB::Value.create_list(:integer, int_values(1, 2, 3))
+
+      assert_equal([1, 2, 3], list.to_ruby)
+    end
+
+    def test_create_list_with_unknown_type
+      assert_raises(DuckDB::Error) { DuckDB::Value.create_list(:nonsense, int_values(1)) }
     end
 
     def test_create_array_with_invalid_element
       assert_raises(ArgumentError) { DuckDB::Value.create_array(integer_type, [1]) }
+    end
+
+    def test_create_array_with_symbol_child_type
+      array = DuckDB::Value.create_array(:integer, int_values(10, 20))
+
+      assert_equal([10, 20], array.to_ruby)
+    end
+
+    def test_create_array_with_unknown_type
+      assert_raises(DuckDB::Error) { DuckDB::Value.create_array(:nonsense, int_values(1)) }
     end
 
     def test_bind_list_value_to_prepared_statement


### PR DESCRIPTION
#refs #1273, #1274

## Summary
First of three PRs adding composite `DuckDB::Value` support (LIST/ARRAY here; STRUCT and MAP follow separately).

- `DuckDB::Value.create_list(child_type, values)` / `.create_array(child_type, values)` — build LIST/ARRAY values from a `DuckDB::LogicalType` (element type) and an Array of `DuckDB::Value` elements, wrapping `duckdb_create_list_value` / `duckdb_create_array_value`. Created values bind to prepared statements via the existing `#bind_value` (PG-array-style flow, covered by test).
- `DuckDB::Value#list_size` / `#list_child(index)` — low-level LIST getters returning `DuckDB::Value` (`IndexError` out of range).
- `DuckDB::Value#to_ruby` — converts a value to a Ruby object; LIST/ARRAY convert recursively to Array, NULL to `nil`. (Internal `rbduckdb_duckdb_value_to_ruby` gains a NULL-value guard, so table-function bind params / `Expression#fold` now also map SQL NULL to `nil`.)

Implementation notes:
- ARRAY values are read via a temporary vector (`duckdb_create_vector` + `duckdb_vector_reference_value` + `rbduckdb_vector_value_at`) because the C API has **no** `duckdb_get_array_size/child` — `duckdb_get_list_size/child` explicitly reject ARRAY values. For the same reason there are no low-level ARRAY getters.
- Element marshaling uses a heap-backed tmpbuf via `rb_alloc_tmp_buffer2` (exception-safe, no stack overflow on large arrays; ALLOCV_N was avoided because its alloca fast path would dangle across the function return); the buffer stays non-NULL for empty composites since `duckdb_create_*_value` rejects a NULL pointer.
- All C APIs used exist in DuckDB 1.4.0 (required minimum) — no feature guards.

## Test plan
New `test/duckdb_test/value_list_array_test.rb` (15 tests): round-trips (flat, empty, nested list-of-list, array-of-list), NULL elements, low-level getters + IndexError, ArgumentError validations, and binding a LIST value to a prepared statement (`list_sum`).
Full suite: 1200 runs, 0 failures. RuboCop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added Ruby APIs to create DuckDB LIST and ARRAY values from a child logical type and element values.
  - Added methods to inspect list contents (size and indexed child access).
  - Added conversion from LIST/ARRAY `DuckDB::Value` to native Ruby arrays, including nested structures and `NULL` → `nil`.
- **Bug Fixes**
  - Improved handling of `NULL` when retrieving bind parameters for table functions.
- **Tests**
  - Added Minitest coverage for LIST/ARRAY creation, inspection, conversion, error cases, and statement binding/querying.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
