### PR TITLE
Rename DuckDB::TableFunction bind data accessors to Ruby style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,9 @@
 All notable changes to this project will be documented in this file.
 
 # Unreleased
-- add `DuckDB::TableFunction::BindInfo#set_bind_data` to store an arbitrary Ruby object as a custom table function's bind data.
-- add `DuckDB::TableFunction::FunctionInfo#get_bind_data` to retrieve, during execution, the object stored by `BindInfo#set_bind_data`.
-- add `DuckDB::TableFunction::InitInfo#bind_data` (and `#get_bind_data`) to retrieve, during the init phase, the object stored by `BindInfo#set_bind_data`.
+- add `DuckDB::TableFunction::BindInfo#bind_data=` to store an arbitrary Ruby object as a custom table function's bind data.
+- add `DuckDB::TableFunction::FunctionInfo#bind_data` to retrieve, during execution, the object stored by `BindInfo#bind_data=`.
+- add `DuckDB::TableFunction::InitInfo#bind_data` to retrieve, during the init phase, the object stored by `BindInfo#bind_data=`.
 - support the statement types added in DuckDB 1.5.5: `#statement_type` now returns `:copy_database`, `:update_extensions` and `:merge_into` instead of raising `DuckDB::Error: Unknown statement type`.
 
 # 1.5.5.0 - 2026-07-27

--- a/ext/duckdb/table_function_bind_info.c
+++ b/ext/duckdb/table_function_bind_info.c
@@ -170,13 +170,13 @@ static VALUE table_function_bind_info_set_cardinality(VALUE self, VALUE cardinal
 
 /*
  * call-seq:
- *   bind_info.set_bind_data(data) -> self
+ *   bind_info.bind_data = data
  *
  * Stores an arbitrary Ruby object as the table function's bind data. The same
  * object can be retrieved during init and execution, and is kept alive until
  * DuckDB frees the bind data.
  *
- *   bind_info.set_bind_data({ rows: 100 })
+ *   bind_info.bind_data = { rows: 100 }
  */
 static VALUE table_function_bind_info_set_bind_data(VALUE self, VALUE data) {
     rubyDuckDBBindInfo *ctx;
@@ -225,7 +225,7 @@ void rbduckdb_init_table_function_bind_info(void) {
     rb_define_method(cDuckDBTableFunctionBindInfo, "get_parameter", table_function_bind_info_get_parameter, 1);
     rb_define_method(cDuckDBTableFunctionBindInfo, "get_named_parameter", table_function_bind_info_get_named_parameter, 1);
     rb_define_method(cDuckDBTableFunctionBindInfo, "set_cardinality", table_function_bind_info_set_cardinality, 2);
-    rb_define_method(cDuckDBTableFunctionBindInfo, "set_bind_data", table_function_bind_info_set_bind_data, 1);
+    rb_define_method(cDuckDBTableFunctionBindInfo, "bind_data=", table_function_bind_info_set_bind_data, 1);
     rb_define_method(cDuckDBTableFunctionBindInfo, "set_error", table_function_bind_info_set_error, 1);
 
     rb_define_private_method(cDuckDBTableFunctionBindInfo, "_add_result_column", table_function_bind_info__add_result_column, 2);

--- a/ext/duckdb/table_function_function_info.c
+++ b/ext/duckdb/table_function_function_info.c
@@ -5,7 +5,7 @@ VALUE cDuckDBTableFunctionFunctionInfo;
 static void deallocate(void *ctx);
 static VALUE allocate(VALUE klass);
 static size_t memsize(const void *p);
-static VALUE table_function_function_info_get_bind_data(VALUE self);
+static VALUE table_function_function_info_bind_data(VALUE self);
 static VALUE table_function_function_info_set_error(VALUE self, VALUE error);
 
 static const rb_data_type_t function_info_data_type = {
@@ -36,14 +36,14 @@ rubyDuckDBFunctionInfo *rbduckdb_get_struct_function_info(VALUE obj) {
 
 /*
  * call-seq:
- *   function_info.get_bind_data -> object or nil
+ *   function_info.bind_data -> object or nil
  *
  * Returns the object stored during the bind phase with
- * DuckDB::TableFunction::BindInfo#set_bind_data, or nil if none was set.
+ * DuckDB::TableFunction::BindInfo#bind_data=, or nil if none was set.
  *
- *   data = function_info.get_bind_data
+ *   data = function_info.bind_data
  */
-static VALUE table_function_function_info_get_bind_data(VALUE self) {
+static VALUE table_function_function_info_bind_data(VALUE self) {
     rubyDuckDBFunctionInfo *ctx;
     void *bind_data;
 
@@ -82,6 +82,6 @@ void rbduckdb_init_table_function_function_info(void) {
     cDuckDBTableFunctionFunctionInfo = rb_define_class_under(cDuckDBTableFunction, "FunctionInfo", rb_cObject);
     rb_define_alloc_func(cDuckDBTableFunctionFunctionInfo, allocate);
 
-    rb_define_method(cDuckDBTableFunctionFunctionInfo, "get_bind_data", table_function_function_info_get_bind_data, 0);
+    rb_define_method(cDuckDBTableFunctionFunctionInfo, "bind_data", table_function_function_info_bind_data, 0);
     rb_define_method(cDuckDBTableFunctionFunctionInfo, "set_error", table_function_function_info_set_error, 1);
 }

--- a/ext/duckdb/table_function_init_info.c
+++ b/ext/duckdb/table_function_init_info.c
@@ -9,7 +9,7 @@ static VALUE table_function_init_info_set_error(VALUE self, VALUE error);
 static VALUE table_function_init_info_set_max_threads(VALUE self, VALUE max_threads);
 static VALUE table_function_init_info_column_count(VALUE self);
 static VALUE table_function_init_info_column_index(VALUE self, VALUE index);
-static VALUE table_function_init_info_get_bind_data(VALUE self);
+static VALUE table_function_init_info_bind_data(VALUE self);
 
 static const rb_data_type_t init_info_data_type = {
     "DuckDB/TableFunctionInitInfo",
@@ -118,15 +118,14 @@ static VALUE table_function_init_info_column_index(VALUE self, VALUE index) {
 
 /*
  * call-seq:
- *   init_info.get_bind_data -> object or nil
  *   init_info.bind_data -> object or nil
  *
  * Returns the object stored during the bind phase with
- * DuckDB::TableFunction::BindInfo#set_bind_data, or nil if none was set.
+ * DuckDB::TableFunction::BindInfo#bind_data=, or nil if none was set.
  *
  *   data = init_info.bind_data
  */
-static VALUE table_function_init_info_get_bind_data(VALUE self) {
+static VALUE table_function_init_info_bind_data(VALUE self) {
     rubyDuckDBInitInfo *ctx;
 
     TypedData_Get_Struct(self, rubyDuckDBInitInfo, &init_info_data_type, ctx);
@@ -146,6 +145,5 @@ void rbduckdb_init_table_function_init_info(void) {
     rb_define_method(cDuckDBTableFunctionInitInfo, "max_threads=", table_function_init_info_set_max_threads, 1);
     rb_define_method(cDuckDBTableFunctionInitInfo, "column_count", table_function_init_info_column_count, 0);
     rb_define_method(cDuckDBTableFunctionInitInfo, "column_index", table_function_init_info_column_index, 1);
-    rb_define_method(cDuckDBTableFunctionInitInfo, "get_bind_data", table_function_init_info_get_bind_data, 0);
-    rb_define_method(cDuckDBTableFunctionInitInfo, "bind_data", table_function_init_info_get_bind_data, 0);
+    rb_define_method(cDuckDBTableFunctionInitInfo, "bind_data", table_function_init_info_bind_data, 0);
 }

--- a/test/duckdb_test/table_function/function_info_test.rb
+++ b/test/duckdb_test/table_function/function_info_test.rb
@@ -49,24 +49,22 @@ module DuckDBTest
       table_function = DuckDB::TableFunction.new
       table_function.name = 'test_bind_data'
 
-      returned_bind_info = nil
       table_function.bind do |bind_info|
         bind_info.add_result_column('value', DuckDB::LogicalType::BIGINT)
-        returned_bind_info = bind_info.set_bind_data({ token: 'round-trip', n: 7 })
+        bind_info.bind_data = { token: 'round-trip', n: 7 }
       end
 
       table_function.init { |_init_info| GC.compact }
 
       observed_bind_data = nil
       table_function.execute do |func_info, output|
-        observed_bind_data = func_info.get_bind_data
+        observed_bind_data = func_info.bind_data
         output.size = 0
       end
 
       @connection.register_table_function(table_function)
       @connection.query('SELECT * FROM test_bind_data()').each.to_a
 
-      assert_instance_of DuckDB::TableFunction::BindInfo, returned_bind_info
       assert_equal({ token: 'round-trip', n: 7 }, observed_bind_data)
     end
 
@@ -78,15 +76,15 @@ module DuckDBTest
 
       table_function.bind do |bind_info|
         bind_info.add_result_column('value', DuckDB::LogicalType::BIGINT)
-        bind_info.set_bind_data({ which: 'first' })
-        bind_info.set_bind_data({ which: 'second' })
+        bind_info.bind_data = { which: 'first' }
+        bind_info.bind_data = { which: 'second' }
       end
 
       table_function.init { |_init_info| GC.compact }
 
       observed_bind_data = nil
       table_function.execute do |func_info, output|
-        observed_bind_data = func_info.get_bind_data
+        observed_bind_data = func_info.bind_data
         output.size = 0
       end
 
@@ -110,7 +108,7 @@ module DuckDBTest
 
       observed_bind_data = :unset
       table_function.execute do |func_info, output|
-        observed_bind_data = func_info.get_bind_data
+        observed_bind_data = func_info.bind_data
         output.size = 0
       end
 

--- a/test/duckdb_test/table_function/init_info_test.rb
+++ b/test/duckdb_test/table_function/init_info_test.rb
@@ -148,15 +148,13 @@ module DuckDBTest
 
       table_function.bind do |bind_info|
         bind_info.add_result_column('value', DuckDB::LogicalType::BIGINT)
-        bind_info.set_bind_data({ token: 'init-round-trip', n: 7 })
+        bind_info.bind_data = { token: 'init-round-trip', n: 7 }
       end
 
       observed_bind_data = nil
-      observed_via_alias = nil
       table_function.init do |init_info|
         GC.compact
-        observed_bind_data = init_info.get_bind_data
-        observed_via_alias = init_info.bind_data
+        observed_bind_data = init_info.bind_data
       end
 
       table_function.execute { |_func_info, output| output.size = 0 }
@@ -165,7 +163,6 @@ module DuckDBTest
       @connection.query('SELECT * FROM test_init_bind_data()').each.to_a
 
       assert_equal({ token: 'init-round-trip', n: 7 }, observed_bind_data)
-      assert_same observed_bind_data, observed_via_alias
     end
 
     def test_init_info_bind_data_nil_when_unset
@@ -178,7 +175,7 @@ module DuckDBTest
 
       observed_bind_data = :unset
       table_function.init do |init_info|
-        observed_bind_data = init_info.get_bind_data
+        observed_bind_data = init_info.bind_data
       end
 
       table_function.execute { |_func_info, output| output.size = 0 }


### PR DESCRIPTION
GitHub: GH-1123

Storing and reading bind data is attribute access, so name it that way:

- `BindInfo#set_bind_data` → `#bind_data=`
- `FunctionInfo#get_bind_data` → `#bind_data`
- `InitInfo#get_bind_data` → `#bind_data`

Rename rather than alias, because all three are unreleased.
Nothing that shipped changes, and the API keeps one name per concept. 
`DataChunk#size=` is the same shape: it wraps `duckdb_data_chunk_set_size` and no `set_size` exists.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **API Updates**
  * Renamed table-function bind-data methods for a more consistent interface:
    * Use `bind_data = value` to set bind data.
    * Use `bind_data` to retrieve bind data.
  * Existing bind-data storage and initialization behavior remain unchanged.
* **Documentation**
  * Updated changelog entries and API references to reflect the new method names.
* **Tests**
  * Updated coverage for setting, retrieving, overwriting, and handling unset bind data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->