### PR TITLE
Bump DuckDB on CI to 1.5.5

### DIFF
--- a/.github/workflows/test_on_macos.yml
+++ b/.github/workflows/test_on_macos.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby: ['3.3.12', '3.4.10', '4.0.6', 'head']
-        duckdb: ['1.4.5', '1.5.4']
+        duckdb: ['1.4.5', '1.5.5']
     env:
       # Released Bundler is broken on ruby-head due to ruby/ruby#16895.
       # Use Ruby's bundled Bundler until rubygems/rubygems#9529 is released.
@@ -54,7 +54,7 @@ jobs:
       run: |
         curl -OL https://github.com/duckdb/duckdb/releases/download/v${DUCKDB_VERSION}/libduckdb-osx-universal.zip
         case "${DUCKDB_VERSION}" in
-          "1.5.4") EXPECTED_SHA256="3f3c52970ad1407ec5037062e1a5e575b24bd5b993c889f89fe5876eff47782c" ;;
+          "1.5.5") EXPECTED_SHA256="7b5b8915cc382d0708636fe6385c0cdad5a61c9ff8ba2638b3e2141640783155" ;;
           "1.4.5") EXPECTED_SHA256="33f840404e3b420600936d5b59d342680aa4af41cc06d9a5589711e43cd75766" ;;
           *) echo "No known SHA256 for DuckDB v${DUCKDB_VERSION}"; exit 1 ;;
         esac

--- a/.github/workflows/test_on_ubuntu.yml
+++ b/.github/workflows/test_on_ubuntu.yml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby: ['3.3.12', '3.4.10', '4.0.6', 'head']
-        duckdb: ['1.4.5', '1.5.4']
+        duckdb: ['1.4.5', '1.5.5']
     env:
       # Released Bundler is broken on ruby-head due to ruby/ruby#16895.
       # Use Ruby's bundled Bundler until rubygems/rubygems#9529 is released.
@@ -67,7 +67,7 @@ jobs:
       run: |
         curl -OL https://github.com/duckdb/duckdb/releases/download/v${DUCKDB_VERSION}/libduckdb-linux-amd64.zip
         case "${DUCKDB_VERSION}" in
-          "1.5.4") EXPECTED_SHA256="838d98a85e697bab9935010c88a8c67d3312ccedcab4cb4a0ba01da65113bb70" ;;
+          "1.5.5") EXPECTED_SHA256="1fb8ce388157d84a25abe685a8a2520bf00c00321821968e4bb398fd766e7abb" ;;
           "1.4.5") EXPECTED_SHA256="291efb2e127492ec5b652fb728a29587837763dac1d96bf211dc6429f10149b5" ;;
           *) echo "No known SHA256 for DuckDB v${DUCKDB_VERSION}"; exit 1 ;;
         esac

--- a/.github/workflows/test_on_windows.yml
+++ b/.github/workflows/test_on_windows.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby: ['3.3.10', '3.4.10', '4.0.6', 'ucrt', 'mingw', 'mswin', 'head']
-        duckdb: ['1.4.5', '1.5.4']
+        duckdb: ['1.4.5', '1.5.5']
     env:
       # Released Bundler is broken on ruby-head due to ruby/ruby#16895.
       # Use Ruby's bundled Bundler until rubygems/rubygems#9529 is released.
@@ -54,7 +54,7 @@ jobs:
       run: |
         curl -OL https://github.com/duckdb/duckdb/releases/download/v${env:DUCKDB_VERSION}/libduckdb-windows-amd64.zip
         switch ($env:DUCKDB_VERSION) {
-          "1.5.4" { $EXPECTED_SHA256 = "74e73afd3b010c6f310e14a961fff679f876952bc196f82584b0e2e76d11a91f" }
+          "1.5.5" { $EXPECTED_SHA256 = "8375eb1fcf2212e8a0817950354815d4dde9dd383c2d9fa7b8975b71e278c1bd" }
           "1.4.5" { $EXPECTED_SHA256 = "f2079105369a2698f7d9663e5908a16919e7b03f4ff681ceb716b270a5903a11" }
           default { Write-Error "No known SHA256 for DuckDB v$env:DUCKDB_VERSION"; exit 1 }
         }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 # Unreleased
+- bump up DuckDB 1.5.5 on CI.
 - support TIME_NS columns in `DuckDB::ScalarFunction` and `DuckDB::AggregateFunction`: TIME_NS can now be used as parameter and return type (with `DuckDB::LogicalType::TIME_NS`). Requires DuckDB >= 1.5.0 for full TIME_NS support in the C API.
 - bump Ruby to 3.4.10 on CI.
 - add `DuckDB::Connection#table_names(sql, qualified: false)` returning the table names referenced by a SQL query without executing it (binds `duckdb_get_table_names`). With `qualified: true`, names are returned as written in the query (including schema/catalog prefixes and aliases). Result order is unspecified.


### PR DESCRIPTION
## Summary
- Bump DuckDB version on CI from 1.5.4 to 1.5.5.
- Update the Ubuntu, macOS, and Windows test matrices.
- Update the expected SHA256 checksums (Ubuntu, macOS, and Windows) from the GitHub release digests.
- Add a CHANGELOG entry under Unreleased.

## Release reference
- https://github.com/duckdb/duckdb/releases/tag/v1.5.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated CI testing across macOS, Ubuntu, and Windows to use DuckDB 1.5.5.
  - Updated download verification checks for the new DuckDB release.

- **Documentation**
  - Added the DuckDB 1.5.5 CI update to the unreleased changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->