### PR TITLE
Add DuckDB::Value.create_timestamp_s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
 - add `DuckDB::Value.create_time_ns(value)` to create TIME_NS values (nanosecond precision) from a Time or a parseable String. TIME_NS values are now converted to Ruby Time with full nanosecond precision (previously truncated to microseconds).
 - add `DuckDB::Value.create_time_tz(value)` to create TIMETZ values from a Time (the UTC offset is taken from the Time) or a parseable String with offset.
 - add `DuckDB::Value.create_timestamp(value)` to create TIMESTAMP values (microsecond precision) from a Time, a Date, or a parseable String (same lenient input as `Appender#append_timestamp`).
+- add `DuckDB::Value.create_timestamp_s(value)` to create TIMESTAMP_S values (second precision; sub-second input is truncated).
 
 # 1.5.4.0 - 2026-06-20
 - bump up DuckDB 1.5.4 and 1.4.5 on CI.

--- a/ext/duckdb/value.c
+++ b/ext/duckdb/value.c
@@ -26,6 +26,7 @@ static VALUE value_s__create_time(VALUE klass, VALUE hour, VALUE min, VALUE sec,
 static VALUE value_s__create_time_ns(VALUE klass, VALUE hour, VALUE min, VALUE sec, VALUE nanos);
 static VALUE value_s__create_time_tz(VALUE klass, VALUE micros, VALUE offset);
 static VALUE value_s__create_timestamp(VALUE klass, VALUE year, VALUE month, VALUE day, VALUE hour, VALUE min, VALUE sec, VALUE micros);
+static VALUE value_s__create_timestamp_s(VALUE klass, VALUE year, VALUE month, VALUE day, VALUE hour, VALUE min, VALUE sec);
 static VALUE value_s_create_null(VALUE klass);
 static idx_t marshal_values(VALUE ary, duckdb_value **out, volatile VALUE *guard);
 static VALUE value_s__create_list(VALUE klass, VALUE ltype, VALUE values);
@@ -187,6 +188,14 @@ static VALUE value_s__create_time_tz(VALUE klass, VALUE micros, VALUE offset) {
 static VALUE value_s__create_timestamp(VALUE klass, VALUE year, VALUE month, VALUE day, VALUE hour, VALUE min, VALUE sec, VALUE micros) {
     duckdb_timestamp timestamp = rbduckdb_to_duckdb_timestamp_from_value(year, month, day, hour, min, sec, micros);
     return rbduckdb_value_new(duckdb_create_timestamp(timestamp));
+}
+
+/* :nodoc: */
+static VALUE value_s__create_timestamp_s(VALUE klass, VALUE year, VALUE month, VALUE day, VALUE hour, VALUE min, VALUE sec) {
+    duckdb_timestamp_s ts;
+
+    ts.seconds = rbduckdb_to_duckdb_timestamp_from_value(year, month, day, hour, min, sec, INT2FIX(0)).micros / 1000000;
+    return rbduckdb_value_new(duckdb_create_timestamp_s(ts));
 }
 
 /*
@@ -647,6 +656,7 @@ void rbduckdb_init_value(void) {
     rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_time_ns", value_s__create_time_ns, 4);
     rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_time_tz", value_s__create_time_tz, 2);
     rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_timestamp", value_s__create_timestamp, 7);
+    rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_timestamp_s", value_s__create_timestamp_s, 6);
     rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_list", value_s__create_list, 2);
     rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_array", value_s__create_array, 2);
     rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_struct", value_s__create_struct, 2);

--- a/lib/duckdb/value.rb
+++ b/lib/duckdb/value.rb
@@ -314,6 +314,21 @@ module DuckDB
         _create_timestamp(time.year, time.month, time.day, time.hour, time.min, time.sec, time.usec)
       end
 
+      # Creates a DuckDB::Value of TIMESTAMP_S type (second precision).
+      # The argument is parsed leniently: a Time, a Date, or a String
+      # accepted by Time.parse. Sub-second input is truncated to seconds.
+      #
+      #   value = DuckDB::Value.create_timestamp_s(Time.now)
+      #   value = DuckDB::Value.create_timestamp_s('2026-07-12 12:34:56')
+      #
+      # @param value [Time, Date, String] the timestamp value.
+      # @return [DuckDB::Value] the created Value object.
+      # @raise [ArgumentError] if +value+ cannot be parsed to a Time.
+      def create_timestamp_s(value)
+        time = to_time(value)
+        _create_timestamp_s(time.year, time.month, time.day, time.hour, time.min, time.sec)
+      end
+
       # Creates a DuckDB::Value of LIST type.
       # The first argument is the element type: a Symbol (e.g. :integer) or a
       # DuckDB::LogicalType.

--- a/test/duckdb_test/value_temporal_test.rb
+++ b/test/duckdb_test/value_temporal_test.rb
@@ -126,6 +126,28 @@ module DuckDBTest
       assert_raises(ArgumentError) { DuckDB::Value.create_timestamp(nil) }
     end
 
+    def test_create_timestamp_s_with_time_truncates_to_seconds
+      time = Time.local(2026, 7, 12, 12, 34, 56, 789_012)
+      value = DuckDB::Value.create_timestamp_s(time)
+
+      assert_instance_of(DuckDB::Value, value)
+      assert_equal(Time.local(2026, 7, 12, 12, 34, 56), value.to_ruby)
+    end
+
+    def test_create_timestamp_s_with_string
+      expected = Time.local(2026, 7, 12, 12, 34, 56)
+
+      assert_equal(expected, DuckDB::Value.create_timestamp_s('2026-07-12 12:34:56').to_ruby)
+    end
+
+    def test_create_timestamp_s_with_invalid_string_raises_argument_error
+      assert_raises(ArgumentError) { DuckDB::Value.create_timestamp_s('not a timestamp') }
+    end
+
+    def test_create_timestamp_s_with_nil_raises_argument_error
+      assert_raises(ArgumentError) { DuckDB::Value.create_timestamp_s(nil) }
+    end
+
     def test_create_date_with_invalid_string_raises_argument_error
       assert_raises(ArgumentError) { DuckDB::Value.create_date('not a date') }
     end


### PR DESCRIPTION
Adds `DuckDB::Value.create_timestamp_s(value)` building a TIMESTAMP_S value (second precision) from a `Time`, a `Date`, or a parseable `String`; sub-second input is truncated to seconds. `to_ruby` round-trips.

Part of the DuckDB::Value API stack (#1393–#1411). Stacked on `feature/timestamp-value` — only the last commit(s) are new here; GitHub will retarget this PR to `main` automatically once the base PR merges and its branch is deleted.

Closes #1398

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for creating `TIMESTAMP_S` values from time objects and timestamp strings.
  * Values use second-level precision, truncating sub-second components.

* **Bug Fixes**
  * Added validation for invalid and missing timestamp inputs, returning clear argument errors.

* **Documentation**
  * Documented the new timestamp creation capability in the changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->