### PR TITLE
Add DuckDB::Value.create_enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to this project will be documented in this file.
 - add `DuckDB::Value.create_timestamp_ns(value)` to create TIMESTAMP_NS values (nanosecond precision). TIMESTAMP_NS values (including query results) are now converted to Ruby Time with full nanosecond precision (previously truncated to microseconds).
 - add `DuckDB::Value.create_timestamp_tz(value)` to create TIMESTAMP WITH TIME ZONE values; the instant is stored correctly regardless of the input UTC offset.
 - add `DuckDB::Value.create_interval(value)` to create INTERVAL values from a `DuckDB::Interval`.
+- add `DuckDB::Value.create_enum(enum_type, member)` to create ENUM values from an Array of member names (or an ENUM `DuckDB::LogicalType`) and a member name or 0-based index.
 
 # 1.5.4.0 - 2026-06-20
 - bump up DuckDB 1.5.4 and 1.4.5 on CI.

--- a/ext/duckdb/value.c
+++ b/ext/duckdb/value.c
@@ -31,6 +31,7 @@ static VALUE value_s__create_timestamp_ms(VALUE klass, VALUE year, VALUE month, 
 static VALUE value_s__create_timestamp_ns(VALUE klass, VALUE year, VALUE month, VALUE day, VALUE hour, VALUE min, VALUE sec, VALUE nanos);
 static VALUE value_s__create_timestamp_tz(VALUE klass, VALUE micros);
 static VALUE value_s__create_interval(VALUE klass, VALUE months, VALUE days, VALUE micros);
+static VALUE value_s__create_enum(VALUE klass, VALUE ltype, VALUE index);
 static VALUE value_s_create_null(VALUE klass);
 static idx_t marshal_values(VALUE ary, duckdb_value **out, volatile VALUE *guard);
 static VALUE value_s__create_list(VALUE klass, VALUE ltype, VALUE values);
@@ -232,6 +233,17 @@ static VALUE value_s__create_interval(VALUE klass, VALUE months, VALUE days, VAL
 
     rbduckdb_to_duckdb_interval_from_value(&interval, months, days, micros);
     return rbduckdb_value_new(duckdb_create_interval(interval));
+}
+
+/* :nodoc: */
+static VALUE value_s__create_enum(VALUE klass, VALUE ltype, VALUE index) {
+    duckdb_logical_type type = rbduckdb_get_struct_logical_type(ltype)->logical_type;
+    duckdb_value value = duckdb_create_enum_value(type, NUM2ULL(index));
+
+    if (value == NULL) {
+        rb_raise(eDuckDBError, "failed to create ENUM value");
+    }
+    return rbduckdb_value_new(value);
 }
 
 /*
@@ -697,6 +709,7 @@ void rbduckdb_init_value(void) {
     rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_timestamp_ns", value_s__create_timestamp_ns, 7);
     rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_timestamp_tz", value_s__create_timestamp_tz, 1);
     rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_interval", value_s__create_interval, 3);
+    rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_enum", value_s__create_enum, 2);
     rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_list", value_s__create_list, 2);
     rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_array", value_s__create_array, 2);
     rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_struct", value_s__create_struct, 2);

--- a/lib/duckdb/value.rb
+++ b/lib/duckdb/value.rb
@@ -391,6 +391,32 @@ module DuckDB
         _create_interval(value.interval_months, value.interval_days, value.interval_micros)
       end
 
+      # Creates a DuckDB::Value of ENUM type.
+      # The first argument is the enum type: an Array of member names (as
+      # accepted by DuckDB::LogicalType.create_enum) or an ENUM
+      # DuckDB::LogicalType.
+      # The second argument is the member: its name (String or Symbol) or
+      # its 0-based index (Integer).
+      #
+      #   value = DuckDB::Value.create_enum(%w[happy sad neutral], 'sad')
+      #
+      #   # equivalent, with an explicit ENUM logical type:
+      #   enum_type = DuckDB::LogicalType.create_enum('happy', 'sad', 'neutral')
+      #   value = DuckDB::Value.create_enum(enum_type, 'sad')
+      #
+      # @param enum_type [Array<String>, DuckDB::LogicalType] the member names or ENUM logical type.
+      # @param member [String, Symbol, Integer] the member name or 0-based index.
+      # @return [DuckDB::Value] the created Value object.
+      # @raise [ArgumentError] if enum_type is not an Array or an ENUM
+      #   DuckDB::LogicalType, or member is not a member of the enum.
+      def create_enum(enum_type, member)
+        enum_type = DuckDB::LogicalType.create_enum(*enum_type) if enum_type.is_a?(Array)
+        check_type!(enum_type, DuckDB::LogicalType)
+        raise ArgumentError, "expected ENUM LogicalType, got #{enum_type.type}" unless enum_type.type == :enum
+
+        _create_enum(enum_type, enum_member_index(enum_type, member))
+      end
+
       # Creates a DuckDB::Value of LIST type.
       # The first argument is the element type: a Symbol (e.g. :integer) or a
       # DuckDB::LogicalType.
@@ -507,6 +533,25 @@ module DuckDB
 
       def to_time(value)
         value.is_a?(Date) ? value.to_time : _parse_time(value)
+      end
+
+      def enum_member_index(enum_type, member)
+        case member
+        when Integer
+          check_range!(member, 0...enum_type.dictionary_size, 'ENUM index')
+          member
+        when String, Symbol
+          enum_member_index_by_name(enum_type, member)
+        else
+          raise ArgumentError, "expected String, Symbol or Integer, got #{member.class.name}"
+        end
+      end
+
+      def enum_member_index_by_name(enum_type, member)
+        index = enum_type.each_dictionary_value.find_index(member.to_s)
+        raise ArgumentError, "`#{member}` is not a member of the enum" if index.nil?
+
+        index
       end
 
       def resolve_map_type(map_type)

--- a/test/duckdb_test/value_enum_test.rb
+++ b/test/duckdb_test/value_enum_test.rb
@@ -28,6 +28,15 @@ module DuckDBTest
       assert_instance_of(DuckDB::Value, DuckDB::Value.create_enum(enum_type, 2))
     end
 
+    def test_create_enum_reuses_same_logical_type
+      type = enum_type
+      happy = DuckDB::Value.create_enum(type, 'happy')
+      sad = DuckDB::Value.create_enum(type, 'sad')
+
+      assert_instance_of(DuckDB::Value, happy)
+      assert_instance_of(DuckDB::Value, sad)
+    end
+
     def test_create_enum_with_unknown_member_raises_argument_error
       assert_raises(ArgumentError) { DuckDB::Value.create_enum(enum_type, 'angry') }
     end

--- a/test/duckdb_test/value_enum_test.rb
+++ b/test/duckdb_test/value_enum_test.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module DuckDBTest
+  class ValueEnumTest < Minitest::Test
+    def enum_type
+      DuckDB::LogicalType.create_enum('happy', 'sad', 'neutral')
+    end
+
+    def test_create_enum_with_logical_type_and_string
+      value = DuckDB::Value.create_enum(enum_type, 'sad')
+
+      assert_instance_of(DuckDB::Value, value)
+    end
+
+    def test_create_enum_with_member_array_spec
+      value = DuckDB::Value.create_enum(%w[happy sad neutral], 'happy')
+
+      assert_instance_of(DuckDB::Value, value)
+    end
+
+    def test_create_enum_with_symbol_member
+      assert_instance_of(DuckDB::Value, DuckDB::Value.create_enum(enum_type, :neutral))
+    end
+
+    def test_create_enum_with_index_member
+      assert_instance_of(DuckDB::Value, DuckDB::Value.create_enum(enum_type, 2))
+    end
+
+    def test_create_enum_with_unknown_member_raises_argument_error
+      assert_raises(ArgumentError) { DuckDB::Value.create_enum(enum_type, 'angry') }
+    end
+
+    def test_create_enum_with_out_of_range_index_raises_argument_error
+      assert_raises(ArgumentError) { DuckDB::Value.create_enum(enum_type, 3) }
+    end
+
+    def test_create_enum_with_negative_index_raises_argument_error
+      assert_raises(ArgumentError) { DuckDB::Value.create_enum(enum_type, -1) }
+    end
+
+    def test_create_enum_with_non_enum_logical_type_raises_argument_error
+      assert_raises(ArgumentError) do
+        DuckDB::Value.create_enum(DuckDB::LogicalType.resolve(:integer), 'happy')
+      end
+    end
+
+    def test_create_enum_with_invalid_member_type_raises_argument_error
+      assert_raises(ArgumentError) { DuckDB::Value.create_enum(enum_type, nil) }
+    end
+  end
+end


### PR DESCRIPTION
Adds `DuckDB::Value.create_enum(enum_type, member)` building an ENUM value from an Array of member names (or an ENUM `DuckDB::LogicalType`, following the type-spec-or-LogicalType convention of `create_struct`/`create_map`) and a member name (String/Symbol) or 0-based index. Unknown members, out-of-range indexes, and non-ENUM logical types raise `ArgumentError`.

Part of the DuckDB::Value API stack (#1393–#1411). Stacked on `feature/interval-value` — only the last commit(s) are new here; GitHub will retarget this PR to `main` automatically once the base PR merges and its branch is deleted.

Closes #1403

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `DuckDB::Value.create_enum` for creating ENUM values from member names, symbols, or zero-based indexes.
  * Supports defining ENUM types with either an existing logical type or an array of member names.
  * Added validation with clear errors for invalid types, unknown members, and out-of-range indexes.

* **Documentation**
  * Updated the unreleased changelog with the new ENUM value creation API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->