### PR TITLE
Add DuckDB::Value.create_timestamp_ms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project will be documented in this file.
 - add `DuckDB::Value.create_time_tz(value)` to create TIMETZ values from a Time (the UTC offset is taken from the Time) or a parseable String with offset.
 - add `DuckDB::Value.create_timestamp(value)` to create TIMESTAMP values (microsecond precision) from a Time, a Date, or a parseable String (same lenient input as `Appender#append_timestamp`).
 - add `DuckDB::Value.create_timestamp_s(value)` to create TIMESTAMP_S values (second precision; sub-second input is truncated).
+- add `DuckDB::Value.create_timestamp_ms(value)` to create TIMESTAMP_MS values (millisecond precision).
 
 # 1.5.4.0 - 2026-06-20
 - bump up DuckDB 1.5.4 and 1.4.5 on CI.

--- a/ext/duckdb/value.c
+++ b/ext/duckdb/value.c
@@ -27,6 +27,7 @@ static VALUE value_s__create_time_ns(VALUE klass, VALUE hour, VALUE min, VALUE s
 static VALUE value_s__create_time_tz(VALUE klass, VALUE micros, VALUE offset);
 static VALUE value_s__create_timestamp(VALUE klass, VALUE year, VALUE month, VALUE day, VALUE hour, VALUE min, VALUE sec, VALUE micros);
 static VALUE value_s__create_timestamp_s(VALUE klass, VALUE year, VALUE month, VALUE day, VALUE hour, VALUE min, VALUE sec);
+static VALUE value_s__create_timestamp_ms(VALUE klass, VALUE year, VALUE month, VALUE day, VALUE hour, VALUE min, VALUE sec, VALUE micros);
 static VALUE value_s_create_null(VALUE klass);
 static idx_t marshal_values(VALUE ary, duckdb_value **out, volatile VALUE *guard);
 static VALUE value_s__create_list(VALUE klass, VALUE ltype, VALUE values);
@@ -196,6 +197,14 @@ static VALUE value_s__create_timestamp_s(VALUE klass, VALUE year, VALUE month, V
 
     ts.seconds = rbduckdb_to_duckdb_timestamp_from_value(year, month, day, hour, min, sec, INT2FIX(0)).micros / 1000000;
     return rbduckdb_value_new(duckdb_create_timestamp_s(ts));
+}
+
+/* :nodoc: */
+static VALUE value_s__create_timestamp_ms(VALUE klass, VALUE year, VALUE month, VALUE day, VALUE hour, VALUE min, VALUE sec, VALUE micros) {
+    duckdb_timestamp_ms ts;
+
+    ts.millis = rbduckdb_to_duckdb_timestamp_from_value(year, month, day, hour, min, sec, micros).micros / 1000;
+    return rbduckdb_value_new(duckdb_create_timestamp_ms(ts));
 }
 
 /*
@@ -657,6 +666,7 @@ void rbduckdb_init_value(void) {
     rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_time_tz", value_s__create_time_tz, 2);
     rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_timestamp", value_s__create_timestamp, 7);
     rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_timestamp_s", value_s__create_timestamp_s, 6);
+    rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_timestamp_ms", value_s__create_timestamp_ms, 7);
     rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_list", value_s__create_list, 2);
     rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_array", value_s__create_array, 2);
     rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_struct", value_s__create_struct, 2);

--- a/lib/duckdb/value.rb
+++ b/lib/duckdb/value.rb
@@ -329,6 +329,21 @@ module DuckDB
         _create_timestamp_s(time.year, time.month, time.day, time.hour, time.min, time.sec)
       end
 
+      # Creates a DuckDB::Value of TIMESTAMP_MS type (millisecond precision).
+      # The argument is parsed leniently: a Time, a Date, or a String
+      # accepted by Time.parse. Sub-millisecond input is truncated.
+      #
+      #   value = DuckDB::Value.create_timestamp_ms(Time.now)
+      #   value = DuckDB::Value.create_timestamp_ms('2026-07-12 12:34:56.789')
+      #
+      # @param value [Time, Date, String] the timestamp value.
+      # @return [DuckDB::Value] the created Value object.
+      # @raise [ArgumentError] if +value+ cannot be parsed to a Time.
+      def create_timestamp_ms(value)
+        time = to_time(value)
+        _create_timestamp_ms(time.year, time.month, time.day, time.hour, time.min, time.sec, time.usec)
+      end
+
       # Creates a DuckDB::Value of LIST type.
       # The first argument is the element type: a Symbol (e.g. :integer) or a
       # DuckDB::LogicalType.

--- a/test/duckdb_test/value_temporal_test.rb
+++ b/test/duckdb_test/value_temporal_test.rb
@@ -148,6 +148,28 @@ module DuckDBTest
       assert_raises(ArgumentError) { DuckDB::Value.create_timestamp_s(nil) }
     end
 
+    def test_create_timestamp_ms_with_time_preserves_milliseconds
+      time = Time.local(2026, 7, 12, 12, 34, 56, 789_012)
+      value = DuckDB::Value.create_timestamp_ms(time)
+
+      assert_instance_of(DuckDB::Value, value)
+      assert_equal(Time.local(2026, 7, 12, 12, 34, 56, 789_000), value.to_ruby)
+    end
+
+    def test_create_timestamp_ms_with_string
+      expected = Time.local(2026, 7, 12, 12, 34, 56, 789_000)
+
+      assert_equal(expected, DuckDB::Value.create_timestamp_ms('2026-07-12 12:34:56.789').to_ruby)
+    end
+
+    def test_create_timestamp_ms_with_invalid_string_raises_argument_error
+      assert_raises(ArgumentError) { DuckDB::Value.create_timestamp_ms('not a timestamp') }
+    end
+
+    def test_create_timestamp_ms_with_nil_raises_argument_error
+      assert_raises(ArgumentError) { DuckDB::Value.create_timestamp_ms(nil) }
+    end
+
     def test_create_date_with_invalid_string_raises_argument_error
       assert_raises(ArgumentError) { DuckDB::Value.create_date('not a date') }
     end


### PR DESCRIPTION
Adds `DuckDB::Value.create_timestamp_ms(value)` building a TIMESTAMP_MS value (millisecond precision) from a `Time`, a `Date`, or a parseable `String`, preserving milliseconds. `to_ruby` round-trips.

Part of the DuckDB::Value API stack (#1393–#1411). Stacked on `feature/timestamp-s-value` — only the last commit(s) are new here; GitHub will retarget this PR to `main` automatically once the base PR merges and its branch is deleted.

Closes #1399

🤖 Generated with [Claude Code](https://claude.com/claude-code)