### PR TITLE
Support BIGNUM in DuckDB::Value#to_ruby

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ All notable changes to this project will be documented in this file.
 - add `DuckDB::Value.create_bit(value)` to create BIT values from a String of '0'/'1' characters.
 - `DuckDB::Value#to_ruby` converts BIT values to a String of '0'/'1' characters.
 - add `DuckDB::Value.create_bignum(value)` to create BIGNUM (arbitrary-precision integer) values from a Ruby Integer.
+- `DuckDB::Value#to_ruby` converts BIGNUM values to a Ruby Integer.
 
 # 1.5.4.0 - 2026-06-20
 - bump up DuckDB 1.5.4 and 1.4.5 on CI.

--- a/ext/duckdb/value.c
+++ b/ext/duckdb/value.c
@@ -713,6 +713,16 @@ VALUE rbduckdb_duckdb_value_to_ruby(duckdb_value val) {
         case DUCKDB_TYPE_BIT:
             result = to_ruby_via_vector(logical_type, val);
             break;
+        case DUCKDB_TYPE_BIGNUM: {
+            duckdb_bignum bignum = duckdb_get_bignum(val);
+
+            result = rb_integer_unpack(bignum.data, bignum.size, 1, 0, INTEGER_PACK_BIG_ENDIAN);
+            duckdb_free(bignum.data);
+            if (bignum.is_negative) {
+                result = rb_funcall(result, rb_intern("-@"), 0);
+            }
+            break;
+        }
         default:
             result = Qnil;
             break;
@@ -731,8 +741,8 @@ VALUE rbduckdb_duckdb_value_to_ruby(duckdb_value val) {
  *  recursively (STRUCT keys are Symbols; MAP keys keep their natural Ruby
  *  type). ENUM values are converted to the member String. UNION values
  *  are converted to the member's Ruby value. BIT values are converted to
- *  a String of '0'/'1' characters. NULL is converted to nil. Returns nil
- *  for unsupported types.
+ *  a String of '0'/'1' characters. BIGNUM values are converted to
+ *  Integer. NULL is converted to nil. Returns nil for unsupported types.
  *
  *    require 'duckdb'
  *    child_type = DuckDB::LogicalType.resolve(:integer)

--- a/test/duckdb_test/value_bignum_test.rb
+++ b/test/duckdb_test/value_bignum_test.rb
@@ -22,6 +22,20 @@ module DuckDBTest
       assert_instance_of(DuckDB::Value, DuckDB::Value.create_bignum(0))
     end
 
+    def test_to_ruby_round_trips_beyond_hugeint_range
+      assert_equal(BEYOND_HUGEINT, DuckDB::Value.create_bignum(BEYOND_HUGEINT).to_ruby)
+    end
+
+    def test_to_ruby_round_trips_negative
+      assert_equal(-BEYOND_HUGEINT, DuckDB::Value.create_bignum(-BEYOND_HUGEINT).to_ruby)
+    end
+
+    def test_to_ruby_round_trips_small_values
+      [0, 1, -1, 255, -256].each do |i|
+        assert_equal(i, DuckDB::Value.create_bignum(i).to_ruby)
+      end
+    end
+
     def test_create_bignum_with_string_raises_argument_error
       assert_raises(ArgumentError) { DuckDB::Value.create_bignum('123') }
     end


### PR DESCRIPTION
`DuckDB::Value#to_ruby` on a BIGNUM value now returns the exact Ruby Integer (via `rb_integer_unpack`), round-tripping with `create_bignum` for positive and negative values beyond the HUGEINT range.

Part of the DuckDB::Value API stack (#1393–#1411). Stacked on `feature/bignum-value` — only the last commit(s) are new here; GitHub will retarget this PR to `main` automatically once the base PR merges and its branch is deleted.

Closes #1409

🤖 Generated with [Claude Code](https://claude.com/claude-code)