### PR TITLE
Support ENUM in DuckDB::Value#to_ruby

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to this project will be documented in this file.
 - add `DuckDB::Value.create_timestamp_tz(value)` to create TIMESTAMP WITH TIME ZONE values; the instant is stored correctly regardless of the input UTC offset.
 - add `DuckDB::Value.create_interval(value)` to create INTERVAL values from a `DuckDB::Interval`.
 - add `DuckDB::Value.create_enum(enum_type, member)` to create ENUM values from an Array of member names (or an ENUM `DuckDB::LogicalType`) and a member name or 0-based index.
+- `DuckDB::Value#to_ruby` converts ENUM values to the member String.
 
 # 1.5.4.0 - 2026-06-20
 - bump up DuckDB 1.5.4 and 1.4.5 on CI.

--- a/ext/duckdb/value.c
+++ b/ext/duckdb/value.c
@@ -599,6 +599,11 @@ VALUE rbduckdb_duckdb_value_to_ruby(duckdb_value val) {
         case DUCKDB_TYPE_UUID:
             result = rbduckdb_uuid_uhugeint_to_ruby(duckdb_get_uuid(val));
             break;
+        case DUCKDB_TYPE_ENUM:
+            str = duckdb_enum_dictionary_value(logical_type, duckdb_get_enum_value(val));
+            result = rb_utf8_str_new_cstr(str);
+            duckdb_free(str);
+            break;
         case DUCKDB_TYPE_LIST:
             size = duckdb_get_list_size(val);
             result = rb_ary_new_capa(size);
@@ -664,7 +669,8 @@ VALUE rbduckdb_duckdb_value_to_ruby(duckdb_value val) {
  *  to their natural Ruby classes. LIST and ARRAY values are converted to
  *  Array recursively. STRUCT and MAP values are converted to Hash
  *  recursively (STRUCT keys are Symbols; MAP keys keep their natural Ruby
- *  type). NULL is converted to nil. Returns nil for unsupported types.
+ *  type). ENUM values are converted to the member String. NULL is
+ *  converted to nil. Returns nil for unsupported types.
  *
  *    require 'duckdb'
  *    child_type = DuckDB::LogicalType.resolve(:integer)

--- a/ext/duckdb/value.c
+++ b/ext/duckdb/value.c
@@ -601,6 +601,10 @@ VALUE rbduckdb_duckdb_value_to_ruby(duckdb_value val) {
             break;
         case DUCKDB_TYPE_ENUM:
             str = duckdb_enum_dictionary_value(logical_type, duckdb_get_enum_value(val));
+            if (str == NULL) {
+                result = Qnil;
+                break;
+            }
             result = rb_utf8_str_new_cstr(str);
             duckdb_free(str);
             break;

--- a/test/duckdb_test/value_enum_test.rb
+++ b/test/duckdb_test/value_enum_test.rb
@@ -28,6 +28,14 @@ module DuckDBTest
       assert_instance_of(DuckDB::Value, DuckDB::Value.create_enum(enum_type, 2))
     end
 
+    def test_to_ruby_returns_member_string
+      assert_equal('sad', DuckDB::Value.create_enum(enum_type, 'sad').to_ruby)
+    end
+
+    def test_to_ruby_round_trips_with_index_member
+      assert_equal('neutral', DuckDB::Value.create_enum(enum_type, 2).to_ruby)
+    end
+
     def test_create_enum_with_unknown_member_raises_argument_error
       assert_raises(ArgumentError) { DuckDB::Value.create_enum(enum_type, 'angry') }
     end


### PR DESCRIPTION
`DuckDB::Value#to_ruby` on an ENUM value now returns the member as a Ruby String, round-tripping with `create_enum`. Includes a NULL guard on `duckdb_enum_dictionary_value` matching the existing call sites.

Part of the DuckDB::Value API stack (#1393–#1411). Stacked on `feature/enum-value` — only the last commit(s) are new here; GitHub will retarget this PR to `main` automatically once the base PR merges and its branch is deleted.

Closes #1404

🤖 Generated with [Claude Code](https://claude.com/claude-code)