### PR TITLE
Add edge case tests for PreparedStatement#param_logical_type

### DIFF
--- a/test/duckdb_test/prepared_statement_param_logical_type_test.rb
+++ b/test/duckdb_test/prepared_statement_param_logical_type_test.rb
@@ -31,10 +31,38 @@ module DuckDBTest
       assert_equal(4, logical_type.scale)
     end
 
+    def test_param_logical_type_list
+      @con.query('CREATE TABLE items (tags INTEGER[])')
+      stmt = @con.prepared_statement('SELECT * FROM items WHERE tags = ?')
+      logical_type = stmt.param_logical_type(1)
+
+      assert_equal(:list, logical_type.type)
+      assert_equal(:integer, logical_type.child_type.type)
+    end
+
+    def test_param_logical_type_named_parameter
+      stmt = @con.prepared_statement('SELECT * FROM users WHERE id = $id')
+      logical_type = stmt.param_logical_type(stmt.bind_parameter_index('id'))
+
+      assert_equal(:integer, logical_type.type)
+    end
+
+    def test_param_logical_type_untyped_parameter
+      stmt = @con.prepared_statement('SELECT $1')
+
+      assert_raises(DuckDB::Error) { stmt.param_logical_type(1) }
+    end
+
     def test_param_logical_type_out_of_range
       stmt = @con.prepared_statement('SELECT * FROM users WHERE id = ?')
 
       assert_raises(DuckDB::Error) { stmt.param_logical_type(2) }
+    end
+
+    def test_param_logical_type_with_zero_index
+      stmt = @con.prepared_statement('SELECT * FROM users WHERE id = ?')
+
+      assert_raises(ArgumentError) { stmt.param_logical_type(0) }
     end
   end
 end


### PR DESCRIPTION
## Summary
Follow-up to #1386. Adds edge case tests for `param_logical_type` covering gaps found by comparing against DuckDB's own C API tests (`test/api/capi/test_capi_prepared.cpp`):

- **list parameter** — nested type resolves with `child_type` (the richer-than-`param_type` case the method exists for)
- **named parameter** — works via `bind_parameter_index`
- **untyped parameter** (`SELECT $1`) — raises `DuckDB::Error` (C API returns NULL)
- **zero index** — raises `ArgumentError`

## Test plan
- [x] `bundle exec ruby -Ilib:test test/duckdb_test/prepared_statement_param_logical_type_test.rb` — 7 runs, 0 failures
- [x] `bundle exec rake test` — 1195 runs, 0 failures, 0 errors
- [x] `bundle exec rubocop` — no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for prepared statement parameter type reporting.
  * Added validation for list and named parameters.
  * Added checks for errors caused by untyped, out-of-range, and zero-index parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->