### PR TITLE
Support TIME_NS in ScalarFunction/AggregateFunction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 # Unreleased
+- support TIME_NS columns in `DuckDB::ScalarFunction` and `DuckDB::AggregateFunction`: TIME_NS can now be used as parameter and return type (with `DuckDB::LogicalType::TIME_NS`). Requires DuckDB >= 1.5.0 for full TIME_NS support in the C API.
 - bump Ruby to 3.4.10 on CI.
 - add `DuckDB::Connection#table_names(sql, qualified: false)` returning the table names referenced by a SQL query without executing it (binds `duckdb_get_table_names`). With `qualified: true`, names are returned as written in the query (including schema/catalog prefixes and aliases). Result order is unspecified.
 - add `DuckDB::Value.create_list(child_type, values)` and `DuckDB::Value.create_array(child_type, values)` to create LIST/ARRAY values from an element type (a Symbol like `:integer` or a `DuckDB::LogicalType`) and an Array of `DuckDB::Value` elements. The created values can be bound to prepared statements with `#bind_value`.

--- a/ext/duckdb/function_vector.c
+++ b/ext/duckdb/function_vector.c
@@ -137,6 +137,20 @@ void rbduckdb_vector_set_value_at(duckdb_vector vector, duckdb_logical_type elem
             ((duckdb_time *)vector_data)[index] = time;
             break;
         }
+        case DUCKDB_TYPE_TIME_NS: {
+            if (!rb_obj_is_kind_of(value, rb_cTime)) {
+                rb_raise(rb_eTypeError, "Expected Time object for TIME_NS");
+            }
+
+            VALUE hour = rb_funcall(value, rb_intern("hour"), 0);
+            VALUE min = rb_funcall(value, rb_intern("min"), 0);
+            VALUE sec = rb_funcall(value, rb_intern("sec"), 0);
+            VALUE nsec = rb_funcall(value, rb_intern("nsec"), 0);
+
+            duckdb_time_ns time_ns = rbduckdb_to_duckdb_time_ns_from_value(hour, min, sec, nsec);
+            ((duckdb_time_ns *)vector_data)[index] = time_ns;
+            break;
+        }
         case DUCKDB_TYPE_TIME_TZ: {
             if (!rb_obj_is_kind_of(value, rb_cTime)) {
                 rb_raise(rb_eTypeError, "Expected Time object for TIME_TZ");

--- a/ext/duckdb/util.c
+++ b/ext/duckdb/util.c
@@ -21,6 +21,14 @@ duckdb_time rbduckdb_to_duckdb_time_from_value(VALUE hour, VALUE min, VALUE sec,
     return duckdb_to_time(time_st);
 }
 
+duckdb_time_ns rbduckdb_to_duckdb_time_ns_from_value(VALUE hour, VALUE min, VALUE sec, VALUE nanos) {
+    duckdb_time_ns time_ns;
+
+    time_ns.nanos = ((NUM2LL(hour) * 60 + NUM2LL(min)) * 60 + NUM2LL(sec)) * 1000000000LL + NUM2LL(nanos);
+
+    return time_ns;
+}
+
 duckdb_timestamp rbduckdb_to_duckdb_timestamp_from_time_value(VALUE time_obj) {
     if (!rb_obj_is_kind_of(time_obj, rb_cTime)) {
         rb_raise(rb_eTypeError, "Expected Time object");

--- a/ext/duckdb/util.h
+++ b/ext/duckdb/util.h
@@ -3,6 +3,7 @@
 
 duckdb_date rbduckdb_to_duckdb_date_from_value(VALUE year, VALUE month, VALUE day);
 duckdb_time rbduckdb_to_duckdb_time_from_value(VALUE hour, VALUE min, VALUE sec, VALUE micros);
+duckdb_time_ns rbduckdb_to_duckdb_time_ns_from_value(VALUE hour, VALUE min, VALUE sec, VALUE nanos);
 duckdb_timestamp rbduckdb_to_duckdb_timestamp_from_time_value(VALUE time_obj);
 duckdb_timestamp rbduckdb_to_duckdb_timestamp_from_value(VALUE year, VALUE month, VALUE day, VALUE hour, VALUE min, VALUE sec, VALUE micros);
 void rbduckdb_to_duckdb_interval_from_value(duckdb_interval* interval, VALUE months, VALUE days, VALUE micros);

--- a/ext/duckdb/value.c
+++ b/ext/duckdb/value.c
@@ -181,9 +181,8 @@ static VALUE value_s__create_time(VALUE klass, VALUE hour, VALUE min, VALUE sec,
 
 /* :nodoc: */
 static VALUE value_s__create_time_ns(VALUE klass, VALUE hour, VALUE min, VALUE sec, VALUE nanos) {
-    duckdb_time_ns time_ns;
+    duckdb_time_ns time_ns = rbduckdb_to_duckdb_time_ns_from_value(hour, min, sec, nanos);
 
-    time_ns.nanos = ((NUM2LL(hour) * 60 + NUM2LL(min)) * 60 + NUM2LL(sec)) * 1000000000LL + NUM2LL(nanos);
     return rbduckdb_value_new(duckdb_create_time_ns(time_ns));
 }
 

--- a/lib/duckdb/converter/int_to_sym.rb
+++ b/lib/duckdb/converter/int_to_sym.rb
@@ -73,7 +73,8 @@ module DuckDB
         35 => :bignum,
         36 => :sqlnull,
         37 => :string_literal,
-        38 => :integer_literal
+        38 => :integer_literal,
+        39 => :time_ns
       }.freeze
 
       ERROR_TYPES = %i[

--- a/lib/duckdb/function_type_validation.rb
+++ b/lib/duckdb/function_type_validation.rb
@@ -23,6 +23,7 @@ module DuckDB
       timestamp_s
       timestamp_ms
       timestamp_ns
+      time_ns
       time_tz
       timestamp_tz
       tinyint

--- a/lib/duckdb/logical_type.rb
+++ b/lib/duckdb/logical_type.rb
@@ -7,7 +7,7 @@ module DuckDB
 
     @logical_types = {}
 
-    {
+    types = {
       boolean: 1,
       tinyint: 2,
       smallint: 3,
@@ -46,9 +46,12 @@ module DuckDB
       bignum: 35,
       sqlnull: 36,
       string_literal: 37,
-      integer_literal: 38,
-      time_ns: 39
-    }.each do |method_name, type_id|
+      integer_literal: 38
+    }
+    # duckdb_create_logical_type rejects TIME_NS on DuckDB < 1.5.0.
+    types[:time_ns] = 39 if Gem::Version.new(DuckDB::LIBRARY_VERSION) >= Gem::Version.new('1.5.0')
+
+    types.each do |method_name, type_id|
       define_singleton_method(method_name) do
         @logical_types[type_id] ||= DuckDB::LogicalType.new(type_id)
       end

--- a/lib/duckdb/logical_type.rb
+++ b/lib/duckdb/logical_type.rb
@@ -46,8 +46,8 @@ module DuckDB
       bignum: 35,
       sqlnull: 36,
       string_literal: 37,
-      integer_literal: 38
-      # time_ns: 39
+      integer_literal: 38,
+      time_ns: 39
     }.each do |method_name, type_id|
       define_singleton_method(method_name) do
         @logical_types[type_id] ||= DuckDB::LogicalType.new(type_id)

--- a/lib/duckdb/scalar_function.rb
+++ b/lib/duckdb/scalar_function.rb
@@ -96,8 +96,8 @@ module DuckDB
 
     # Adds a parameter to the scalar function.
     # Currently supports BIGINT, BLOB, BOOLEAN, DATE, DECIMAL, DOUBLE, FLOAT, HUGEINT, INTEGER, INTERVAL, SMALLINT,
-    # TIME, TIMESTAMP, TIMESTAMP_S, TIMESTAMP_MS, TIMESTAMP_NS, TIME_TZ, TIMESTAMP_TZ, TINYINT, UBIGINT, UHUGEINT,
-    # UINTEGER, USMALLINT, UTINYINT, UUID, and VARCHAR types.
+    # TIME, TIMESTAMP, TIMESTAMP_S, TIMESTAMP_MS, TIMESTAMP_NS, TIME_NS, TIME_TZ, TIMESTAMP_TZ, TINYINT, UBIGINT,
+    # UHUGEINT, UINTEGER, USMALLINT, UTINYINT, UUID, and VARCHAR types.
     # For DECIMAL, pass a DuckDB::LogicalType instance created with DuckDB::LogicalType.create_decimal(width, scale).
     #
     # @param logical_type [DuckDB::LogicalType | :logical_type_symbol] the parameter type
@@ -111,8 +111,8 @@ module DuckDB
 
     # Sets the return type for the scalar function.
     # Currently supports BIGINT, BLOB, BOOLEAN, DATE, DECIMAL, DOUBLE, FLOAT, HUGEINT, INTEGER, INTERVAL, SMALLINT,
-    # TIME, TIMESTAMP, TIMESTAMP_S, TIMESTAMP_MS, TIMESTAMP_NS, TIME_TZ, TIMESTAMP_TZ, TINYINT, UBIGINT, UHUGEINT,
-    # UINTEGER, USMALLINT, UTINYINT, UUID, and VARCHAR types.
+    # TIME, TIMESTAMP, TIMESTAMP_S, TIMESTAMP_MS, TIMESTAMP_NS, TIME_NS, TIME_TZ, TIMESTAMP_TZ, TINYINT, UBIGINT,
+    # UHUGEINT, UINTEGER, USMALLINT, UTINYINT, UUID, and VARCHAR types.
     # For DECIMAL, pass a DuckDB::LogicalType instance created with DuckDB::LogicalType.create_decimal(width, scale).
     #
     # @param logical_type [DuckDB::LogicalType | :logical_type_symbol] the return type
@@ -144,8 +144,8 @@ module DuckDB
     # (e.g. a separator followed by a variable list of values).
     # The block receives fixed parameters positionally, then varargs as a splat (|fixed, *rest|).
     # Currently supports BIGINT, BLOB, BOOLEAN, DATE, DECIMAL, DOUBLE, FLOAT, HUGEINT, INTEGER, INTERVAL, SMALLINT,
-    # TIME, TIMESTAMP, TIMESTAMP_S, TIMESTAMP_MS, TIMESTAMP_NS, TIME_TZ, TIMESTAMP_TZ, TINYINT, UBIGINT, UHUGEINT,
-    # UINTEGER, USMALLINT, UTINYINT, UUID, and VARCHAR types.
+    # TIME, TIMESTAMP, TIMESTAMP_S, TIMESTAMP_MS, TIMESTAMP_NS, TIME_NS, TIME_TZ, TIMESTAMP_TZ, TINYINT, UBIGINT,
+    # UHUGEINT, UINTEGER, USMALLINT, UTINYINT, UUID, and VARCHAR types.
     # For DECIMAL, pass a DuckDB::LogicalType instance created with DuckDB::LogicalType.create_decimal(width, scale).
     #
     # @param logical_type [DuckDB::LogicalType | :logical_type_symbol] the varargs element type

--- a/test/duckdb_test/aggregate_function_test.rb
+++ b/test/duckdb_test/aggregate_function_test.rb
@@ -29,6 +29,27 @@ module DuckDBTest
       assert_equal 4950, result.first.first
     end
 
+    def test_time_ns_parameter_and_return_type
+      # The C API supports TIME_NS fully on DuckDB >= 1.5.0.
+      skip 'TIME_NS requires DuckDB >= 1.5.0' if ::DuckDBTest.duckdb_library_version < Gem::Version.new('1.5.0')
+
+      af = DuckDB::AggregateFunction.create(
+        name: 'my_max_time_ns',
+        return_type: :time_ns,
+        params: [:time_ns],
+        init: -> {},
+        update: ->(state, value) { state && state > value ? state : value },
+        combine: ->(state, other_state) { [state, other_state].compact.max }
+      )
+      @con.register_aggregate_function(af)
+      @con.execute('CREATE TABLE test_table (t TIME_NS)')
+      @con.execute("INSERT INTO test_table VALUES ('10:30:00.123456789'), ('23:59:59.999999999')")
+
+      result = @con.query('SELECT my_max_time_ns(t) FROM test_table').first.first
+
+      assert_equal [23, 59, 59, 999_999_999], [result.hour, result.min, result.sec, result.nsec]
+    end
+
     def test_default_finalize_returns_state_as_is
       register_aggregate('my_agg_default_finalize',
                          init: -> { 42 })

--- a/test/duckdb_test/scalar_function_test.rb
+++ b/test/duckdb_test/scalar_function_test.rb
@@ -307,6 +307,30 @@ module DuckDBTest
       assert_equal 59, rows[1][0].min
     end
 
+    def test_scalar_function_time_ns_return_type
+      # The C API supports TIME_NS fully on DuckDB >= 1.5.0.
+      skip 'TIME_NS requires DuckDB >= 1.5.0' if ::DuckDBTest.duckdb_library_version < Gem::Version.new('1.5.0')
+
+      @con.execute('CREATE TABLE test_table (t TIME_NS)')
+      @con.execute("INSERT INTO test_table VALUES ('10:30:00.123456789'), ('23:59:59.999999999')")
+
+      sf = DuckDB::ScalarFunction.new
+      sf.name = 'add_one_hour_ns'
+      sf.add_parameter(DuckDB::LogicalType::TIME_NS)
+      sf.return_type = DuckDB::LogicalType::TIME_NS
+      sf.set_function { |time| time + 3600 } # Add 1 hour (3600 seconds)
+
+      @con.register_scalar_function(sf)
+      result = @con.execute('SELECT add_one_hour_ns(t) FROM test_table ORDER BY t')
+      rows = result.to_a
+
+      assert_equal 2, rows.size
+      assert_equal [11, 30, 0, 123_456_789],
+                   [rows[0][0].hour, rows[0][0].min, rows[0][0].sec, rows[0][0].nsec]
+      assert_equal [0, 59, 59, 999_999_999],
+                   [rows[1][0].hour, rows[1][0].min, rows[1][0].sec, rows[1][0].nsec]
+    end
+
     def test_scalar_function_smallint_return_type # rubocop:disable Minitest/MultipleAssertions
       @con.execute('CREATE TABLE test_table (value SMALLINT)')
       @con.execute('INSERT INTO test_table VALUES (32767), (-32768), (1000)')


### PR DESCRIPTION
Closes #1265

TIME_NS can now be used as a parameter and return type for scalar and aggregate functions (requires DuckDB >= 1.5.0 for full TIME_NS support in the C API; tests skip on older versions).

- Add `DUCKDB_TYPE_TIME_NS` write case to `rbduckdb_vector_set_value_at` (shared by scalar and aggregate function output)
- Extract `rbduckdb_to_duckdb_time_ns_from_value` helper, reused by `Value.create_time_ns`
- Enable `DuckDB::LogicalType::TIME_NS` (type id 39) with `int_to_sym` mapping and function type allowlist entry
- Tests: scalar function TIME_NS in/out (nanosecond precision, midnight wrap) and aggregate function TIME_NS max

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for `TIME_NS` logical types in scalar and aggregate functions.
  - Exposed `DuckDB::LogicalType::TIME_NS` (enabled when the underlying DuckDB version is 1.5.0+).
  - `TIME_NS` values can now be created from Ruby time components, converted into vectors, and returned from queries.
- **Documentation**
  - Refreshed `DuckDB::ScalarFunction` documentation formatting for supported time-related types.
- **Tests**
  - Added test coverage for `TIME_NS` scalar function return types and aggregate function parameter/return types (skipping when DuckDB < 1.5.0).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->