### PR TITLE
Add DuckDB::TableFunction::InitInfo#bind_data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 # Unreleased
 - add `DuckDB::TableFunction::BindInfo#set_bind_data` to store an arbitrary Ruby object as a custom table function's bind data.
 - add `DuckDB::TableFunction::FunctionInfo#get_bind_data` to retrieve, during execution, the object stored by `BindInfo#set_bind_data`.
+- add `DuckDB::TableFunction::InitInfo#bind_data` (and `#get_bind_data`) to retrieve, during the init phase, the object stored by `BindInfo#set_bind_data`.
 
 # 1.5.5.0 - 2026-07-27
 

--- a/ext/duckdb/table_function_init_info.c
+++ b/ext/duckdb/table_function_init_info.c
@@ -9,6 +9,7 @@ static VALUE table_function_init_info_set_error(VALUE self, VALUE error);
 static VALUE table_function_init_info_set_max_threads(VALUE self, VALUE max_threads);
 static VALUE table_function_init_info_column_count(VALUE self);
 static VALUE table_function_init_info_column_index(VALUE self, VALUE index);
+static VALUE table_function_init_info_get_bind_data(VALUE self);
 
 static const rb_data_type_t init_info_data_type = {
     "DuckDB/TableFunctionInitInfo",
@@ -115,6 +116,24 @@ static VALUE table_function_init_info_column_index(VALUE self, VALUE index) {
     return ULL2NUM(duckdb_init_get_column_index(ctx->info, NUM2ULL(index)));
 }
 
+/*
+ * call-seq:
+ *   init_info.get_bind_data -> object or nil
+ *   init_info.bind_data -> object or nil
+ *
+ * Returns the object stored during the bind phase with
+ * DuckDB::TableFunction::BindInfo#set_bind_data, or nil if none was set.
+ *
+ *   data = init_info.bind_data
+ */
+static VALUE table_function_init_info_get_bind_data(VALUE self) {
+    rubyDuckDBInitInfo *ctx;
+
+    TypedData_Get_Struct(self, rubyDuckDBInitInfo, &init_info_data_type, ctx);
+
+    return rbduckdb_function_data_lookup(duckdb_init_get_bind_data(ctx->info));
+}
+
 void rbduckdb_init_table_function_init_info(void) {
 #if 0
     VALUE mDuckDB = rb_define_module("DuckDB");
@@ -127,4 +146,6 @@ void rbduckdb_init_table_function_init_info(void) {
     rb_define_method(cDuckDBTableFunctionInitInfo, "max_threads=", table_function_init_info_set_max_threads, 1);
     rb_define_method(cDuckDBTableFunctionInitInfo, "column_count", table_function_init_info_column_count, 0);
     rb_define_method(cDuckDBTableFunctionInitInfo, "column_index", table_function_init_info_column_index, 1);
+    rb_define_method(cDuckDBTableFunctionInitInfo, "get_bind_data", table_function_init_info_get_bind_data, 0);
+    rb_define_method(cDuckDBTableFunctionInitInfo, "bind_data", table_function_init_info_get_bind_data, 0);
 }

--- a/test/duckdb_test/table_function/init_info_test.rb
+++ b/test/duckdb_test/table_function/init_info_test.rb
@@ -140,6 +140,55 @@ module DuckDBTest
       assert_equal [0, 1], observed_column_indexes
     end
 
+    def test_init_info_bind_data_round_trip
+      skip 'GC.compact hangs on Windows in parallel test execution' if Gem.win_platform?
+
+      table_function = DuckDB::TableFunction.new
+      table_function.name = 'test_init_bind_data'
+
+      table_function.bind do |bind_info|
+        bind_info.add_result_column('value', DuckDB::LogicalType::BIGINT)
+        bind_info.set_bind_data({ token: 'init-round-trip', n: 7 })
+      end
+
+      observed_bind_data = nil
+      observed_via_alias = nil
+      table_function.init do |init_info|
+        GC.compact
+        observed_bind_data = init_info.get_bind_data
+        observed_via_alias = init_info.bind_data
+      end
+
+      table_function.execute { |_func_info, output| output.size = 0 }
+
+      @connection.register_table_function(table_function)
+      @connection.query('SELECT * FROM test_init_bind_data()').each.to_a
+
+      assert_equal({ token: 'init-round-trip', n: 7 }, observed_bind_data)
+      assert_same observed_bind_data, observed_via_alias
+    end
+
+    def test_init_info_bind_data_nil_when_unset
+      table_function = DuckDB::TableFunction.new
+      table_function.name = 'test_init_bind_data_unset'
+
+      table_function.bind do |bind_info|
+        bind_info.add_result_column('value', DuckDB::LogicalType::BIGINT)
+      end
+
+      observed_bind_data = :unset
+      table_function.init do |init_info|
+        observed_bind_data = init_info.get_bind_data
+      end
+
+      table_function.execute { |_func_info, output| output.size = 0 }
+
+      @connection.register_table_function(table_function)
+      @connection.query('SELECT * FROM test_init_bind_data_unset()').each.to_a
+
+      assert_nil observed_bind_data
+    end
+
     def test_init_info_alias
       assert_same DuckDB::TableFunction::InitInfo, DuckDB::InitInfo
     end


### PR DESCRIPTION
GitHub: GH-1123

Wrap duckdb_init_get_bind_data() so the init callback can read the object the bind callback stashed with BindInfo#set_bind_data. Init runs before execute and is where per-scan state (thread count, projected columns) is decided, so it needs the bind-phase data too. #bind_data is the Ruby-style reader and #get_bind_data mirrors the C API name, following #max_threads= / #set_max_threads. ref: https://duckdb.org/docs/stable/clients/c/api.html#duckdb_init_get_bind_data

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added access to table-function bind data through `TableFunction::InitInfo`.
  * Bind data can be retrieved as the original Ruby object, or returns `nil` when unset.

* **Bug Fixes**
  * Preserved bind-data object identity during garbage collection.

* **Documentation**
  * Added an unreleased changelog entry describing bind-data access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->