### PR TITLE
Add DuckDB::Value.create_union

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to this project will be documented in this file.
 - add `DuckDB::Value.create_interval(value)` to create INTERVAL values from a `DuckDB::Interval`.
 - add `DuckDB::Value.create_enum(enum_type, member)` to create ENUM values from an Array of member names (or an ENUM `DuckDB::LogicalType`) and a member name or 0-based index.
 - `DuckDB::Value#to_ruby` converts ENUM values to the member String.
+- add `DuckDB::Value.create_union(union_type, tag, value)` to create UNION values from a member spec Hash like `{ num: :integer, str: :varchar }` (or a UNION `DuckDB::LogicalType`), a member tag, and a `DuckDB::Value`. `DuckDB::Value#to_ruby` converts UNION values to the member value.
 
 # 1.5.4.0 - 2026-06-20
 - bump up DuckDB 1.5.4 and 1.4.5 on CI.

--- a/ext/duckdb/value.c
+++ b/ext/duckdb/value.c
@@ -32,7 +32,9 @@ static VALUE value_s__create_timestamp_ns(VALUE klass, VALUE year, VALUE month, 
 static VALUE value_s__create_timestamp_tz(VALUE klass, VALUE micros);
 static VALUE value_s__create_interval(VALUE klass, VALUE months, VALUE days, VALUE micros);
 static VALUE value_s__create_enum(VALUE klass, VALUE ltype, VALUE index);
+static VALUE value_s__create_union(VALUE klass, VALUE ltype, VALUE tag_index, VALUE member);
 static VALUE value_s_create_null(VALUE klass);
+static VALUE to_ruby_via_vector(duckdb_logical_type logical_type, duckdb_value val);
 static idx_t marshal_values(VALUE ary, duckdb_value **out, volatile VALUE *guard);
 static VALUE value_s__create_list(VALUE klass, VALUE ltype, VALUE values);
 static VALUE value_s__create_array(VALUE klass, VALUE ltype, VALUE values);
@@ -242,6 +244,17 @@ static VALUE value_s__create_enum(VALUE klass, VALUE ltype, VALUE index) {
 
     if (value == NULL) {
         rb_raise(eDuckDBError, "failed to create ENUM value");
+    }
+    return rbduckdb_value_new(value);
+}
+
+/* :nodoc: */
+static VALUE value_s__create_union(VALUE klass, VALUE ltype, VALUE tag_index, VALUE member) {
+    duckdb_logical_type type = rbduckdb_get_struct_logical_type(ltype)->logical_type;
+    duckdb_value value = duckdb_create_union_value(type, (idx_t)NUM2ULL(tag_index), rbduckdb_get_struct_value(member)->value);
+
+    if (value == NULL) {
+        rb_raise(eDuckDBError, "failed to create UNION value (mismatched member type?)");
     }
     return rbduckdb_value_new(value);
 }
@@ -499,13 +512,26 @@ rubyDuckDBValue *rbduckdb_get_struct_value(VALUE obj) {
     return ctx;
 }
 
+/*
+ * Converts a duckdb_value to Ruby by referencing it into a one-element
+ * vector and reusing the vector read path, so Value#to_ruby returns the
+ * same Ruby object a query result produces for that type. Used for types
+ * the C API has no direct duckdb_get_* accessors for.
+ */
+static VALUE to_ruby_via_vector(duckdb_logical_type logical_type, duckdb_value val) {
+    duckdb_vector vec = duckdb_create_vector(logical_type, 1);
+    VALUE result;
+
+    duckdb_vector_reference_value(vec, val);
+    result = rbduckdb_vector_value_at(vec, logical_type, 0);
+    duckdb_destroy_vector(&vec);
+    return result;
+}
+
 VALUE rbduckdb_duckdb_value_to_ruby(duckdb_value val) {
     duckdb_logical_type logical_type;
-    duckdb_logical_type child_type;
     duckdb_type type_id;
     duckdb_value child_value;
-    duckdb_vector vec;
-    duckdb_vector child_vec;
     VALUE result;
     VALUE elem;
     VALUE key;
@@ -644,18 +670,8 @@ VALUE rbduckdb_duckdb_value_to_ruby(duckdb_value val) {
             }
             break;
         case DUCKDB_TYPE_ARRAY:
-            /* the C API has no duckdb_get_array_size/child; read via a vector */
-            child_type = duckdb_array_type_child_type(logical_type);
-            vec = duckdb_create_vector(logical_type, 1);
-            size = duckdb_array_type_array_size(logical_type);
-            duckdb_vector_reference_value(vec, val);
-            child_vec = duckdb_array_vector_get_child(vec);
-            result = rb_ary_new_capa(size);
-            for (i = 0; i < size; i++) {
-                rb_ary_push(result, rbduckdb_vector_value_at(child_vec, child_type, i));
-            }
-            duckdb_destroy_logical_type(&child_type);
-            duckdb_destroy_vector(&vec);
+        case DUCKDB_TYPE_UNION:
+            result = to_ruby_via_vector(logical_type, val);
             break;
         default:
             result = Qnil;
@@ -673,8 +689,9 @@ VALUE rbduckdb_duckdb_value_to_ruby(duckdb_value val) {
  *  to their natural Ruby classes. LIST and ARRAY values are converted to
  *  Array recursively. STRUCT and MAP values are converted to Hash
  *  recursively (STRUCT keys are Symbols; MAP keys keep their natural Ruby
- *  type). ENUM values are converted to the member String. NULL is
- *  converted to nil. Returns nil for unsupported types.
+ *  type). ENUM values are converted to the member String. UNION values
+ *  are converted to the member's Ruby value. NULL is converted to nil.
+ *  Returns nil for unsupported types.
  *
  *    require 'duckdb'
  *    child_type = DuckDB::LogicalType.resolve(:integer)
@@ -720,6 +737,7 @@ void rbduckdb_init_value(void) {
     rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_timestamp_tz", value_s__create_timestamp_tz, 1);
     rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_interval", value_s__create_interval, 3);
     rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_enum", value_s__create_enum, 2);
+    rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_union", value_s__create_union, 3);
     rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_list", value_s__create_list, 2);
     rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_array", value_s__create_array, 2);
     rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_struct", value_s__create_struct, 2);

--- a/lib/duckdb/value.rb
+++ b/lib/duckdb/value.rb
@@ -417,6 +417,41 @@ module DuckDB
         _create_enum(enum_type, enum_member_index(enum_type, member))
       end
 
+      # Creates a DuckDB::Value of UNION type.
+      # The first argument is the union type: a Hash of member name to
+      # member type (as accepted by DuckDB::LogicalType.create_union) or a
+      # UNION DuckDB::LogicalType.
+      # The second argument is the member tag (String or Symbol), and the
+      # third is the member value as a DuckDB::Value of the tagged type.
+      #
+      #   value = DuckDB::Value.create_union({ num: :integer, str: :varchar }, :num, DuckDB::Value.create_int32(42))
+      #   value.to_ruby #=> 42
+      #
+      #   # equivalent, with an explicit UNION logical type:
+      #   union_type = DuckDB::LogicalType.create_union(num: :integer, str: :varchar)
+      #   value = DuckDB::Value.create_union(union_type, :num, DuckDB::Value.create_int32(42))
+      #
+      # @param union_type [Hash, DuckDB::LogicalType] the member spec or UNION logical type.
+      # @param tag [String, Symbol] the member tag.
+      # @param member_value [DuckDB::Value] the member value.
+      # @return [DuckDB::Value] the created Value object.
+      # @raise [ArgumentError] if union_type is not a Hash or a UNION
+      #   DuckDB::LogicalType, tag is not a member of the union, or
+      #   member_value is not a DuckDB::Value.
+      # @raise [DuckDB::Error] if member_value does not match the tagged
+      #   member's type.
+      def create_union(union_type, tag, member_value)
+        union_type = DuckDB::LogicalType.create_union(**union_type) if union_type.is_a?(Hash)
+        check_type!(union_type, DuckDB::LogicalType)
+        raise ArgumentError, "expected UNION LogicalType, got #{union_type.type}" unless union_type.type == :union
+
+        check_type!(member_value, DuckDB::Value)
+        tag_index = union_type.each_member_name.find_index(tag.to_s)
+        raise ArgumentError, "`#{tag}` is not a member of the union" if tag_index.nil?
+
+        _create_union(union_type, tag_index, member_value)
+      end
+
       # Creates a DuckDB::Value of LIST type.
       # The first argument is the element type: a Symbol (e.g. :integer) or a
       # DuckDB::LogicalType.

--- a/test/duckdb_test/value_union_test.rb
+++ b/test/duckdb_test/value_union_test.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module DuckDBTest
+  class ValueUnionTest < Minitest::Test
+    def union_type
+      DuckDB::LogicalType.create_union(num: :integer, str: :varchar)
+    end
+
+    def test_create_union_with_logical_type
+      value = DuckDB::Value.create_union(union_type, :num, DuckDB::Value.create_int32(42))
+
+      assert_instance_of(DuckDB::Value, value)
+      assert_equal(42, value.to_ruby)
+    end
+
+    def test_create_union_with_member_spec_hash
+      value = DuckDB::Value.create_union({ num: :integer, str: :varchar }, :str, DuckDB::Value.create_varchar('x'))
+
+      assert_equal('x', value.to_ruby)
+    end
+
+    def test_create_union_with_string_tag
+      value = DuckDB::Value.create_union(union_type, 'str', DuckDB::Value.create_varchar('hello'))
+
+      assert_equal('hello', value.to_ruby)
+    end
+
+    def test_create_union_with_unknown_tag_raises_argument_error
+      assert_raises(ArgumentError) do
+        DuckDB::Value.create_union(union_type, :missing, DuckDB::Value.create_int32(1))
+      end
+    end
+
+    def test_create_union_with_mismatched_member_type_raises_error
+      assert_raises(DuckDB::Error) do
+        DuckDB::Value.create_union(union_type, :num, DuckDB::Value.create_varchar('not an int'))
+      end
+    end
+
+    def test_create_union_with_non_union_logical_type_raises_argument_error
+      assert_raises(ArgumentError) do
+        DuckDB::Value.create_union(DuckDB::LogicalType.resolve(:integer), :num, DuckDB::Value.create_int32(1))
+      end
+    end
+
+    def test_create_union_with_non_value_member_raises_argument_error
+      assert_raises(ArgumentError) { DuckDB::Value.create_union(union_type, :num, 42) }
+    end
+  end
+end


### PR DESCRIPTION
Adds `DuckDB::Value.create_union(union_type, tag, value)` building a UNION value from a member spec Hash (or a UNION `DuckDB::LogicalType`), a member tag, and a member `DuckDB::Value`. Unknown tags raise `ArgumentError`; mismatched member types raise `DuckDB::Error`. `to_ruby` returns the member value, via a new shared helper that references the value into a one-element vector and reuses the vector read path (the ARRAY branch now uses the same helper).

Part of the DuckDB::Value API stack (#1393–#1411). Stacked on `feature/enum-to-ruby` — only the last commit(s) are new here; GitHub will retarget this PR to `main` automatically once the base PR merges and its branch is deleted.

Closes #1405

🤖 Generated with [Claude Code](https://claude.com/claude-code)