### PR TITLE
Add DuckDB::Value.create_timestamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 - add `DuckDB::Value.create_time(value)` to create TIME values (microsecond precision) from a Time or a parseable String.
 - add `DuckDB::Value.create_time_ns(value)` to create TIME_NS values (nanosecond precision) from a Time or a parseable String. TIME_NS values are now converted to Ruby Time with full nanosecond precision (previously truncated to microseconds).
 - add `DuckDB::Value.create_time_tz(value)` to create TIMETZ values from a Time (the UTC offset is taken from the Time) or a parseable String with offset.
+- add `DuckDB::Value.create_timestamp(value)` to create TIMESTAMP values (microsecond precision) from a Time, a Date, or a parseable String (same lenient input as `Appender#append_timestamp`).
 
 # 1.5.4.0 - 2026-06-20
 - bump up DuckDB 1.5.4 and 1.4.5 on CI.

--- a/ext/duckdb/value.c
+++ b/ext/duckdb/value.c
@@ -25,6 +25,7 @@ static VALUE value_s__create_date(VALUE klass, VALUE year, VALUE month, VALUE da
 static VALUE value_s__create_time(VALUE klass, VALUE hour, VALUE min, VALUE sec, VALUE micros);
 static VALUE value_s__create_time_ns(VALUE klass, VALUE hour, VALUE min, VALUE sec, VALUE nanos);
 static VALUE value_s__create_time_tz(VALUE klass, VALUE micros, VALUE offset);
+static VALUE value_s__create_timestamp(VALUE klass, VALUE year, VALUE month, VALUE day, VALUE hour, VALUE min, VALUE sec, VALUE micros);
 static VALUE value_s_create_null(VALUE klass);
 static idx_t marshal_values(VALUE ary, duckdb_value **out, volatile VALUE *guard);
 static VALUE value_s__create_list(VALUE klass, VALUE ltype, VALUE values);
@@ -180,6 +181,12 @@ static VALUE value_s__create_time_ns(VALUE klass, VALUE hour, VALUE min, VALUE s
 static VALUE value_s__create_time_tz(VALUE klass, VALUE micros, VALUE offset) {
     duckdb_time_tz time_tz = duckdb_create_time_tz(NUM2LL(micros), NUM2INT(offset));
     return rbduckdb_value_new(duckdb_create_time_tz_value(time_tz));
+}
+
+/* :nodoc: */
+static VALUE value_s__create_timestamp(VALUE klass, VALUE year, VALUE month, VALUE day, VALUE hour, VALUE min, VALUE sec, VALUE micros) {
+    duckdb_timestamp timestamp = rbduckdb_to_duckdb_timestamp_from_value(year, month, day, hour, min, sec, micros);
+    return rbduckdb_value_new(duckdb_create_timestamp(timestamp));
 }
 
 /*
@@ -639,6 +646,7 @@ void rbduckdb_init_value(void) {
     rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_time", value_s__create_time, 4);
     rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_time_ns", value_s__create_time_ns, 4);
     rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_time_tz", value_s__create_time_tz, 2);
+    rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_timestamp", value_s__create_timestamp, 7);
     rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_list", value_s__create_list, 2);
     rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_array", value_s__create_array, 2);
     rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_struct", value_s__create_struct, 2);

--- a/lib/duckdb/value.rb
+++ b/lib/duckdb/value.rb
@@ -299,6 +299,21 @@ module DuckDB
         _create_time_tz(micros, time.utc_offset)
       end
 
+      # Creates a DuckDB::Value of TIMESTAMP type (microsecond precision).
+      # The argument is parsed leniently: a Time, a Date, or a String
+      # accepted by Time.parse, matching Appender#append_timestamp.
+      #
+      #   value = DuckDB::Value.create_timestamp(Time.now)
+      #   value = DuckDB::Value.create_timestamp('2026-07-12 12:34:56.789')
+      #
+      # @param value [Time, Date, String] the timestamp value.
+      # @return [DuckDB::Value] the created Value object.
+      # @raise [ArgumentError] if +value+ cannot be parsed to a Time.
+      def create_timestamp(value)
+        time = to_time(value)
+        _create_timestamp(time.year, time.month, time.day, time.hour, time.min, time.sec, time.usec)
+      end
+
       # Creates a DuckDB::Value of LIST type.
       # The first argument is the element type: a Symbol (e.g. :integer) or a
       # DuckDB::LogicalType.
@@ -412,6 +427,10 @@ module DuckDB
       end
 
       private
+
+      def to_time(value)
+        value.is_a?(Date) ? value.to_time : _parse_time(value)
+      end
 
       def resolve_map_type(map_type)
         if map_type.is_a?(Hash)

--- a/test/duckdb_test/value_temporal_test.rb
+++ b/test/duckdb_test/value_temporal_test.rb
@@ -100,6 +100,32 @@ module DuckDBTest
       assert_raises(ArgumentError) { DuckDB::Value.create_time_tz(nil) }
     end
 
+    def test_create_timestamp_with_time
+      time = Time.local(2026, 7, 12, 12, 34, 56, 789_012)
+      value = DuckDB::Value.create_timestamp(time)
+
+      assert_instance_of(DuckDB::Value, value)
+      assert_equal(time, value.to_ruby)
+    end
+
+    def test_create_timestamp_with_string
+      expected = Time.local(2026, 7, 12, 12, 34, 56, 789_000)
+
+      assert_equal(expected, DuckDB::Value.create_timestamp('2026-07-12 12:34:56.789').to_ruby)
+    end
+
+    def test_create_timestamp_with_date
+      assert_equal(Time.local(2026, 7, 12), DuckDB::Value.create_timestamp(Date.new(2026, 7, 12)).to_ruby)
+    end
+
+    def test_create_timestamp_with_invalid_string_raises_argument_error
+      assert_raises(ArgumentError) { DuckDB::Value.create_timestamp('not a timestamp') }
+    end
+
+    def test_create_timestamp_with_nil_raises_argument_error
+      assert_raises(ArgumentError) { DuckDB::Value.create_timestamp(nil) }
+    end
+
     def test_create_date_with_invalid_string_raises_argument_error
       assert_raises(ArgumentError) { DuckDB::Value.create_date('not a date') }
     end


### PR DESCRIPTION
Adds `DuckDB::Value.create_timestamp(value)` building a TIMESTAMP value (microsecond precision) from a `Time`, a `Date`, or a parseable `String`, matching `Appender#append_timestamp`. `to_ruby` round-trips preserving microseconds.

Part of the DuckDB::Value API stack (#1393–#1411). Stacked on `feature/time-tz-value` — only the last commit(s) are new here; GitHub will retarget this PR to `main` automatically once the base PR merges and its branch is deleted.

Closes #1397

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `DuckDB::Value.create_timestamp` for creating microsecond-precision TIMESTAMP values from `Time`, `Date`, or parseable timestamp strings.
  * Invalid or unsupported inputs now produce an `ArgumentError`.

* **Documentation**
  * Documented the new timestamp value constructor in the unreleased changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->