### PR TITLE
Add DuckDB::Value.create_time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 - add `DuckDB::Error#error_type` returning the DuckDB error category as a Symbol (e.g. `:constraint`, `:catalog`, `:parser`), or `nil` for errors not originating from a query result. Helps the ActiveRecord adapter map failures to `RecordNotUnique` / `NotNullViolation` etc. without parsing error messages.
 - add `DuckDB::PreparedStatement#param_logical_type(param_index)` returning the `DuckDB::LogicalType` of a bind parameter (1-based index), giving richer type information than `#param_type` (e.g. decimal width/scale, nested types).
 - add `DuckDB::Value.create_date(value)` to create DATE values from a Date, a Time, or a parseable String (same lenient input as `Appender#append_date`).
+- add `DuckDB::Value.create_time(value)` to create TIME values (microsecond precision) from a Time or a parseable String.
 
 # 1.5.4.0 - 2026-06-20
 - bump up DuckDB 1.5.4 and 1.4.5 on CI.

--- a/ext/duckdb/value.c
+++ b/ext/duckdb/value.c
@@ -22,6 +22,7 @@ static VALUE value_s__create_hugeint(VALUE klass, VALUE lower, VALUE upper);
 static VALUE value_s__create_uhugeint(VALUE klass, VALUE lower, VALUE upper);
 static VALUE value_s__create_decimal(VALUE klass, VALUE lower, VALUE upper, VALUE width, VALUE scale);
 static VALUE value_s__create_date(VALUE klass, VALUE year, VALUE month, VALUE day);
+static VALUE value_s__create_time(VALUE klass, VALUE hour, VALUE min, VALUE sec, VALUE micros);
 static VALUE value_s_create_null(VALUE klass);
 static idx_t marshal_values(VALUE ary, duckdb_value **out, volatile VALUE *guard);
 static VALUE value_s__create_list(VALUE klass, VALUE ltype, VALUE values);
@@ -156,6 +157,12 @@ static VALUE value_s__create_decimal(VALUE klass, VALUE lower, VALUE upper, VALU
 /* :nodoc: */
 static VALUE value_s__create_date(VALUE klass, VALUE year, VALUE month, VALUE day) {
     duckdb_value value = duckdb_create_date(rbduckdb_to_duckdb_date_from_value(year, month, day));
+    return rbduckdb_value_new(value);
+}
+
+/* :nodoc: */
+static VALUE value_s__create_time(VALUE klass, VALUE hour, VALUE min, VALUE sec, VALUE micros) {
+    duckdb_value value = duckdb_create_time(rbduckdb_to_duckdb_time_from_value(hour, min, sec, micros));
     return rbduckdb_value_new(value);
 }
 
@@ -613,6 +620,7 @@ void rbduckdb_init_value(void) {
     rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_uhugeint", value_s__create_uhugeint, 2);
     rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_decimal", value_s__create_decimal, 4);
     rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_date", value_s__create_date, 3);
+    rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_time", value_s__create_time, 4);
     rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_list", value_s__create_list, 2);
     rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_array", value_s__create_array, 2);
     rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_struct", value_s__create_struct, 2);

--- a/lib/duckdb/value.rb
+++ b/lib/duckdb/value.rb
@@ -253,6 +253,21 @@ module DuckDB
         _create_date(date.year, date.month, date.day)
       end
 
+      # Creates a DuckDB::Value of TIME type (microsecond precision).
+      # The argument is parsed leniently: a Time or a String accepted by
+      # Time.parse, matching Appender#append_time.
+      #
+      #   value = DuckDB::Value.create_time(Time.now)
+      #   value = DuckDB::Value.create_time('12:34:56.789')
+      #
+      # @param value [Time, String] the time value.
+      # @return [DuckDB::Value] the created Value object.
+      # @raise [ArgumentError] if +value+ cannot be parsed to a Time.
+      def create_time(value)
+        time = _parse_time(value)
+        _create_time(time.hour, time.min, time.sec, time.usec)
+      end
+
       # Creates a DuckDB::Value of LIST type.
       # The first argument is the element type: a Symbol (e.g. :integer) or a
       # DuckDB::LogicalType.

--- a/test/duckdb_test/value_temporal_test.rb
+++ b/test/duckdb_test/value_temporal_test.rb
@@ -21,6 +21,30 @@ module DuckDBTest
       assert_equal(Date.new(2026, 7, 12), DuckDB::Value.create_date(time).to_ruby)
     end
 
+    def test_create_time_with_time
+      time = Time.local(2026, 7, 12, 12, 34, 56, 789_012)
+      value = DuckDB::Value.create_time(time)
+
+      assert_instance_of(DuckDB::Value, value)
+      result = value.to_ruby
+
+      assert_equal([12, 34, 56, 789_012], [result.hour, result.min, result.sec, result.usec])
+    end
+
+    def test_create_time_with_string
+      result = DuckDB::Value.create_time('12:34:56.789').to_ruby
+
+      assert_equal([12, 34, 56, 789_000], [result.hour, result.min, result.sec, result.usec])
+    end
+
+    def test_create_time_with_invalid_string_raises_argument_error
+      assert_raises(ArgumentError) { DuckDB::Value.create_time('not a time') }
+    end
+
+    def test_create_time_with_nil_raises_argument_error
+      assert_raises(ArgumentError) { DuckDB::Value.create_time(nil) }
+    end
+
     def test_create_date_with_invalid_string_raises_argument_error
       assert_raises(ArgumentError) { DuckDB::Value.create_date('not a date') }
     end


### PR DESCRIPTION
Adds `DuckDB::Value.create_time(value)` building a TIME value (microsecond precision) from a `Time` or a parseable `String`. `to_ruby` round-trips preserving microseconds; unparseable input raises `ArgumentError`.

Part of the DuckDB::Value API stack (#1393–#1411). Stacked on `feature/date-value` — only the last commit(s) are new here; GitHub will retarget this PR to `main` automatically once the base PR merges and its branch is deleted.

Closes #1394

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `DuckDB::Value.create_time` for creating TIME values from `Time` objects or parseable strings.
  * Supports microsecond precision and validates invalid or missing input.

* **Tests**
  * Added coverage for valid time values, string parsing, microseconds, and invalid inputs.

* **Documentation**
  * Documented the new TIME value creation method in the unreleased changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->