### PR TITLE
Add DuckDB::Value.create_bignum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to this project will be documented in this file.
 - add `DuckDB::Value.create_union(union_type, tag, value)` to create UNION values from a member spec Hash like `{ num: :integer, str: :varchar }` (or a UNION `DuckDB::LogicalType`), a member tag, and a `DuckDB::Value`. `DuckDB::Value#to_ruby` converts UNION values to the member value.
 - add `DuckDB::Value.create_bit(value)` to create BIT values from a String of '0'/'1' characters.
 - `DuckDB::Value#to_ruby` converts BIT values to a String of '0'/'1' characters.
+- add `DuckDB::Value.create_bignum(value)` to create BIGNUM (arbitrary-precision integer) values from a Ruby Integer.
 
 # 1.5.4.0 - 2026-06-20
 - bump up DuckDB 1.5.4 and 1.4.5 on CI.

--- a/ext/duckdb/value.c
+++ b/ext/duckdb/value.c
@@ -34,6 +34,7 @@ static VALUE value_s__create_interval(VALUE klass, VALUE months, VALUE days, VAL
 static VALUE value_s__create_enum(VALUE klass, VALUE ltype, VALUE index);
 static VALUE value_s__create_union(VALUE klass, VALUE ltype, VALUE tag_index, VALUE member);
 static VALUE value_s__create_bit(VALUE klass, VALUE data);
+static VALUE value_s__create_bignum(VALUE klass, VALUE data, VALUE is_negative);
 static VALUE value_s_create_null(VALUE klass);
 static VALUE to_ruby_via_vector(duckdb_logical_type logical_type, duckdb_value val);
 static idx_t marshal_values(VALUE ary, duckdb_value **out, volatile VALUE *guard);
@@ -275,6 +276,24 @@ static VALUE value_s__create_bit(VALUE klass, VALUE data) {
     value = duckdb_create_bit(bit);
     if (value == NULL) {
         rb_raise(eDuckDBError, "failed to create BIT value");
+    }
+    return rbduckdb_value_new(value);
+}
+
+/*
+ * :nodoc:
+ * data is the magnitude in big-endian bytes, built in Ruby.
+ */
+static VALUE value_s__create_bignum(VALUE klass, VALUE data, VALUE is_negative) {
+    duckdb_bignum bignum;
+    duckdb_value value;
+
+    bignum.data = (uint8_t *)StringValuePtr(data);
+    bignum.size = RSTRING_LEN(data);
+    bignum.is_negative = RTEST(is_negative);
+    value = duckdb_create_bignum(bignum);
+    if (value == NULL) {
+        rb_raise(eDuckDBError, "failed to create BIGNUM value");
     }
     return rbduckdb_value_new(value);
 }
@@ -761,6 +780,7 @@ void rbduckdb_init_value(void) {
     rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_enum", value_s__create_enum, 2);
     rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_union", value_s__create_union, 3);
     rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_bit", value_s__create_bit, 1);
+    rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_bignum", value_s__create_bignum, 2);
     rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_list", value_s__create_list, 2);
     rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_array", value_s__create_array, 2);
     rb_define_private_method(rb_singleton_class(cDuckDBValue), "_create_struct", value_s__create_struct, 2);

--- a/lib/duckdb/value.rb
+++ b/lib/duckdb/value.rb
@@ -468,6 +468,22 @@ module DuckDB
         _create_bit("#{pad.chr}#{[('1' * pad) + value].pack('B*')}".b)
       end
 
+      # Creates a DuckDB::Value of BIGNUM (arbitrary-precision integer)
+      # type.
+      #
+      #   value = DuckDB::Value.create_bignum(2**200)
+      #
+      # @param value [Integer] the integer value, of arbitrary size.
+      # @return [DuckDB::Value] the created Value object.
+      # @raise [ArgumentError] if +value+ is not an Integer.
+      def create_bignum(value)
+        check_type!(value, Integer)
+
+        hex = value.abs.to_s(16)
+        hex = "0#{hex}" if hex.length.odd?
+        _create_bignum([hex].pack('H*'), value.negative?)
+      end
+
       # Creates a DuckDB::Value of LIST type.
       # The first argument is the element type: a Symbol (e.g. :integer) or a
       # DuckDB::LogicalType.

--- a/test/duckdb_test/value_bignum_test.rb
+++ b/test/duckdb_test/value_bignum_test.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module DuckDBTest
+  class ValueBignumTest < Minitest::Test
+    BEYOND_HUGEINT = (2**200) + 123_456_789
+
+    def test_create_bignum
+      value = DuckDB::Value.create_bignum(BEYOND_HUGEINT)
+
+      assert_instance_of(DuckDB::Value, value)
+    end
+
+    def test_create_bignum_with_negative
+      value = DuckDB::Value.create_bignum(-BEYOND_HUGEINT)
+
+      assert_instance_of(DuckDB::Value, value)
+    end
+
+    def test_create_bignum_with_zero
+      assert_instance_of(DuckDB::Value, DuckDB::Value.create_bignum(0))
+    end
+
+    def test_create_bignum_with_string_raises_argument_error
+      assert_raises(ArgumentError) { DuckDB::Value.create_bignum('123') }
+    end
+
+    def test_create_bignum_with_nil_raises_argument_error
+      assert_raises(ArgumentError) { DuckDB::Value.create_bignum(nil) }
+    end
+  end
+end


### PR DESCRIPTION
Adds `DuckDB::Value.create_bignum(value)` building a BIGNUM (arbitrary-precision integer) value from a Ruby Integer, positive or negative, beyond the HUGEINT range. Non-Integer input raises `ArgumentError`. No version guard needed: `duckdb_create_bignum` exists in DuckDB 1.4.0.

Part of the DuckDB::Value API stack (#1393–#1411). Stacked on `feature/bit-to-ruby` — only the last commit(s) are new here; GitHub will retarget this PR to `main` automatically once the base PR merges and its branch is deleted.

Closes #1408

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `DuckDB::Value.create_bignum(value)` for creating arbitrary-precision `BIGNUM` values from Ruby integers.
  * Supports positive, negative, zero, and values larger than the `HUGEINT` range.

* **Bug Fixes**
  * Added input validation to reject non-integer values with an `ArgumentError`.

* **Documentation**
  * Documented the new API in the changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->