### PR TITLE
Add edge case tests for prepared statement column metadata

### DIFF
--- a/test/duckdb_test/prepared_statement_column_metadata_test.rb
+++ b/test/duckdb_test/prepared_statement_column_metadata_test.rb
@@ -55,5 +55,28 @@ module DuckDBTest
       assert_equal 9, logical_type.width
       assert_equal 4, logical_type.scale
     end
+
+    def test_column_logical_type_out_of_range
+      stmt = @con.prepared_statement('SELECT id FROM users')
+
+      assert_raises(DuckDB::Error) { stmt.column_logical_type(1) }
+    end
+
+    # When any result column type is ambiguous (untyped parameter),
+    # metadata collapses to a single column of invalid type named 'unknown'.
+    def test_ambiguous_column_types
+      stmt = @con.prepared_statement('SELECT $1::TEXT, $2::INTEGER, $3')
+
+      assert_equal 1, stmt.column_count
+      assert_equal :invalid, stmt.column_type(0)
+      assert_equal :invalid, stmt.column_logical_type(0).type
+    end
+
+    def test_ambiguous_column_name
+      stmt = @con.prepared_statement('SELECT $1::TEXT, $2::INTEGER, $3')
+
+      assert_equal 'unknown', stmt.column_name(0)
+      assert_raises(DuckDB::Error) { stmt.column_name(1) }
+    end
   end
 end


### PR DESCRIPTION
Follow-up to #1385. Compared our tests against DuckDB's own C API tests (`test/api/capi/test_capi_prepared.cpp`) and added the two missing cases:

- **Ambiguous result types**: a statement with an untyped parameter (`SELECT $1::TEXT, $2::INTEGER, $3`) collapses metadata to a single column — `column_count == 1`, `column_type`/`column_logical_type` return `:invalid`, `column_name(0) == 'unknown'`.
- **Out-of-range `#column_logical_type`** raises `DuckDB::Error` (the name/type variants were already tested).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for prepared-statement column metadata edge cases.
  * Improved validation for out-of-range column lookups.
  * Verified ambiguous or untyped results are reported consistently with an `unknown` column and invalid type metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->