### PR TITLE
Add DuckDB::Value.create_timestamp_ns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file.
 - add `DuckDB::Value.create_timestamp(value)` to create TIMESTAMP values (microsecond precision) from a Time, a Date, or a parseable String (same lenient input as `Appender#append_timestamp`).
 - add `DuckDB::Value.create_timestamp_s(value)` to create TIMESTAMP_S values (second precision; sub-second input is truncated).
 - add `DuckDB::Value.create_timestamp_ms(value)` to create TIMESTAMP_MS values (millisecond precision).
+- add `DuckDB::Value.create_timestamp_ns(value)` to create TIMESTAMP_NS values (nanosecond precision). TIMESTAMP_NS values (including query results) are now converted to Ruby Time with full nanosecond precision (previously truncated to microseconds).
 
 # 1.5.4.0 - 2026-06-20
 - bump up DuckDB 1.5.4 and 1.4.5 on CI.

--- a/ext/duckdb/value.c
+++ b/ext/duckdb/value.c
@@ -28,6 +28,7 @@ static VALUE value_s__create_time_tz(VALUE klass, VALUE micros, VALUE offset);
 static VALUE value_s__create_timestamp(VALUE klass, VALUE year, VALUE month, VALUE day, VALUE hour, VALUE min, VALUE sec, VALUE micros);
 static VALUE value_s__create_timestamp_s(VALUE klass, VALUE year, VALUE month, VALUE day, VALUE hour, VALUE min, VALUE sec);
 static VALUE value_s__create_timestamp_ms(VALUE klass, VALUE year, VALUE month, VALUE day, VALUE hour, VALUE min, VALUE sec, VALUE micros);
+static VALUE value_s__create_timestamp_ns(VALUE klass, VALUE year, VALUE month, VALUE day, VALUE hour, VALUE min, VALUE sec, VALUE nanos);
 static VALUE value_s_create_null(VALUE klass);
 static idx_t marshal_values(VALUE ary, duckdb_value **out, volatile VALUE *guard);
 static VALUE value_s__create_list(VALUE klass, VALUE ltype, VALUE values);
@@ -205,6 +206,14 @@ static VALUE value_s__create_timestamp_ms(VALUE klass, VALUE year, VALUE month, 
 
     ts.millis = rbduckdb_to_duckdb_timestamp_from_value(year, month, day, hour, min, sec, micros).micros / 1000;
     return rbduckdb_value_new(duckdb_create_timestamp_ms(ts));
+}
+
+/* :nodoc: */
+static VALUE value_s__create_timestamp_ns(VALUE klass, VALUE year, VALUE month, VALUE day, VALUE hour, VALUE min, VALUE sec, VALUE nanos) {
+    duckdb_timestamp_ns ts;
+
+    ts.nanos = rbduckdb_to_duckdb_timestamp_from_value(year, month, day, hour, min, sec, INT2FIX(0)).micros * 1000 + NUM2LL(nanos);
+    return rbduckdb_value_new(duckdb_create_timestamp_ns(ts));
 }
 
 /*
@@ -667,6 +676,7 @@ void rbduckdb_init_value(void) {
     rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_timestamp", value_s__create_timestamp, 7);
     rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_timestamp_s", value_s__create_timestamp_s, 6);
     rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_timestamp_ms", value_s__create_timestamp_ms, 7);
+    rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_timestamp_ns", value_s__create_timestamp_ns, 7);
     rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_list", value_s__create_list, 2);
     rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_array", value_s__create_array, 2);
     rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_struct", value_s__create_struct, 2);

--- a/lib/duckdb/converter.rb
+++ b/lib/duckdb/converter.rb
@@ -83,7 +83,7 @@ module DuckDB
 
     def _to_time_from_duckdb_timestamp_ns(time)
       _to_time_from_duckdb_timestamp_s(time / 1_000_000_000).then do |tm|
-        _to_time(tm.year, tm.month, tm.day, tm.hour, tm.min, tm.sec, time % 1_000_000_000 / 1000)
+        _to_time(tm.year, tm.month, tm.day, tm.hour, tm.min, tm.sec, Rational(time % 1_000_000_000, 1000))
       end
     end
 

--- a/lib/duckdb/value.rb
+++ b/lib/duckdb/value.rb
@@ -344,6 +344,21 @@ module DuckDB
         _create_timestamp_ms(time.year, time.month, time.day, time.hour, time.min, time.sec, time.usec)
       end
 
+      # Creates a DuckDB::Value of TIMESTAMP_NS type (nanosecond precision).
+      # The argument is parsed leniently: a Time, a Date, or a String
+      # accepted by Time.parse. Nanoseconds are preserved.
+      #
+      #   value = DuckDB::Value.create_timestamp_ns(Time.now)
+      #   value = DuckDB::Value.create_timestamp_ns('2026-07-12 12:34:56.123456789')
+      #
+      # @param value [Time, Date, String] the timestamp value.
+      # @return [DuckDB::Value] the created Value object.
+      # @raise [ArgumentError] if +value+ cannot be parsed to a Time.
+      def create_timestamp_ns(value)
+        time = to_time(value)
+        _create_timestamp_ns(time.year, time.month, time.day, time.hour, time.min, time.sec, time.nsec)
+      end
+
       # Creates a DuckDB::Value of LIST type.
       # The first argument is the element type: a Symbol (e.g. :integer) or a
       # DuckDB::LogicalType.

--- a/test/duckdb_test/result_each_test.rb
+++ b/test/duckdb_test/result_each_test.rb
@@ -93,7 +93,7 @@ module DuckDBTest
       [:ok, 'TIMESTAMP_MS', 'TIMESTAMP_MS',                "'2019-11-03 12:34:56.123456789'",          Time,                 Time.parse('2019-11-3 12:34:56.123')                ],
       [:ok, 'TIMESTAMP_MS', 'TIMESTAMP_MS',                "'infinity'",                               String,               'infinity'                                          ],
       [:ok, 'TIMESTAMP_MS', 'TIMESTAMP_MS',                "'-infinity'",                              String,               '-infinity'                                         ],
-      [:ok, 'TIMESTAMP_NS', 'TIMESTAMP_NS',                "'2019-11-03 12:34:56.123456789'",          Time,                 Time.parse('2019-11-3 12:34:56.123456')             ],
+      [:ok, 'TIMESTAMP_NS', 'TIMESTAMP_NS',                "'2019-11-03 12:34:56.123456789'",          Time,                 Time.parse('2019-11-3 12:34:56.123456789')          ],
       [:ok, 'TIMESTAMP_NS', 'TIMESTAMP_NS',                "'infinity'",                               String,               'infinity'                                          ],
       [:ok, 'TIMESTAMP_NS', 'TIMESTAMP_NS',                "'-infinity'",                              String,               '-infinity'                                         ],
       [:ok, 'ENUM',         'mood',                        "'happy'",                                  String,               'happy'                                             ],

--- a/test/duckdb_test/result_timestamp_default_timezone_test.rb
+++ b/test/duckdb_test/result_timestamp_default_timezone_test.rb
@@ -63,8 +63,7 @@ module DuckDBTest
       result = @conn.execute('SELECT value FROM test;')
       time = result.each.to_a.first.first
 
-      # TIMESTAMP_NS has nanosecond resolution; Ruby Time stores microseconds.
-      assert_equal(Time.utc(2019, 1, 2, 12, 34, 56, 123_456), time)
+      assert_equal(Time.utc(2019, 1, 2, 12, 34, 56, Rational(123_456_789, 1000)), time)
       assert_predicate(time, :utc?)
     end
 

--- a/test/duckdb_test/result_timestamp_ns_test.rb
+++ b/test/duckdb_test/result_timestamp_ns_test.rb
@@ -21,7 +21,7 @@ module DuckDBTest
       result = @conn.execute('SELECT value FROM test;')
       ary = result.each.to_a
 
-      assert_equal([[Time.local(2019, 1, 2, 12, 34, 56, 123_456)]], ary)
+      assert_equal([[Time.local(2019, 1, 2, 12, 34, 56, Rational(123_456_789, 1000))]], ary)
     end
   end
 end

--- a/test/duckdb_test/value_temporal_test.rb
+++ b/test/duckdb_test/value_temporal_test.rb
@@ -170,6 +170,32 @@ module DuckDBTest
       assert_raises(ArgumentError) { DuckDB::Value.create_timestamp_ms(nil) }
     end
 
+    def test_create_timestamp_ns_with_time_preserves_nanoseconds
+      time = Time.local(2026, 7, 12, 12, 34, 56, Rational(123_456_789, 1000))
+      value = DuckDB::Value.create_timestamp_ns(time)
+
+      assert_instance_of(DuckDB::Value, value)
+      result = value.to_ruby
+
+      assert_equal(time, result)
+      assert_equal(123_456_789, result.nsec)
+    end
+
+    def test_create_timestamp_ns_with_string
+      result = DuckDB::Value.create_timestamp_ns('2026-07-12 12:34:56.123456789').to_ruby
+
+      assert_equal(Time.local(2026, 7, 12, 12, 34, 56, Rational(123_456_789, 1000)), result)
+      assert_equal(123_456_789, result.nsec)
+    end
+
+    def test_create_timestamp_ns_with_invalid_string_raises_argument_error
+      assert_raises(ArgumentError) { DuckDB::Value.create_timestamp_ns('not a timestamp') }
+    end
+
+    def test_create_timestamp_ns_with_nil_raises_argument_error
+      assert_raises(ArgumentError) { DuckDB::Value.create_timestamp_ns(nil) }
+    end
+
     def test_create_date_with_invalid_string_raises_argument_error
       assert_raises(ArgumentError) { DuckDB::Value.create_date('not a date') }
     end


### PR DESCRIPTION
Adds `DuckDB::Value.create_timestamp_ns(value)` building a TIMESTAMP_NS value (nanosecond precision) from a `Time`, a `Date`, or a parseable `String`. To satisfy the nanosecond round-trip criterion, TIMESTAMP_NS→Ruby conversion now preserves nanoseconds (Rational subsec) instead of truncating to microseconds — this also applies to TIMESTAMP_NS columns in query results (existing test expectations updated).

Part of the DuckDB::Value API stack (#1393–#1411). Stacked on `feature/timestamp-ms-value` — only the last commit(s) are new here; GitHub will retarget this PR to `main` automatically once the base PR merges and its branch is deleted.

Closes #1400

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `DuckDB::Value.create_timestamp_ns` for creating timestamps with full nanosecond precision.
  * Timestamp values from queries now convert to Ruby `Time` without truncating fractional seconds.
  * Supports `Time`, `Date`, and parseable string inputs, with validation for invalid values.

* **Bug Fixes**
  * Corrected UTC and local timezone conversions to preserve nanosecond precision.

* **Documentation**
  * Documented nanosecond-precision timestamp support in the changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->