### PR TITLE
Add Appender tests for LIST/ARRAY values

### DIFF
--- a/test/duckdb_test/appender_test.rb
+++ b/test/duckdb_test/appender_test.rb
@@ -247,6 +247,24 @@ module DuckDBTest
       assert_duckdb_appender(42, 'INTEGER') { |a| a.append_value(value) }
     end
 
+    def test_append_value_with_list
+      values = [1, 2, 3].map { |i| DuckDB::Value.create_int32(i) }
+      list = DuckDB::Value.create_list(:integer, values)
+      assert_duckdb_appender([1, 2, 3], 'INTEGER[]') { |a| a.append_value(list) }
+    end
+
+    def test_append_value_with_list_containing_null
+      values = [DuckDB::Value.create_int32(1), DuckDB::Value.create_null]
+      list = DuckDB::Value.create_list(:integer, values)
+      assert_duckdb_appender([1, nil], 'INTEGER[]') { |a| a.append_value(list) }
+    end
+
+    def test_append_value_with_array
+      values = [10, 20, 30].map { |i| DuckDB::Value.create_int32(i) }
+      array = DuckDB::Value.create_array(:integer, values)
+      assert_duckdb_appender([10, 20, 30], 'INTEGER[3]') { |a| a.append_value(array) }
+    end
+
     def test_append_value_with_invalid_type
       create_appender('col INTEGER')
       e = assert_raises(ArgumentError) { @appender.append_value(42) }


### PR DESCRIPTION
## Summary
Follow-up to #1387. `Appender#append_value` already wraps `duckdb_append_value`, which supports composite values — so LIST/ARRAY values created with the new `DuckDB::Value.create_list` / `.create_array` can be appended today, just without coverage. This adds the missing tests:

- append a LIST value to an `INTEGER[]` column
- append a LIST containing a NULL element (round-trips as `[1, nil]`)
- append an ARRAY value to an `INTEGER[3]` column

No production code changes.

## Test plan
- [x] `bundle exec ruby -Ilib:test test/duckdb_test/appender_test.rb` — 162 runs, 0 failures
- [x] `bundle exec rubocop` — no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)