### PR TITLE
Support DECIMAL in DuckDB::Value#to_ruby

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ All notable changes to this project will be documented in this file.
 - add `DuckDB::Value.create_bignum(value)` to create BIGNUM (arbitrary-precision integer) values from a Ruby Integer.
 - `DuckDB::Value#to_ruby` converts BIGNUM values to a Ruby Integer.
 - `DuckDB::Value#to_ruby` converts BLOB values to a BINARY-encoded String.
+- `DuckDB::Value#to_ruby` converts DECIMAL values to a BigDecimal.
 
 # 1.5.4.0 - 2026-06-20
 - bump up DuckDB 1.5.4 and 1.4.5 on CI.

--- a/ext/duckdb/value.c
+++ b/ext/duckdb/value.c
@@ -711,6 +711,7 @@ VALUE rbduckdb_duckdb_value_to_ruby(duckdb_value val) {
         case DUCKDB_TYPE_ARRAY:
         case DUCKDB_TYPE_UNION:
         case DUCKDB_TYPE_BIT:
+        case DUCKDB_TYPE_DECIMAL:
             result = to_ruby_via_vector(logical_type, val);
             break;
         case DUCKDB_TYPE_BLOB: {
@@ -749,8 +750,9 @@ VALUE rbduckdb_duckdb_value_to_ruby(duckdb_value val) {
  *  type). ENUM values are converted to the member String. UNION values
  *  are converted to the member's Ruby value. BIT values are converted to
  *  a String of '0'/'1' characters. BIGNUM values are converted to
- *  Integer. BLOB values are converted to a BINARY-encoded String. NULL
- *  is converted to nil. Returns nil for unsupported types.
+ *  Integer. BLOB values are converted to a BINARY-encoded String.
+ *  DECIMAL values are converted to BigDecimal. NULL is converted to nil.
+ *  Returns nil for unsupported types.
  *
  *    require 'duckdb'
  *    child_type = DuckDB::LogicalType.resolve(:integer)

--- a/test/duckdb_test/value_test.rb
+++ b/test/duckdb_test/value_test.rb
@@ -573,6 +573,24 @@ module DuckDBTest
       end
     end
 
+    def test_decimal_to_ruby_round_trips
+      decimal = BigDecimal('12345.678')
+
+      assert_equal(decimal, DuckDB::Value.create_decimal(decimal).to_ruby)
+    end
+
+    def test_decimal_to_ruby_round_trips_negative
+      decimal = BigDecimal('-0.00001')
+
+      assert_equal(decimal, DuckDB::Value.create_decimal(decimal).to_ruby)
+    end
+
+    def test_decimal_to_ruby_round_trips_max_width
+      decimal = BigDecimal('-1234567890123456789012345678.9012345678')
+
+      assert_equal(decimal, DuckDB::Value.create_decimal(decimal).to_ruby)
+    end
+
     def test_create_decimal_with_positive
       value = DuckDB::Value.create_decimal(BigDecimal('12345.678'))
 


### PR DESCRIPTION
`DuckDB::Value#to_ruby` on a DECIMAL value now returns a `BigDecimal` preserving width and scale, round-tripping with the existing `create_decimal` including max width (38) and negative values.

Part of the DuckDB::Value API stack (#1393–#1411). Stacked on `feature/blob-to-ruby` — only the last commit(s) are new here; GitHub will retarget this PR to `main` automatically once the base PR merges and its branch is deleted.

Closes #1411

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - `DuckDB::Value#to_ruby` now converts `DECIMAL` values to Ruby `BigDecimal` objects.
  - Supports positive, negative, and high-precision decimal values.

- **Documentation**
  - Updated the value conversion documentation to describe `DECIMAL` behavior and unsupported types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->