### PR TITLE
Add DuckDB::Value.create_time_ns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 - add `DuckDB::PreparedStatement#param_logical_type(param_index)` returning the `DuckDB::LogicalType` of a bind parameter (1-based index), giving richer type information than `#param_type` (e.g. decimal width/scale, nested types).
 - add `DuckDB::Value.create_date(value)` to create DATE values from a Date, a Time, or a parseable String (same lenient input as `Appender#append_date`).
 - add `DuckDB::Value.create_time(value)` to create TIME values (microsecond precision) from a Time or a parseable String.
+- add `DuckDB::Value.create_time_ns(value)` to create TIME_NS values (nanosecond precision) from a Time or a parseable String. TIME_NS values are now converted to Ruby Time with full nanosecond precision (previously truncated to microseconds).
 
 # 1.5.4.0 - 2026-06-20
 - bump up DuckDB 1.5.4 and 1.4.5 on CI.

--- a/ext/duckdb/value.c
+++ b/ext/duckdb/value.c
@@ -23,6 +23,7 @@ static VALUE value_s__create_uhugeint(VALUE klass, VALUE lower, VALUE upper);
 static VALUE value_s__create_decimal(VALUE klass, VALUE lower, VALUE upper, VALUE width, VALUE scale);
 static VALUE value_s__create_date(VALUE klass, VALUE year, VALUE month, VALUE day);
 static VALUE value_s__create_time(VALUE klass, VALUE hour, VALUE min, VALUE sec, VALUE micros);
+static VALUE value_s__create_time_ns(VALUE klass, VALUE hour, VALUE min, VALUE sec, VALUE nanos);
 static VALUE value_s_create_null(VALUE klass);
 static idx_t marshal_values(VALUE ary, duckdb_value **out, volatile VALUE *guard);
 static VALUE value_s__create_list(VALUE klass, VALUE ltype, VALUE values);
@@ -164,6 +165,14 @@ static VALUE value_s__create_date(VALUE klass, VALUE year, VALUE month, VALUE da
 static VALUE value_s__create_time(VALUE klass, VALUE hour, VALUE min, VALUE sec, VALUE micros) {
     duckdb_value value = duckdb_create_time(rbduckdb_to_duckdb_time_from_value(hour, min, sec, micros));
     return rbduckdb_value_new(value);
+}
+
+/* :nodoc: */
+static VALUE value_s__create_time_ns(VALUE klass, VALUE hour, VALUE min, VALUE sec, VALUE nanos) {
+    duckdb_time_ns time_ns;
+
+    time_ns.nanos = ((NUM2LL(hour) * 60 + NUM2LL(min)) * 60 + NUM2LL(sec)) * 1000000000LL + NUM2LL(nanos);
+    return rbduckdb_value_new(duckdb_create_time_ns(time_ns));
 }
 
 /*
@@ -621,6 +630,7 @@ void rbduckdb_init_value(void) {
     rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_decimal", value_s__create_decimal, 4);
     rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_date", value_s__create_date, 3);
     rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_time", value_s__create_time, 4);
+    rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_time_ns", value_s__create_time_ns, 4);
     rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_list", value_s__create_list, 2);
     rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_array", value_s__create_array, 2);
     rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_struct", value_s__create_struct, 2);

--- a/lib/duckdb/converter.rb
+++ b/lib/duckdb/converter.rb
@@ -89,12 +89,12 @@ module DuckDB
 
     def _to_time_from_duckdb_time_ns(nanos)
       hour = nanos / 3_600_000_000_000
-      nanos %= 3_600_000_000_000
-      min = nanos / 60_000_000_000
-      nanos %= 60_000_000_000
-      sec = nanos / 1_000_000_000
-      microsecond = (nanos % 1_000_000_000) / 1_000
-      _to_time_from_duckdb_time(hour, min, sec, microsecond)
+      min = nanos % 3_600_000_000_000 / 60_000_000_000
+      sec = nanos % 60_000_000_000 / 1_000_000_000
+      nsec = nanos % 1_000_000_000
+      return Time.utc(1970, 1, 1, hour, min, sec, Rational(nsec, 1_000)) if default_timezone_utc?
+
+      Time.parse(format('%<hour>02d:%<min>02d:%<sec>02d.%<nsec>09d', hour: hour, min: min, sec: sec, nsec: nsec))
     end
 
     def _to_time_from_duckdb_time_tz(hour, min, sec, micro, timezone)

--- a/lib/duckdb/value.rb
+++ b/lib/duckdb/value.rb
@@ -268,6 +268,21 @@ module DuckDB
         _create_time(time.hour, time.min, time.sec, time.usec)
       end
 
+      # Creates a DuckDB::Value of TIME_NS type (nanosecond precision).
+      # The argument is parsed leniently: a Time or a String accepted by
+      # Time.parse. Nanoseconds are preserved.
+      #
+      #   value = DuckDB::Value.create_time_ns(Time.now)
+      #   value = DuckDB::Value.create_time_ns('12:34:56.123456789')
+      #
+      # @param value [Time, String] the time value.
+      # @return [DuckDB::Value] the created Value object.
+      # @raise [ArgumentError] if +value+ cannot be parsed to a Time.
+      def create_time_ns(value)
+        time = _parse_time(value)
+        _create_time_ns(time.hour, time.min, time.sec, time.nsec)
+      end
+
       # Creates a DuckDB::Value of LIST type.
       # The first argument is the element type: a Symbol (e.g. :integer) or a
       # DuckDB::LogicalType.

--- a/test/duckdb_test/value_temporal_test.rb
+++ b/test/duckdb_test/value_temporal_test.rb
@@ -45,6 +45,30 @@ module DuckDBTest
       assert_raises(ArgumentError) { DuckDB::Value.create_time(nil) }
     end
 
+    def test_create_time_ns_with_time_preserves_nanoseconds
+      time = Time.local(2026, 7, 12, 12, 34, 56, Rational(123_456_789, 1000))
+      value = DuckDB::Value.create_time_ns(time)
+
+      assert_instance_of(DuckDB::Value, value)
+      result = value.to_ruby
+
+      assert_equal([12, 34, 56, 123_456_789], [result.hour, result.min, result.sec, result.nsec])
+    end
+
+    def test_create_time_ns_with_string
+      result = DuckDB::Value.create_time_ns('12:34:56.123456789').to_ruby
+
+      assert_equal(123_456_789, result.nsec)
+    end
+
+    def test_create_time_ns_with_invalid_string_raises_argument_error
+      assert_raises(ArgumentError) { DuckDB::Value.create_time_ns('not a time') }
+    end
+
+    def test_create_time_ns_with_nil_raises_argument_error
+      assert_raises(ArgumentError) { DuckDB::Value.create_time_ns(nil) }
+    end
+
     def test_create_date_with_invalid_string_raises_argument_error
       assert_raises(ArgumentError) { DuckDB::Value.create_date('not a date') }
     end

--- a/test/duckdb_test/value_temporal_test.rb
+++ b/test/duckdb_test/value_temporal_test.rb
@@ -46,6 +46,9 @@ module DuckDBTest
     end
 
     def test_create_time_ns_with_time_preserves_nanoseconds
+      # Value#to_ruby cannot convert TIME_NS on DuckDB < 1.5.0.
+      skip 'TIME_NS requires DuckDB >= 1.5.0' if ::DuckDBTest.duckdb_library_version < Gem::Version.new('1.5.0')
+
       time = Time.local(2026, 7, 12, 12, 34, 56, Rational(123_456_789, 1000))
       value = DuckDB::Value.create_time_ns(time)
 
@@ -56,6 +59,9 @@ module DuckDBTest
     end
 
     def test_create_time_ns_with_string
+      # Value#to_ruby cannot convert TIME_NS on DuckDB < 1.5.0.
+      skip 'TIME_NS requires DuckDB >= 1.5.0' if ::DuckDBTest.duckdb_library_version < Gem::Version.new('1.5.0')
+
       result = DuckDB::Value.create_time_ns('12:34:56.123456789').to_ruby
 
       assert_equal(123_456_789, result.nsec)


### PR DESCRIPTION
Adds `DuckDB::Value.create_time_ns(value)` building a TIME_NS value (nanosecond precision) from a `Time` or a parseable `String`. To satisfy the nanosecond round-trip criterion, TIME_NS→Ruby conversion now preserves nanoseconds (Rational subsec) instead of truncating to microseconds.

Part of the DuckDB::Value API stack (#1393–#1411). Stacked on `feature/time-value` — only the last commit(s) are new here; GitHub will retarget this PR to `main` automatically once the base PR merges and its branch is deleted.

Closes #1395

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `DuckDB::Value.create_time_ns` for creating `TIME_NS` values from Ruby `Time` objects or parseable strings.
  * Preserves nanosecond precision during TIME_NS conversions.

* **Bug Fixes**
  * Fixed TIME_NS conversions that previously truncated nanoseconds to microseconds.

* **Tests**
  * Added coverage for nanosecond preservation, string parsing, and invalid input handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->