### PR TITLE
Support BLOB in DuckDB::Value#to_ruby

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ All notable changes to this project will be documented in this file.
 - `DuckDB::Value#to_ruby` converts BIT values to a String of '0'/'1' characters.
 - add `DuckDB::Value.create_bignum(value)` to create BIGNUM (arbitrary-precision integer) values from a Ruby Integer.
 - `DuckDB::Value#to_ruby` converts BIGNUM values to a Ruby Integer.
+- `DuckDB::Value#to_ruby` converts BLOB values to a BINARY-encoded String.
 
 # 1.5.4.0 - 2026-06-20
 - bump up DuckDB 1.5.4 and 1.4.5 on CI.

--- a/ext/duckdb/value.c
+++ b/ext/duckdb/value.c
@@ -713,6 +713,13 @@ VALUE rbduckdb_duckdb_value_to_ruby(duckdb_value val) {
         case DUCKDB_TYPE_BIT:
             result = to_ruby_via_vector(logical_type, val);
             break;
+        case DUCKDB_TYPE_BLOB: {
+            duckdb_blob blob = duckdb_get_blob(val);
+
+            result = rb_str_new((const char *)blob.data, blob.size);
+            duckdb_free(blob.data);
+            break;
+        }
         case DUCKDB_TYPE_BIGNUM: {
             duckdb_bignum bignum = duckdb_get_bignum(val);
 
@@ -742,7 +749,8 @@ VALUE rbduckdb_duckdb_value_to_ruby(duckdb_value val) {
  *  type). ENUM values are converted to the member String. UNION values
  *  are converted to the member's Ruby value. BIT values are converted to
  *  a String of '0'/'1' characters. BIGNUM values are converted to
- *  Integer. NULL is converted to nil. Returns nil for unsupported types.
+ *  Integer. BLOB values are converted to a BINARY-encoded String. NULL
+ *  is converted to nil. Returns nil for unsupported types.
  *
  *    require 'duckdb'
  *    child_type = DuckDB::LogicalType.resolve(:integer)

--- a/test/duckdb_test/value_test.rb
+++ b/test/duckdb_test/value_test.rb
@@ -462,6 +462,21 @@ module DuckDBTest
       assert_instance_of(DuckDB::Value, value)
     end
 
+    def test_blob_to_ruby_round_trips_byte_exact
+      bytes = "\x00\x01\xFFabc\x00".b
+      result = DuckDB::Value.create_blob(bytes).to_ruby
+
+      assert_equal(bytes, result)
+      assert_equal(Encoding::BINARY, result.encoding)
+    end
+
+    def test_blob_to_ruby_with_empty_blob
+      result = DuckDB::Value.create_blob(''.b).to_ruby
+
+      assert_equal(''.b, result)
+      assert_equal(Encoding::BINARY, result.encoding)
+    end
+
     def test_create_blob_with_binary_duckdb_blob
       value = DuckDB::Value.create_blob(DuckDB::Blob.new("\x00\x01\x02".b))
 


### PR DESCRIPTION
`DuckDB::Value#to_ruby` on a BLOB value now returns the bytes as a BINARY-encoded Ruby String, byte-exact including NUL bytes, round-tripping with the existing `create_blob`.

Part of the DuckDB::Value API stack (#1393–#1411). Stacked on `feature/bignum-to-ruby` — only the last commit(s) are new here; GitHub will retarget this PR to `main` automatically once the base PR merges and its branch is deleted.

Closes #1410

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `DuckDB::Value#to_ruby` now converts BLOB values into binary-encoded Ruby strings.
  * Binary data and empty BLOBs preserve their exact contents and use `Encoding::BINARY`.

* **Documentation**
  * Updated the value conversion documentation and unreleased changelog to describe BLOB support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->