### PR TITLE
Bump ruby 4.0.5 -> 4.0.6 and 3.3.11 -> 3.3.12 in CI

### DIFF
--- a/.github/workflows/test_on_macos.yml
+++ b/.github/workflows/test_on_macos.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['3.3.11', '3.4.10', '4.0.5', 'head']
+        ruby: ['3.3.12', '3.4.10', '4.0.6', 'head']
         duckdb: ['1.4.5', '1.5.4']
     env:
       # Released Bundler is broken on ruby-head due to ruby/ruby#16895.

--- a/.github/workflows/test_on_ubuntu.yml
+++ b/.github/workflows/test_on_ubuntu.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['3.3.11', '3.4.10', '4.0.5', 'head']
+        ruby: ['3.3.12', '3.4.10', '4.0.6', 'head']
         duckdb: ['1.4.5', '1.5.4']
     env:
       # Released Bundler is broken on ruby-head due to ruby/ruby#16895.

--- a/.github/workflows/test_on_windows.yml
+++ b/.github/workflows/test_on_windows.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['3.3.10', '3.4.10', '4.0.5', 'ucrt', 'mingw', 'mswin', 'head']
+        ruby: ['3.3.10', '3.4.10', '4.0.6', 'ucrt', 'mingw', 'mswin', 'head']
         duckdb: ['1.4.5', '1.5.4']
     env:
       # Released Bundler is broken on ruby-head due to ruby/ruby#16895.


### PR DESCRIPTION
## Summary
- Bump ruby 4.0.5 -> 4.0.6 in CI (ubuntu, macos, windows)
- Bump ruby 3.3.11 -> 3.3.12 in CI (ubuntu, macos); windows stays on 3.3.10

## Test plan
- [ ] CI passes on ubuntu/macos/windows matrices

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated automated test coverage to use newer Ruby patch releases across macOS, Ubuntu, and Windows environments.
  * Existing Ruby versions and test configurations remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->