### PR TITLE
Support statement types added in DuckDB 1.5.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@ All notable changes to this project will be documented in this file.
 # Unreleased
 - add `DuckDB::TableFunction::BindInfo#set_bind_data` to store an arbitrary Ruby object as a custom table function's bind data.
 - add `DuckDB::TableFunction::FunctionInfo#get_bind_data` to retrieve, during execution, the object stored by `BindInfo#set_bind_data`.
-
 - support the statement types added in DuckDB 1.5.5: `#statement_type` now returns `:copy_database`, `:update_extensions` and `:merge_into` instead of raising `DuckDB::Error: Unknown statement type`.
 
 # 1.5.5.0 - 2026-07-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 - add `DuckDB::TableFunction::BindInfo#set_bind_data` to store an arbitrary Ruby object as a custom table function's bind data.
 - add `DuckDB::TableFunction::FunctionInfo#get_bind_data` to retrieve, during execution, the object stored by `BindInfo#set_bind_data`.
 
+- support the statement types added in DuckDB 1.5.5: `#statement_type` now returns `:copy_database`, `:update_extensions` and `:merge_into` instead of raising `DuckDB::Error: Unknown statement type`.
+
 # 1.5.5.0 - 2026-07-27
 
 - bump up DuckDB 1.5.5 on CI.

--- a/lib/duckdb/converter/int_to_sym.rb
+++ b/lib/duckdb/converter/int_to_sym.rb
@@ -32,6 +32,9 @@ module DuckDB
         attach
         detach
         multi
+        copy_database
+        update_extensions
+        merge_into
       ].freeze
 
       HASH_TYPES = {

--- a/test/duckdb_test/prepared_statement_test.rb
+++ b/test/duckdb_test/prepared_statement_test.rb
@@ -141,6 +141,18 @@ module DuckDBTest
       assert_equal(:select, stmt.statement_type)
     end
 
+    def test_statement_type_merge_into
+      skip 'MERGE INTO requires DuckDB >= 1.5.0' if ::DuckDBTest.duckdb_library_version < Gem::Version.new('1.5.0')
+
+      @con.query('CREATE TABLE src (id INTEGER, col_integer INTEGER)')
+      stmt = DuckDB::PreparedStatement.new(
+        @con,
+        'MERGE INTO a USING src ON a.id = src.id WHEN MATCHED THEN UPDATE SET col_integer = src.col_integer'
+      )
+
+      assert_equal(:merge_into, stmt.statement_type)
+    end
+
     def test_param_type
       stmt = DuckDB::PreparedStatement.new(@con, 'SELECT * FROM a WHERE id = $1')
 

--- a/test/duckdb_test/prepared_statement_test.rb
+++ b/test/duckdb_test/prepared_statement_test.rb
@@ -142,7 +142,7 @@ module DuckDBTest
     end
 
     def test_statement_type_merge_into
-      skip 'MERGE INTO requires DuckDB >= 1.5.0' if ::DuckDBTest.duckdb_library_version < Gem::Version.new('1.5.0')
+      skip 'DUCKDB_STATEMENT_TYPE_MERGE_INTO requires DuckDB >= 1.5.5' if duckdb_before_1_5_5?
 
       @con.query('CREATE TABLE src (id INTEGER, col_integer INTEGER)')
       stmt = DuckDB::PreparedStatement.new(
@@ -151,6 +151,30 @@ module DuckDBTest
       )
 
       assert_equal(:merge_into, stmt.statement_type)
+    end
+
+    def test_statement_type_update_extensions
+      skip 'DUCKDB_STATEMENT_TYPE_UPDATE_EXTENSIONS requires DuckDB >= 1.5.5' if duckdb_before_1_5_5?
+
+      stmt = DuckDB::PreparedStatement.new(@con, 'UPDATE EXTENSIONS')
+
+      assert_equal(:update_extensions, stmt.statement_type)
+    end
+
+    def test_statement_type_copy_database
+      skip 'DUCKDB_STATEMENT_TYPE_COPY_DATABASE requires DuckDB >= 1.5.5' if duckdb_before_1_5_5?
+
+      @con.query("ATTACH ':memory:' AS db1")
+      @con.query("ATTACH ':memory:' AS db2")
+      # COPY FROM DATABASE expands into several statements, so it can only be prepared via ExtractedStatements.
+      stmts = DuckDB::ExtractedStatements.new(@con, 'COPY FROM DATABASE db1 TO db2')
+      types = (0...stmts.size).map { |i| stmts.prepared_statement(@con, i).statement_type }
+
+      assert_includes(types, :copy_database)
+    end
+
+    def duckdb_before_1_5_5?
+      ::DuckDBTest.duckdb_library_version < Gem::Version.new('1.5.5')
     end
 
     def test_param_type


### PR DESCRIPTION
## Summary

`duckdb.h` v1.5.5 adds three `duckdb_statement_type` values — the only change in the header between v1.5.4 and v1.5.5:

- `DUCKDB_STATEMENT_TYPE_COPY_DATABASE = 28`
- `DUCKDB_STATEMENT_TYPE_UPDATE_EXTENSIONS = 29`
- `DUCKDB_STATEMENT_TYPE_MERGE_INTO = 30`

Without them, `#statement_type` raises `DuckDB::Error: Unknown statement type: 30` for a `MERGE INTO` statement.

No new functions or signature changes in the header, so nothing else to bind.

## Compatibility

Appending to `STATEMENT_TYPES` is safe on DuckDB 1.4.5 (LTS): those integers are never returned there, and `statement_type_to_sym` only guards the upper bound. The new test skips on DuckDB < 1.5.0.

## Test plan

- `bundle exec rake test` against DuckDB 1.5.5: 1360 runs, 2621 assertions, 0 failures, 0 errors
- New `test_statement_type_merge_into` asserts `:merge_into`
- `bundle exec rubocop` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for recognizing DuckDB 1.5.5 statement types: `COPY DATABASE`, `UPDATE EXTENSIONS`, and `MERGE INTO`.
  * These statements now return their corresponding statement type instead of raising an error.

* **Tests**
  * Added prepared-statement coverage for all three supported statement types, including version-specific validation.

* **Documentation**
  * Updated the unreleased changelog with the new statement-type support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->