### PR TITLE
Support BIT in DuckDB::Value#to_ruby

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to this project will be documented in this file.
 - `DuckDB::Value#to_ruby` converts ENUM values to the member String.
 - add `DuckDB::Value.create_union(union_type, tag, value)` to create UNION values from a member spec Hash like `{ num: :integer, str: :varchar }` (or a UNION `DuckDB::LogicalType`), a member tag, and a `DuckDB::Value`. `DuckDB::Value#to_ruby` converts UNION values to the member value.
 - add `DuckDB::Value.create_bit(value)` to create BIT values from a String of '0'/'1' characters.
+- `DuckDB::Value#to_ruby` converts BIT values to a String of '0'/'1' characters.
 
 # 1.5.4.0 - 2026-06-20
 - bump up DuckDB 1.5.4 and 1.4.5 on CI.

--- a/ext/duckdb/value.c
+++ b/ext/duckdb/value.c
@@ -691,6 +691,7 @@ VALUE rbduckdb_duckdb_value_to_ruby(duckdb_value val) {
             break;
         case DUCKDB_TYPE_ARRAY:
         case DUCKDB_TYPE_UNION:
+        case DUCKDB_TYPE_BIT:
             result = to_ruby_via_vector(logical_type, val);
             break;
         default:
@@ -710,8 +711,9 @@ VALUE rbduckdb_duckdb_value_to_ruby(duckdb_value val) {
  *  Array recursively. STRUCT and MAP values are converted to Hash
  *  recursively (STRUCT keys are Symbols; MAP keys keep their natural Ruby
  *  type). ENUM values are converted to the member String. UNION values
- *  are converted to the member's Ruby value. NULL is converted to nil.
- *  Returns nil for unsupported types.
+ *  are converted to the member's Ruby value. BIT values are converted to
+ *  a String of '0'/'1' characters. NULL is converted to nil. Returns nil
+ *  for unsupported types.
  *
  *    require 'duckdb'
  *    child_type = DuckDB::LogicalType.resolve(:integer)

--- a/test/duckdb_test/value_bit_test.rb
+++ b/test/duckdb_test/value_bit_test.rb
@@ -10,6 +10,22 @@ module DuckDBTest
       assert_instance_of(DuckDB::Value, value)
     end
 
+    def test_to_ruby_round_trips
+      assert_equal('0101', DuckDB::Value.create_bit('0101').to_ruby)
+    end
+
+    def test_to_ruby_round_trips_with_length_not_divisible_by_eight
+      bits = '010110011'
+
+      assert_equal(bits, DuckDB::Value.create_bit(bits).to_ruby)
+    end
+
+    def test_to_ruby_round_trips_with_multiple_bytes
+      bits = '1010101010101010'
+
+      assert_equal(bits, DuckDB::Value.create_bit(bits).to_ruby)
+    end
+
     def test_create_bit_with_invalid_characters_raises_argument_error
       assert_raises(ArgumentError) { DuckDB::Value.create_bit('01012') }
     end


### PR DESCRIPTION
`DuckDB::Value#to_ruby` on a BIT value now returns the bitstring as a String of '0'/'1' characters, round-tripping with `create_bit` including lengths not divisible by 8.

Part of the DuckDB::Value API stack (#1393–#1411). Stacked on `feature/bit-value` — only the last commit(s) are new here; GitHub will retarget this PR to `main` automatically once the base PR merges and its branch is deleted.

Closes #1407

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `DuckDB::Value#to_ruby` now converts BIT values to Ruby strings containing `'0'` and `'1'` characters.
  * BIT strings of varying lengths, including multi-byte values, are supported.

* **Documentation**
  * Updated the changelog and API documentation to describe BIT conversion behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->