### PR TITLE
Add Connection#table_names using duckdb_get_table_names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 # Unreleased
 - bump Ruby to 3.4.10 on CI.
+- add `DuckDB::Connection#table_names(sql, qualified: false)` returning the table names referenced by a SQL query without executing it (binds `duckdb_get_table_names`). With `qualified: true`, names are returned as written in the query (including schema/catalog prefixes and aliases). Result order is unspecified.
 - add `DuckDB::Value.create_list(child_type, values)` and `DuckDB::Value.create_array(child_type, values)` to create LIST/ARRAY values from an element type (a Symbol like `:integer` or a `DuckDB::LogicalType`) and an Array of `DuckDB::Value` elements. The created values can be bound to prepared statements with `#bind_value`.
 - add `DuckDB::Value#list_size` and `DuckDB::Value#list_child(index)` to read LIST value elements as `DuckDB::Value`.
 - add `DuckDB::Value#to_ruby` converting a `DuckDB::Value` to a Ruby object. LIST/ARRAY values are converted to Ruby Arrays recursively; NULL becomes `nil`.

--- a/ext/duckdb/connection.c
+++ b/ext/duckdb/connection.c
@@ -17,6 +17,7 @@ static VALUE connection__register_scalar_function_set(VALUE self, VALUE scalar_f
 static VALUE connection__register_aggregate_function(VALUE self, VALUE aggregate_function);
 static VALUE connection__register_aggregate_function_set(VALUE self, VALUE aggregate_function_set);
 static VALUE connection__register_table_function(VALUE self, VALUE table_function);
+static VALUE connection__get_table_names(VALUE self, VALUE query, VALUE qualified);
 
 static const rb_data_type_t connection_data_type = {
     "DuckDB/Connection",
@@ -204,6 +205,26 @@ static VALUE connection__query_sql(VALUE self, VALUE str) {
 }
 
 /* :nodoc: */
+static VALUE connection__get_table_names(VALUE self, VALUE query, VALUE qualified) {
+    rubyDuckDBConnection *ctx;
+    duckdb_value table_names;
+
+    ctx = rbduckdb_get_struct_connection(self);
+
+    if (!(ctx->con)) {
+        rb_raise(eDuckDBError, "Database connection closed");
+    }
+
+    table_names = duckdb_get_table_names(ctx->con, StringValueCStr(query), RTEST(qualified));
+
+    if (!table_names) {
+        rb_raise(eDuckDBError, "Failed to get table names from query");
+    }
+
+    return rbduckdb_value_new(table_names);
+}
+
+/* :nodoc: */
 static VALUE connection__register_logical_type(VALUE self, VALUE logical_type) {
     rubyDuckDBConnection *ctxcon;
     rubyDuckDBLogicalType *ctxlt;
@@ -346,4 +367,5 @@ void rbduckdb_init_connection(void) {
     rb_define_private_method(cDuckDBConnection, "_register_table_function", connection__register_table_function, 1);
     rb_define_private_method(cDuckDBConnection, "_connect", connection__connect, 1);
     rb_define_private_method(cDuckDBConnection, "_query_sql", connection__query_sql, 1);
+    rb_define_private_method(cDuckDBConnection, "_get_table_names", connection__get_table_names, 2);
 }

--- a/lib/duckdb/connection.rb
+++ b/lib/duckdb/connection.rb
@@ -423,6 +423,25 @@ module DuckDB
       end
     end
 
+    # Returns the names of the tables referenced by the given SQL query,
+    # without executing it.
+    #
+    # @param query [String] the SQL query to inspect
+    # @param qualified [Boolean] if true, returns each table reference as
+    #   written in the query, keeping any catalog/schema qualification;
+    #   if false (default), bare table names only
+    # @return [Array<String>] the referenced table names
+    # @raise [DuckDB::Error] if the query cannot be parsed
+    #
+    # @example
+    #   con.table_names('SELECT * FROM users u JOIN orders o ON u.id = o.user_id')
+    #   #=> ["users", "orders"]
+    #   con.table_names('SELECT * FROM memory.main.users', qualified: true)
+    #   #=> ["memory.main.users"]
+    def table_names(query, qualified: false)
+      _get_table_names(query, qualified).to_ruby
+    end
+
     private
 
     # Drives the Arrow stream at +address+ chunk by chunk into +table+,

--- a/lib/duckdb/connection.rb
+++ b/lib/duckdb/connection.rb
@@ -430,12 +430,12 @@ module DuckDB
     # @param qualified [Boolean] if true, returns each table reference as
     #   written in the query, keeping any catalog/schema qualification;
     #   if false (default), bare table names only
-    # @return [Array<String>] the referenced table names
+    # @return [Array<String>] the referenced table names, in unspecified order
     # @raise [DuckDB::Error] if the query cannot be parsed
     #
     # @example
-    #   con.table_names('SELECT * FROM users u JOIN orders o ON u.id = o.user_id')
-    #   #=> ["users", "orders"]
+    #   con.table_names('SELECT * FROM users u JOIN orders o ON u.id = o.user_id').sort
+    #   #=> ["orders", "users"]
     #   con.table_names('SELECT * FROM memory.main.users', qualified: true)
     #   #=> ["memory.main.users"]
     def table_names(query, qualified: false)

--- a/test/duckdb_test/connection_test.rb
+++ b/test/duckdb_test/connection_test.rb
@@ -488,5 +488,40 @@ module DuckDBTest
 
       assert_equal 123, rows[0][0]
     end
+
+    def test_table_names
+      @con.query('CREATE TABLE users (id INTEGER)')
+      @con.query('CREATE TABLE orders (id INTEGER, user_id INTEGER)')
+
+      names = @con.table_names('SELECT * FROM users u JOIN orders o ON u.id = o.user_id')
+
+      assert_equal(%w[orders users], names.sort)
+    end
+
+    def test_table_names_qualified
+      @con.query('CREATE TABLE t1 (id INTEGER)')
+
+      names = @con.table_names('SELECT * FROM memory.main.t1', qualified: true)
+
+      assert_equal(['memory.main.t1'], names)
+    end
+
+    def test_table_names_qualified_false_strips_qualification
+      @con.query('CREATE TABLE t1 (id INTEGER)')
+
+      names = @con.table_names('SELECT * FROM memory.main.t1')
+
+      assert_equal(['t1'], names)
+    end
+
+    def test_table_names_without_tables
+      assert_empty(@con.table_names('SELECT 1'))
+    end
+
+    def test_table_names_with_invalid_sql
+      assert_raises(DuckDB::Error) do
+        @con.table_names('NOT A VALID SQL')
+      end
+    end
   end
 end

--- a/test/duckdb_test/connection_test.rb
+++ b/test/duckdb_test/connection_test.rb
@@ -523,5 +523,13 @@ module DuckDBTest
         @con.table_names('NOT A VALID SQL')
       end
     end
+
+    def test_table_names_with_closed_connection
+      @con.disconnect
+
+      assert_raises(DuckDB::Error) do
+        @con.table_names('SELECT * FROM users')
+      end
+    end
   end
 end

--- a/test/duckdb_test/connection_test.rb
+++ b/test/duckdb_test/connection_test.rb
@@ -524,6 +524,45 @@ module DuckDBTest
       end
     end
 
+    def test_table_names_with_nonexistent_tables
+      names = @con.table_names('SELECT * FROM no_such_table')
+
+      assert_equal(['no_such_table'], names)
+    end
+
+    def test_table_names_deduplicates
+      names = @con.table_names('SELECT * FROM my_table, my_table m2, my_table m3')
+
+      assert_equal(['my_table'], names)
+    end
+
+    def test_table_names_excludes_cte_names
+      names = @con.table_names('WITH cte AS (SELECT * FROM my_table) SELECT * FROM cte')
+
+      assert_equal(['my_table'], names)
+    end
+
+    def test_table_names_expands_views
+      @con.query('CREATE TABLE base_table (id INTEGER)')
+      @con.query('CREATE VIEW v1 AS SELECT * FROM base_table')
+
+      names = @con.table_names('SELECT * FROM v1')
+
+      assert_equal(['base_table'], names)
+    end
+
+    def test_table_names_with_table_function
+      names = @con.table_names('SELECT * FROM generate_series(1, 3)')
+
+      assert_empty(names)
+    end
+
+    def test_table_names_qualified_includes_alias
+      names = @con.table_names('SELECT * FROM schema1.table1 alias1', qualified: true)
+
+      assert_equal(['schema1.table1 AS alias1'], names)
+    end
+
     def test_table_names_with_closed_connection
       @con.disconnect
 


### PR DESCRIPTION
## Summary

Binds the DuckDB C API function `duckdb_get_table_names` (available since DuckDB v1.3.0, the gem minimum — no feature guard needed) as `Connection#table_names`: returns the table names referenced by a SQL query without executing it.

```ruby
con.table_names('SELECT * FROM users u JOIN orders o ON u.id = o.user_id').sort
#=> ["orders", "users"]

con.table_names('SELECT * FROM memory.main.users', qualified: true)
#=> ["memory.main.users"]
```

## Design

The C side is minimal: `_get_table_names` calls `duckdb_get_table_names` and wraps the returned `VARCHAR[]` as a `DuckDB::Value` via the existing `rbduckdb_value_new`. List unwrapping happens in Ruby through `Value#to_ruby`. The value is destroyed by `DuckDB::Value`'s GC deallocator; the null-return path (unparseable SQL) raises `DuckDB::Error` before wrapping.

## Notes on semantics

- `qualified: true` returns each table reference **as written in the query** (`ref.ToString()`), including aliases (`"schema1.table1 AS alias1"`) — not expanded to `catalog.schema.table` as the duckdb.h comment suggests. The rdoc documents the real behavior.
- Result order is unspecified (DuckDB returns an unordered set).

## Tests

12 tests, mirroring DuckDB's own `test/api/test_get_table_names.cpp` where the behavior is user-visible: joins, qualified names, dedup, CTE exclusion, view expansion to base tables, table functions, nonexistent tables, empty result, invalid SQL, and closed connection. TPCH/window/set-op cases skipped — they exercise DuckDB's binder, not this binding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `Connection#table_names(sql, qualified: false)` to list referenced table names from a SQL string without executing it.
  * Supports options for qualified output, including aliases; extracts from joins and view definitions; deduplicates repeated mentions; returns empty results for queries without tables.
* **Bug Fixes**
  * Raises `DuckDB::Error` for invalid SQL and when called on a disconnected connection.
* **Documentation**
  * Updated the Unreleased changelog with the new API details.
* **Tests**
  * Added comprehensive coverage for CTE handling, qualified formatting, views, table functions, and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->