### PR TITLE
Add DuckDB::Value.create_bit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to this project will be documented in this file.
 - add `DuckDB::Value.create_enum(enum_type, member)` to create ENUM values from an Array of member names (or an ENUM `DuckDB::LogicalType`) and a member name or 0-based index.
 - `DuckDB::Value#to_ruby` converts ENUM values to the member String.
 - add `DuckDB::Value.create_union(union_type, tag, value)` to create UNION values from a member spec Hash like `{ num: :integer, str: :varchar }` (or a UNION `DuckDB::LogicalType`), a member tag, and a `DuckDB::Value`. `DuckDB::Value#to_ruby` converts UNION values to the member value.
+- add `DuckDB::Value.create_bit(value)` to create BIT values from a String of '0'/'1' characters.
 
 # 1.5.4.0 - 2026-06-20
 - bump up DuckDB 1.5.4 and 1.4.5 on CI.

--- a/ext/duckdb/value.c
+++ b/ext/duckdb/value.c
@@ -33,6 +33,7 @@ static VALUE value_s__create_timestamp_tz(VALUE klass, VALUE micros);
 static VALUE value_s__create_interval(VALUE klass, VALUE months, VALUE days, VALUE micros);
 static VALUE value_s__create_enum(VALUE klass, VALUE ltype, VALUE index);
 static VALUE value_s__create_union(VALUE klass, VALUE ltype, VALUE tag_index, VALUE member);
+static VALUE value_s__create_bit(VALUE klass, VALUE data);
 static VALUE value_s_create_null(VALUE klass);
 static VALUE to_ruby_via_vector(duckdb_logical_type logical_type, duckdb_value val);
 static idx_t marshal_values(VALUE ary, duckdb_value **out, volatile VALUE *guard);
@@ -255,6 +256,25 @@ static VALUE value_s__create_union(VALUE klass, VALUE ltype, VALUE tag_index, VA
 
     if (value == NULL) {
         rb_raise(eDuckDBError, "failed to create UNION value (mismatched member type?)");
+    }
+    return rbduckdb_value_new(value);
+}
+
+/*
+ * :nodoc:
+ * data is the raw DuckDB BIT blob built in Ruby: one byte holding the
+ * number of padding bits, then the bits MSB-first with the padding bits
+ * of the first data byte set to 1.
+ */
+static VALUE value_s__create_bit(VALUE klass, VALUE data) {
+    duckdb_bit bit;
+    duckdb_value value;
+
+    bit.data = (uint8_t *)StringValuePtr(data);
+    bit.size = RSTRING_LEN(data);
+    value = duckdb_create_bit(bit);
+    if (value == NULL) {
+        rb_raise(eDuckDBError, "failed to create BIT value");
     }
     return rbduckdb_value_new(value);
 }
@@ -738,6 +758,7 @@ void rbduckdb_init_value(void) {
     rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_interval", value_s__create_interval, 3);
     rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_enum", value_s__create_enum, 2);
     rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_union", value_s__create_union, 3);
+    rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_bit", value_s__create_bit, 1);
     rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_list", value_s__create_list, 2);
     rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_array", value_s__create_array, 2);
     rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_struct", value_s__create_struct, 2);

--- a/lib/duckdb/value.rb
+++ b/lib/duckdb/value.rb
@@ -452,6 +452,22 @@ module DuckDB
         _create_union(union_type, tag_index, member_value)
       end
 
+      # Creates a DuckDB::Value of BIT (bitstring) type.
+      #
+      #   value = DuckDB::Value.create_bit('0101')
+      #
+      # @param value [String] the bitstring: '0'/'1' characters, MSB first.
+      # @return [DuckDB::Value] the created Value object.
+      # @raise [ArgumentError] if +value+ is not a non-empty String of '0'
+      #   and '1' characters.
+      def create_bit(value)
+        check_type!(value, String)
+        raise ArgumentError, "expected a String of '0'/'1' characters" unless value.match?(/\A[01]+\z/)
+
+        pad = -value.length % 8
+        _create_bit("#{pad.chr}#{[('1' * pad) + value].pack('B*')}".b)
+      end
+
       # Creates a DuckDB::Value of LIST type.
       # The first argument is the element type: a Symbol (e.g. :integer) or a
       # DuckDB::LogicalType.

--- a/test/duckdb_test/value_bit_test.rb
+++ b/test/duckdb_test/value_bit_test.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module DuckDBTest
+  class ValueBitTest < Minitest::Test
+    def test_create_bit
+      value = DuckDB::Value.create_bit('0101')
+
+      assert_instance_of(DuckDB::Value, value)
+    end
+
+    def test_create_bit_with_invalid_characters_raises_argument_error
+      assert_raises(ArgumentError) { DuckDB::Value.create_bit('01012') }
+    end
+
+    def test_create_bit_with_empty_string_raises_argument_error
+      assert_raises(ArgumentError) { DuckDB::Value.create_bit('') }
+    end
+
+    def test_create_bit_with_nil_raises_argument_error
+      assert_raises(ArgumentError) { DuckDB::Value.create_bit(nil) }
+    end
+  end
+end


### PR DESCRIPTION
Adds `DuckDB::Value.create_bit(value)` building a BIT (bitstring) value from a String of '0'/'1' characters. Other characters (and empty strings) raise `ArgumentError`.

Part of the DuckDB::Value API stack (#1393–#1411). Stacked on `feature/union-value` — only the last commit(s) are new here; GitHub will retarget this PR to `main` automatically once the base PR merges and its branch is deleted.

Closes #1406

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `DuckDB::Value.create_bit` for creating BIT values from strings containing `0` and `1`.
  * Supports bitstrings of any length by automatically padding them as needed.

* **Bug Fixes**
  * Added validation for invalid characters, empty strings, and non-string input, raising `ArgumentError`.

* **Documentation**
  * Documented the new BIT value creation method in the changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->