### PR TITLE
Add DuckDB::Value.create_time_tz

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 - add `DuckDB::Value.create_date(value)` to create DATE values from a Date, a Time, or a parseable String (same lenient input as `Appender#append_date`).
 - add `DuckDB::Value.create_time(value)` to create TIME values (microsecond precision) from a Time or a parseable String.
 - add `DuckDB::Value.create_time_ns(value)` to create TIME_NS values (nanosecond precision) from a Time or a parseable String. TIME_NS values are now converted to Ruby Time with full nanosecond precision (previously truncated to microseconds).
+- add `DuckDB::Value.create_time_tz(value)` to create TIMETZ values from a Time (the UTC offset is taken from the Time) or a parseable String with offset.
 
 # 1.5.4.0 - 2026-06-20
 - bump up DuckDB 1.5.4 and 1.4.5 on CI.

--- a/ext/duckdb/value.c
+++ b/ext/duckdb/value.c
@@ -24,6 +24,7 @@ static VALUE value_s__create_decimal(VALUE klass, VALUE lower, VALUE upper, VALU
 static VALUE value_s__create_date(VALUE klass, VALUE year, VALUE month, VALUE day);
 static VALUE value_s__create_time(VALUE klass, VALUE hour, VALUE min, VALUE sec, VALUE micros);
 static VALUE value_s__create_time_ns(VALUE klass, VALUE hour, VALUE min, VALUE sec, VALUE nanos);
+static VALUE value_s__create_time_tz(VALUE klass, VALUE micros, VALUE offset);
 static VALUE value_s_create_null(VALUE klass);
 static idx_t marshal_values(VALUE ary, duckdb_value **out, volatile VALUE *guard);
 static VALUE value_s__create_list(VALUE klass, VALUE ltype, VALUE values);
@@ -173,6 +174,12 @@ static VALUE value_s__create_time_ns(VALUE klass, VALUE hour, VALUE min, VALUE s
 
     time_ns.nanos = ((NUM2LL(hour) * 60 + NUM2LL(min)) * 60 + NUM2LL(sec)) * 1000000000LL + NUM2LL(nanos);
     return rbduckdb_value_new(duckdb_create_time_ns(time_ns));
+}
+
+/* :nodoc: */
+static VALUE value_s__create_time_tz(VALUE klass, VALUE micros, VALUE offset) {
+    duckdb_time_tz time_tz = duckdb_create_time_tz(NUM2LL(micros), NUM2INT(offset));
+    return rbduckdb_value_new(duckdb_create_time_tz_value(time_tz));
 }
 
 /*
@@ -631,6 +638,7 @@ void rbduckdb_init_value(void) {
     rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_date", value_s__create_date, 3);
     rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_time", value_s__create_time, 4);
     rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_time_ns", value_s__create_time_ns, 4);
+    rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_time_tz", value_s__create_time_tz, 2);
     rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_list", value_s__create_list, 2);
     rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_array", value_s__create_array, 2);
     rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_struct", value_s__create_struct, 2);

--- a/lib/duckdb/value.rb
+++ b/lib/duckdb/value.rb
@@ -283,6 +283,22 @@ module DuckDB
         _create_time_ns(time.hour, time.min, time.sec, time.nsec)
       end
 
+      # Creates a DuckDB::Value of TIMETZ type (time with UTC offset).
+      # The argument is parsed leniently: a Time (the offset is taken from
+      # the Time) or a String accepted by Time.parse.
+      #
+      #   value = DuckDB::Value.create_time_tz(Time.now)
+      #   value = DuckDB::Value.create_time_tz('12:34:56.789012+05:30')
+      #
+      # @param value [Time, String] the time value.
+      # @return [DuckDB::Value] the created Value object.
+      # @raise [ArgumentError] if +value+ cannot be parsed to a Time.
+      def create_time_tz(value)
+        time = _parse_time(value)
+        micros = (((((time.hour * 60) + time.min) * 60) + time.sec) * 1_000_000) + time.usec
+        _create_time_tz(micros, time.utc_offset)
+      end
+
       # Creates a DuckDB::Value of LIST type.
       # The first argument is the element type: a Symbol (e.g. :integer) or a
       # DuckDB::LogicalType.

--- a/test/duckdb_test/value_temporal_test.rb
+++ b/test/duckdb_test/value_temporal_test.rb
@@ -75,6 +75,31 @@ module DuckDBTest
       assert_raises(ArgumentError) { DuckDB::Value.create_time_ns(nil) }
     end
 
+    def test_create_time_tz_with_time
+      time = Time.new(2026, 7, 12, 12, 34, 56, '+05:30')
+      value = DuckDB::Value.create_time_tz(time)
+
+      assert_instance_of(DuckDB::Value, value)
+      result = value.to_ruby
+
+      assert_equal([12, 34, 56, 19_800], [result.hour, result.min, result.sec, result.utc_offset])
+    end
+
+    def test_create_time_tz_with_string
+      result = DuckDB::Value.create_time_tz('12:34:56.789012-08:00').to_ruby
+
+      assert_equal([12, 34, 56, 789_012, -28_800],
+                   [result.hour, result.min, result.sec, result.usec, result.utc_offset])
+    end
+
+    def test_create_time_tz_with_invalid_string_raises_argument_error
+      assert_raises(ArgumentError) { DuckDB::Value.create_time_tz('not a time') }
+    end
+
+    def test_create_time_tz_with_nil_raises_argument_error
+      assert_raises(ArgumentError) { DuckDB::Value.create_time_tz(nil) }
+    end
+
     def test_create_date_with_invalid_string_raises_argument_error
       assert_raises(ArgumentError) { DuckDB::Value.create_date('not a date') }
     end


### PR DESCRIPTION
Adds `DuckDB::Value.create_time_tz(value)` building a TIMETZ value from a `Time` (offset taken from the Time) or a parseable `String` with offset. `to_ruby` round-trips time-of-day and offset.

Part of the DuckDB::Value API stack (#1393–#1411). Stacked on `feature/time-ns-value` — only the last commit(s) are new here; GitHub will retarget this PR to `main` automatically once the base PR merges and its branch is deleted.

Closes #1396

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `DuckDB::Value.create_time_tz` for creating timezone-aware `TIMETZ` values from `Time` objects or timezone-qualified strings.
  - Preserves local time components and UTC offsets.

- **Bug Fixes**
  - Invalid time strings and `nil` inputs now raise `ArgumentError`.

- **Documentation**
  - Documented the new `create_time_tz` factory method in the changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->