### PR TITLE
Add DuckDB::Value.create_date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 - add `DuckDB::PreparedStatement#column_count`, `#column_name(col_index)`, `#column_type(col_index)` and `#column_logical_type(col_index)` to get the result-set column metadata of a prepared statement without executing it (column index is 0-based). Useful for PG-style statement caching where column types must be known before execution.
 - add `DuckDB::Error#error_type` returning the DuckDB error category as a Symbol (e.g. `:constraint`, `:catalog`, `:parser`), or `nil` for errors not originating from a query result. Helps the ActiveRecord adapter map failures to `RecordNotUnique` / `NotNullViolation` etc. without parsing error messages.
 - add `DuckDB::PreparedStatement#param_logical_type(param_index)` returning the `DuckDB::LogicalType` of a bind parameter (1-based index), giving richer type information than `#param_type` (e.g. decimal width/scale, nested types).
+- add `DuckDB::Value.create_date(value)` to create DATE values from a Date, a Time, or a parseable String (same lenient input as `Appender#append_date`).
 
 # 1.5.4.0 - 2026-06-20
 - bump up DuckDB 1.5.4 and 1.4.5 on CI.

--- a/ext/duckdb/value.c
+++ b/ext/duckdb/value.c
@@ -21,6 +21,7 @@ static VALUE value_s__create_blob(VALUE klass, VALUE str);
 static VALUE value_s__create_hugeint(VALUE klass, VALUE lower, VALUE upper);
 static VALUE value_s__create_uhugeint(VALUE klass, VALUE lower, VALUE upper);
 static VALUE value_s__create_decimal(VALUE klass, VALUE lower, VALUE upper, VALUE width, VALUE scale);
+static VALUE value_s__create_date(VALUE klass, VALUE year, VALUE month, VALUE day);
 static VALUE value_s_create_null(VALUE klass);
 static idx_t marshal_values(VALUE ary, duckdb_value **out, volatile VALUE *guard);
 static VALUE value_s__create_list(VALUE klass, VALUE ltype, VALUE values);
@@ -149,6 +150,12 @@ static VALUE value_s__create_decimal(VALUE klass, VALUE lower, VALUE upper, VALU
     decimal.width = (uint8_t)NUM2UINT(width);
     decimal.scale = (uint8_t)NUM2UINT(scale);
     duckdb_value value = duckdb_create_decimal(decimal);
+    return rbduckdb_value_new(value);
+}
+
+/* :nodoc: */
+static VALUE value_s__create_date(VALUE klass, VALUE year, VALUE month, VALUE day) {
+    duckdb_value value = duckdb_create_date(rbduckdb_to_duckdb_date_from_value(year, month, day));
     return rbduckdb_value_new(value);
 }
 
@@ -605,6 +612,7 @@ void rbduckdb_init_value(void) {
     rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_hugeint", value_s__create_hugeint, 2);
     rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_uhugeint", value_s__create_uhugeint, 2);
     rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_decimal", value_s__create_decimal, 4);
+    rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_date", value_s__create_date, 3);
     rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_list", value_s__create_list, 2);
     rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_array", value_s__create_array, 2);
     rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_struct", value_s__create_struct, 2);

--- a/lib/duckdb/value.rb
+++ b/lib/duckdb/value.rb
@@ -238,6 +238,21 @@ module DuckDB
         _create_decimal(lower, upper, width, value.scale)
       end
 
+      # Creates a DuckDB::Value of DATE type.
+      # The argument is parsed leniently: a Date, a Time, or a String
+      # accepted by Date.parse, matching Appender#append_date.
+      #
+      #   value = DuckDB::Value.create_date(Date.new(2026, 7, 12))
+      #   value = DuckDB::Value.create_date('2026-07-12')
+      #
+      # @param value [Date, Time, String] the date value.
+      # @return [DuckDB::Value] the created Value object.
+      # @raise [ArgumentError] if +value+ cannot be parsed to a Date.
+      def create_date(value)
+        date = _parse_date(value)
+        _create_date(date.year, date.month, date.day)
+      end
+
       # Creates a DuckDB::Value of LIST type.
       # The first argument is the element type: a Symbol (e.g. :integer) or a
       # DuckDB::LogicalType.

--- a/test/duckdb_test/value_temporal_test.rb
+++ b/test/duckdb_test/value_temporal_test.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module DuckDBTest
+  class ValueTemporalTest < Minitest::Test
+    def test_create_date_with_date
+      value = DuckDB::Value.create_date(Date.new(2026, 7, 12))
+
+      assert_instance_of(DuckDB::Value, value)
+      assert_equal(Date.new(2026, 7, 12), value.to_ruby)
+    end
+
+    def test_create_date_with_string
+      assert_equal(Date.new(2026, 7, 12), DuckDB::Value.create_date('2026-07-12').to_ruby)
+    end
+
+    def test_create_date_with_time
+      time = Time.local(2026, 7, 12, 1, 2, 3)
+
+      assert_equal(Date.new(2026, 7, 12), DuckDB::Value.create_date(time).to_ruby)
+    end
+
+    def test_create_date_with_invalid_string_raises_argument_error
+      assert_raises(ArgumentError) { DuckDB::Value.create_date('not a date') }
+    end
+
+    def test_create_date_with_nil_raises_argument_error
+      assert_raises(ArgumentError) { DuckDB::Value.create_date(nil) }
+    end
+  end
+end


### PR DESCRIPTION
Adds `DuckDB::Value.create_date(value)` building a DATE value. Lenient input per the temporal-creator convention (ADR 0004): accepts a `Date`, a `Time`, or a parseable date `String`, matching `Appender#append_date`. `to_ruby` round-trips to the equivalent `Date`; unparseable input raises `ArgumentError`.

Part of the DuckDB::Value API stack (#1393–#1411). First PR of the stack (based on `main`).

Closes #1393

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `DuckDB::Value.create_date` for creating DATE values from `Date`, `Time`, or parseable date strings.
  * Invalid or unsupported inputs now raise `ArgumentError`.

* **Tests**
  * Added coverage for supported date inputs, conversions, and invalid values.

* **Documentation**
  * Documented the new date value creation method in the unreleased changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->