### PR TITLE
Add DuckDB::Value.create_timestamp_tz

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to this project will be documented in this file.
 - add `DuckDB::Value.create_timestamp_s(value)` to create TIMESTAMP_S values (second precision; sub-second input is truncated).
 - add `DuckDB::Value.create_timestamp_ms(value)` to create TIMESTAMP_MS values (millisecond precision).
 - add `DuckDB::Value.create_timestamp_ns(value)` to create TIMESTAMP_NS values (nanosecond precision). TIMESTAMP_NS values (including query results) are now converted to Ruby Time with full nanosecond precision (previously truncated to microseconds).
+- add `DuckDB::Value.create_timestamp_tz(value)` to create TIMESTAMP WITH TIME ZONE values; the instant is stored correctly regardless of the input UTC offset.
 
 # 1.5.4.0 - 2026-06-20
 - bump up DuckDB 1.5.4 and 1.4.5 on CI.

--- a/ext/duckdb/value.c
+++ b/ext/duckdb/value.c
@@ -29,6 +29,7 @@ static VALUE value_s__create_timestamp(VALUE klass, VALUE year, VALUE month, VAL
 static VALUE value_s__create_timestamp_s(VALUE klass, VALUE year, VALUE month, VALUE day, VALUE hour, VALUE min, VALUE sec);
 static VALUE value_s__create_timestamp_ms(VALUE klass, VALUE year, VALUE month, VALUE day, VALUE hour, VALUE min, VALUE sec, VALUE micros);
 static VALUE value_s__create_timestamp_ns(VALUE klass, VALUE year, VALUE month, VALUE day, VALUE hour, VALUE min, VALUE sec, VALUE nanos);
+static VALUE value_s__create_timestamp_tz(VALUE klass, VALUE micros);
 static VALUE value_s_create_null(VALUE klass);
 static idx_t marshal_values(VALUE ary, duckdb_value **out, volatile VALUE *guard);
 static VALUE value_s__create_list(VALUE klass, VALUE ltype, VALUE values);
@@ -214,6 +215,14 @@ static VALUE value_s__create_timestamp_ns(VALUE klass, VALUE year, VALUE month, 
 
     ts.nanos = rbduckdb_to_duckdb_timestamp_from_value(year, month, day, hour, min, sec, INT2FIX(0)).micros * 1000 + NUM2LL(nanos);
     return rbduckdb_value_new(duckdb_create_timestamp_ns(ts));
+}
+
+/* :nodoc: */
+static VALUE value_s__create_timestamp_tz(VALUE klass, VALUE micros) {
+    duckdb_timestamp ts;
+
+    ts.micros = NUM2LL(micros);
+    return rbduckdb_value_new(duckdb_create_timestamp_tz(ts));
 }
 
 /*
@@ -677,6 +686,7 @@ void rbduckdb_init_value(void) {
     rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_timestamp_s", value_s__create_timestamp_s, 6);
     rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_timestamp_ms", value_s__create_timestamp_ms, 7);
     rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_timestamp_ns", value_s__create_timestamp_ns, 7);
+    rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_timestamp_tz", value_s__create_timestamp_tz, 1);
     rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_list", value_s__create_list, 2);
     rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_array", value_s__create_array, 2);
     rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_struct", value_s__create_struct, 2);

--- a/lib/duckdb/value.rb
+++ b/lib/duckdb/value.rb
@@ -359,6 +359,22 @@ module DuckDB
         _create_timestamp_ns(time.year, time.month, time.day, time.hour, time.min, time.sec, time.nsec)
       end
 
+      # Creates a DuckDB::Value of TIMESTAMP WITH TIME ZONE type.
+      # The argument is parsed leniently: a Time, a Date, or a String
+      # accepted by Time.parse. The instant is stored (as microseconds since
+      # the Unix epoch), so the input's UTC offset is honored.
+      #
+      #   value = DuckDB::Value.create_timestamp_tz(Time.now)
+      #   value = DuckDB::Value.create_timestamp_tz('2026-07-12 12:34:56.789+05:30')
+      #
+      # @param value [Time, Date, String] the timestamp value.
+      # @return [DuckDB::Value] the created Value object.
+      # @raise [ArgumentError] if +value+ cannot be parsed to a Time.
+      def create_timestamp_tz(value)
+        time = to_time(value)
+        _create_timestamp_tz((time.to_i * 1_000_000) + time.usec)
+      end
+
       # Creates a DuckDB::Value of LIST type.
       # The first argument is the element type: a Symbol (e.g. :integer) or a
       # DuckDB::LogicalType.

--- a/test/duckdb_test/value_temporal_test.rb
+++ b/test/duckdb_test/value_temporal_test.rb
@@ -196,6 +196,28 @@ module DuckDBTest
       assert_raises(ArgumentError) { DuckDB::Value.create_timestamp_ns(nil) }
     end
 
+    def test_create_timestamp_tz_with_time_stores_instant
+      time = Time.new(2026, 7, 12, 12, 34, 56, '+05:30')
+      value = DuckDB::Value.create_timestamp_tz(time)
+
+      assert_instance_of(DuckDB::Value, value)
+      assert_equal(time, value.to_ruby)
+    end
+
+    def test_create_timestamp_tz_with_string
+      expected = Time.parse('2026-07-12 12:34:56.789 +0000')
+
+      assert_equal(expected, DuckDB::Value.create_timestamp_tz('2026-07-12 12:34:56.789 +0000').to_ruby)
+    end
+
+    def test_create_timestamp_tz_with_invalid_string_raises_argument_error
+      assert_raises(ArgumentError) { DuckDB::Value.create_timestamp_tz('not a timestamp') }
+    end
+
+    def test_create_timestamp_tz_with_nil_raises_argument_error
+      assert_raises(ArgumentError) { DuckDB::Value.create_timestamp_tz(nil) }
+    end
+
     def test_create_date_with_invalid_string_raises_argument_error
       assert_raises(ArgumentError) { DuckDB::Value.create_date('not a date') }
     end


### PR DESCRIPTION
Adds `DuckDB::Value.create_timestamp_tz(value)` building a TIMESTAMP WITH TIME ZONE value from a `Time`, a `Date`, or a parseable `String`. The instant (microseconds since the Unix epoch) is stored, so the input UTC offset is honored; `to_ruby` round-trips the instant.

Part of the DuckDB::Value API stack (#1393–#1411). Stacked on `feature/timestamp-ns-value` — only the last commit(s) are new here; GitHub will retarget this PR to `main` automatically once the base PR merges and its branch is deleted.

Closes #1401

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `DuckDB::Value.create_timestamp_tz(value)` for creating `TIMESTAMP WITH TIME ZONE` values.
  * Preserves the represented instant correctly, including input UTC offsets.
  * Supports time objects and parseable time strings.

* **Bug Fixes**
  * Invalid or missing timestamp inputs now raise `ArgumentError`.

* **Documentation**
  * Added the new method to the unreleased changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->