### PR TITLE
Add DuckDB::Value.create_interval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file.
 - add `DuckDB::Value.create_timestamp_ms(value)` to create TIMESTAMP_MS values (millisecond precision).
 - add `DuckDB::Value.create_timestamp_ns(value)` to create TIMESTAMP_NS values (nanosecond precision). TIMESTAMP_NS values (including query results) are now converted to Ruby Time with full nanosecond precision (previously truncated to microseconds).
 - add `DuckDB::Value.create_timestamp_tz(value)` to create TIMESTAMP WITH TIME ZONE values; the instant is stored correctly regardless of the input UTC offset.
+- add `DuckDB::Value.create_interval(value)` to create INTERVAL values from a `DuckDB::Interval`.
 
 # 1.5.4.0 - 2026-06-20
 - bump up DuckDB 1.5.4 and 1.4.5 on CI.

--- a/ext/duckdb/value.c
+++ b/ext/duckdb/value.c
@@ -30,6 +30,7 @@ static VALUE value_s__create_timestamp_s(VALUE klass, VALUE year, VALUE month, V
 static VALUE value_s__create_timestamp_ms(VALUE klass, VALUE year, VALUE month, VALUE day, VALUE hour, VALUE min, VALUE sec, VALUE micros);
 static VALUE value_s__create_timestamp_ns(VALUE klass, VALUE year, VALUE month, VALUE day, VALUE hour, VALUE min, VALUE sec, VALUE nanos);
 static VALUE value_s__create_timestamp_tz(VALUE klass, VALUE micros);
+static VALUE value_s__create_interval(VALUE klass, VALUE months, VALUE days, VALUE micros);
 static VALUE value_s_create_null(VALUE klass);
 static idx_t marshal_values(VALUE ary, duckdb_value **out, volatile VALUE *guard);
 static VALUE value_s__create_list(VALUE klass, VALUE ltype, VALUE values);
@@ -223,6 +224,14 @@ static VALUE value_s__create_timestamp_tz(VALUE klass, VALUE micros) {
 
     ts.micros = NUM2LL(micros);
     return rbduckdb_value_new(duckdb_create_timestamp_tz(ts));
+}
+
+/* :nodoc: */
+static VALUE value_s__create_interval(VALUE klass, VALUE months, VALUE days, VALUE micros) {
+    duckdb_interval interval;
+
+    rbduckdb_to_duckdb_interval_from_value(&interval, months, days, micros);
+    return rbduckdb_value_new(duckdb_create_interval(interval));
 }
 
 /*
@@ -687,6 +696,7 @@ void rbduckdb_init_value(void) {
     rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_timestamp_ms", value_s__create_timestamp_ms, 7);
     rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_timestamp_ns", value_s__create_timestamp_ns, 7);
     rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_timestamp_tz", value_s__create_timestamp_tz, 1);
+    rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_interval", value_s__create_interval, 3);
     rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_list", value_s__create_list, 2);
     rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_array", value_s__create_array, 2);
     rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_struct", value_s__create_struct, 2);

--- a/lib/duckdb/value.rb
+++ b/lib/duckdb/value.rb
@@ -375,6 +375,22 @@ module DuckDB
         _create_timestamp_tz((time.to_i * 1_000_000) + time.usec)
       end
 
+      # Creates a DuckDB::Value of INTERVAL type.
+      # Unlike the other temporal creators, the input is strict: it must be
+      # a DuckDB::Interval.
+      #
+      #   interval = DuckDB::Interval.new(interval_months: 14, interval_days: 3, interval_micros: 12_000_000)
+      #   value = DuckDB::Value.create_interval(interval)
+      #
+      # @param value [DuckDB::Interval] the interval value.
+      # @return [DuckDB::Value] the created Value object.
+      # @raise [ArgumentError] if +value+ is not a DuckDB::Interval.
+      def create_interval(value)
+        check_type!(value, DuckDB::Interval)
+
+        _create_interval(value.interval_months, value.interval_days, value.interval_micros)
+      end
+
       # Creates a DuckDB::Value of LIST type.
       # The first argument is the element type: a Symbol (e.g. :integer) or a
       # DuckDB::LogicalType.

--- a/test/duckdb_test/value_temporal_test.rb
+++ b/test/duckdb_test/value_temporal_test.rb
@@ -218,6 +218,22 @@ module DuckDBTest
       assert_raises(ArgumentError) { DuckDB::Value.create_timestamp_tz(nil) }
     end
 
+    def test_create_interval_with_interval
+      interval = DuckDB::Interval.new(interval_months: 14, interval_days: 3, interval_micros: 12_345_678)
+      value = DuckDB::Value.create_interval(interval)
+
+      assert_instance_of(DuckDB::Value, value)
+      assert_equal(interval, value.to_ruby)
+    end
+
+    def test_create_interval_with_string_raises_argument_error
+      assert_raises(ArgumentError) { DuckDB::Value.create_interval('P1Y2D') }
+    end
+
+    def test_create_interval_with_nil_raises_argument_error
+      assert_raises(ArgumentError) { DuckDB::Value.create_interval(nil) }
+    end
+
     def test_create_date_with_invalid_string_raises_argument_error
       assert_raises(ArgumentError) { DuckDB::Value.create_date('not a date') }
     end


### PR DESCRIPTION
Adds `DuckDB::Value.create_interval(value)` building an INTERVAL value. Strict input per ADR 0004: takes a `DuckDB::Interval`; anything else raises `ArgumentError`. `to_ruby` returns an equal `DuckDB::Interval`.

Part of the DuckDB::Value API stack (#1393–#1411). Stacked on `feature/timestamp-tz-value` — only the last commit(s) are new here; GitHub will retarget this PR to `main` automatically once the base PR merges and its branch is deleted.

Closes #1402

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for creating DuckDB `INTERVAL` values from `DuckDB::Interval` objects.
  - Invalid inputs, including strings and `nil`, are rejected with an `ArgumentError`.

- **Documentation**
  - Updated the changelog with the new interval value creation capability.

- **Tests**
  - Added coverage for successful interval creation and invalid input handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->