### PR TITLE
Fix use-after-free when a registered function outlives its connection

### DIFF
--- a/ext/duckdb/connection.c
+++ b/ext/duckdb/connection.c
@@ -91,7 +91,9 @@ static VALUE connection_disconnect(VALUE self) {
     /*
      * Registered functions are not released here: the catalog entry is still
      * reachable from other connections. They are released with the database.
+     * This connection no longer needs the database, so stop retaining it.
      */
+    ctx->database = Qnil;
 
     return self;
 }

--- a/ext/duckdb/connection.c
+++ b/ext/duckdb/connection.c
@@ -73,11 +73,11 @@ VALUE rbduckdb_create_connection(VALUE oDuckDBDatabase) {
 
     obj = allocate(cDuckDBConnection);
     TypedData_Get_Struct(obj, rubyDuckDBConnection, &connection_data_type, ctxcon);
-    ctxcon->database = oDuckDBDatabase;
 
     if (duckdb_connect(ctxdb->db, &(ctxcon->con)) == DuckDBError) {
         rb_raise(eDuckDBError, "connection error");
     }
+    ctxcon->database = oDuckDBDatabase;
 
     return obj;
 }
@@ -157,11 +157,12 @@ static VALUE connection__connect(VALUE self, VALUE oDuckDBDatabase) {
     }
     ctxdb = rbduckdb_get_struct_database(oDuckDBDatabase);
     TypedData_Get_Struct(self, rubyDuckDBConnection, &connection_data_type, ctx);
-    ctx->database = oDuckDBDatabase;
 
+    /* Set only on success: a failed connect must not re-anchor registrations to the new database. */
     if (duckdb_connect(ctxdb->db, &(ctx->con)) == DuckDBError) {
         rb_raise(eDuckDBError, "connection error");
     }
+    ctx->database = oDuckDBDatabase;
 
     return self;
 }

--- a/ext/duckdb/connection.c
+++ b/ext/duckdb/connection.c
@@ -34,16 +34,24 @@ static void deallocate(void *ctx) {
 
 static void mark(void *ctx) {
     rubyDuckDBConnection *p = (rubyDuckDBConnection *)ctx;
-    rb_gc_mark(p->registered_functions);
+    rb_gc_mark(p->database);
 }
 
 static VALUE allocate(VALUE klass) {
     rubyDuckDBConnection *ctx = xcalloc((size_t)1, sizeof(rubyDuckDBConnection));
-    VALUE obj = TypedData_Wrap_Struct(klass, &connection_data_type, ctx);
-    VALUE registered_functions = rb_ary_new();
-    ctx->registered_functions = registered_functions;
-    RB_GC_GUARD(registered_functions);
-    return obj;
+    ctx->database = Qnil;
+    return TypedData_Wrap_Struct(klass, &connection_data_type, ctx);
+}
+
+/* Anchors obj to this connection's database so it outlives the connection. */
+static void connection_retain_registered(VALUE self, VALUE obj) {
+    rubyDuckDBConnection *ctx;
+
+    TypedData_Get_Struct(self, rubyDuckDBConnection, &connection_data_type, ctx);
+    if (NIL_P(ctx->database)) {
+        rb_raise(eDuckDBError, "connection is not associated with a database");
+    }
+    rbduckdb_database_retain(ctx->database, obj);
 }
 
 static size_t memsize(const void *p) {
@@ -65,6 +73,7 @@ VALUE rbduckdb_create_connection(VALUE oDuckDBDatabase) {
 
     obj = allocate(cDuckDBConnection);
     TypedData_Get_Struct(obj, rubyDuckDBConnection, &connection_data_type, ctxcon);
+    ctxcon->database = oDuckDBDatabase;
 
     if (duckdb_connect(ctxdb->db, &(ctxcon->con)) == DuckDBError) {
         rb_raise(eDuckDBError, "connection error");
@@ -79,8 +88,10 @@ static VALUE connection_disconnect(VALUE self) {
     TypedData_Get_Struct(self, rubyDuckDBConnection, &connection_data_type, ctx);
     duckdb_disconnect(&(ctx->con));
 
-    /* Clear registered functions to release memory */
-    rb_ary_clear(ctx->registered_functions);
+    /*
+     * Registered functions are not released here: the catalog entry is still
+     * reachable from other connections. They are released with the database.
+     */
 
     return self;
 }
@@ -144,6 +155,7 @@ static VALUE connection__connect(VALUE self, VALUE oDuckDBDatabase) {
     }
     ctxdb = rbduckdb_get_struct_database(oDuckDBDatabase);
     TypedData_Get_Struct(self, rubyDuckDBConnection, &connection_data_type, ctx);
+    ctx->database = oDuckDBDatabase;
 
     if (duckdb_connect(ctxdb->db, &(ctx->con)) == DuckDBError) {
         rb_raise(eDuckDBError, "connection error");
@@ -239,8 +251,8 @@ static VALUE connection__register_logical_type(VALUE self, VALUE logical_type) {
         rb_raise(eDuckDBError, "Failed to register logical type");
     }
 
-    /* Keep reference to prevent GC while connection is alive */
-    rb_ary_push(ctxcon->registered_functions, logical_type);
+    /* Keep reference alive as long as the database can call it */
+    connection_retain_registered(self, logical_type);
 
     return self;
 }
@@ -260,8 +272,8 @@ static VALUE connection__register_scalar_function(VALUE self, VALUE scalar_funct
         rb_raise(eDuckDBError, "Failed to register scalar function");
     }
 
-    /* Keep reference to prevent GC while connection is alive */
-    rb_ary_push(ctxcon->registered_functions, scalar_function);
+    /* Keep reference alive as long as the database can call it */
+    connection_retain_registered(self, scalar_function);
 
     return self;
 }
@@ -281,8 +293,8 @@ static VALUE connection__register_scalar_function_set(VALUE self, VALUE scalar_f
         rb_raise(eDuckDBError, "Failed to register scalar function set");
     }
 
-    /* Keep reference to prevent GC while connection is alive */
-    rb_ary_push(ctxcon->registered_functions, scalar_function_set);
+    /* Keep reference alive as long as the database can call it */
+    connection_retain_registered(self, scalar_function_set);
 
     return self;
 }
@@ -302,8 +314,8 @@ static VALUE connection__register_aggregate_function(VALUE self, VALUE aggregate
         rb_raise(eDuckDBError, "Failed to register aggregate function");
     }
 
-    /* Keep reference to prevent GC while connection is alive */
-    rb_ary_push(ctxcon->registered_functions, aggregate_function);
+    /* Keep reference alive as long as the database can call it */
+    connection_retain_registered(self, aggregate_function);
 
     return self;
 }
@@ -323,8 +335,8 @@ static VALUE connection__register_aggregate_function_set(VALUE self, VALUE aggre
         rb_raise(eDuckDBError, "Failed to register aggregate function set");
     }
 
-    /* Keep reference to prevent GC while connection is alive */
-    rb_ary_push(ctxcon->registered_functions, aggregate_function_set);
+    /* Keep reference alive as long as the database can call it */
+    connection_retain_registered(self, aggregate_function_set);
 
     return self;
 }
@@ -343,8 +355,8 @@ static VALUE connection__register_table_function(VALUE self, VALUE table_functio
         rb_raise(eDuckDBError, "Failed to register table function");
     }
 
-    /* Keep reference to prevent GC while connection is alive */
-    rb_ary_push(ctxcon->registered_functions, table_function);
+    /* Keep reference alive as long as the database can call it */
+    connection_retain_registered(self, table_function);
 
     return self;
 }

--- a/ext/duckdb/connection.h
+++ b/ext/duckdb/connection.h
@@ -3,7 +3,8 @@
 
 struct _rubyDuckDBConnection {
     duckdb_connection con;
-    VALUE registered_functions;
+    /* The DuckDB::Database this connection belongs to. Registrations are anchored there. */
+    VALUE database;
 };
 
 typedef struct _rubyDuckDBConnection rubyDuckDBConnection;

--- a/ext/duckdb/database.c
+++ b/ext/duckdb/database.c
@@ -4,6 +4,7 @@ VALUE cDuckDBDatabase;
 
 static void close_database(rubyDuckDB *p);
 static void deallocate(void * ctx);
+static void mark(void *ctx);
 static VALUE allocate(VALUE klass);
 static size_t memsize(const void *p);
 static duckdb_config create_config_with_ruby_api(void);
@@ -13,7 +14,7 @@ static VALUE database_close(VALUE self);
 
 static const rb_data_type_t database_data_type = {
     "DuckDB/Database",
-    {NULL, deallocate, memsize,},
+    {mark, deallocate, memsize,},
     0, 0, RUBY_TYPED_FREE_IMMEDIATELY
 };
 
@@ -28,13 +29,35 @@ static void deallocate(void * ctx) {
     xfree(p);
 }
 
+static void mark(void *ctx) {
+    rubyDuckDB *p = (rubyDuckDB *)ctx;
+
+    rb_gc_mark(p->registered_functions);
+}
+
 static size_t memsize(const void *p) {
     return sizeof(rubyDuckDB);
 }
 
 static VALUE allocate(VALUE klass) {
     rubyDuckDB *ctx = xcalloc((size_t)1, sizeof(rubyDuckDB));
-    return TypedData_Wrap_Struct(klass, &database_data_type, ctx);
+    VALUE obj = TypedData_Wrap_Struct(klass, &database_data_type, ctx);
+    VALUE registered_functions = rb_ary_new();
+    ctx->registered_functions = registered_functions;
+    RB_GC_GUARD(registered_functions);
+    return obj;
+}
+
+/*
+ * Keeps obj alive as long as this database is alive.
+ * DuckDB registers functions in the database-level catalog and has no
+ * unregister API, so releasing them any earlier leaves a dangling extra_info.
+ */
+void rbduckdb_database_retain(VALUE database, VALUE obj) {
+    rubyDuckDB *ctx;
+
+    TypedData_Get_Struct(database, rubyDuckDB, &database_data_type, ctx);
+    rb_ary_push(ctx->registered_functions, obj);
 }
 
 rubyDuckDB *rbduckdb_get_struct_database(VALUE obj) {

--- a/ext/duckdb/database.h
+++ b/ext/duckdb/database.h
@@ -3,12 +3,15 @@
 
 struct _rubyDuckDB {
     duckdb_database db;
+    /* Functions and logical types registered on any connection to this database */
+    VALUE registered_functions;
 };
 
 typedef struct _rubyDuckDB rubyDuckDB;
 
 rubyDuckDB *rbduckdb_get_struct_database(VALUE obj);
 VALUE rbduckdb_create_database_obj(duckdb_database db);
+void rbduckdb_database_retain(VALUE database, VALUE obj);
 void rbduckdb_init_database(void);
 
 #endif

--- a/test/duckdb_test/registered_function_lifetime_test.rb
+++ b/test/duckdb_test/registered_function_lifetime_test.rb
@@ -92,5 +92,22 @@ module DuckDBTest
 
       assert_equal 1, con.query('SELECT 1').first.first
     end
+
+    # Both locals must go out of scope, or the registration stays alive by accident.
+    def register_after_failed_connect(name)
+      con = @db.connect
+      closed = DuckDB::Database.open
+      closed.close
+
+      assert_raises(DuckDB::Error) { con.connect(closed) }
+      register_double(con, name)
+    end
+
+    def test_failed_connect_keeps_the_original_database_association
+      register_after_failed_connect('double_after_failed_connect')
+      3.times { GC.start }
+
+      assert_equal 42, @db.connect.query('SELECT double_after_failed_connect(21)').first.first
+    end
   end
 end

--- a/test/duckdb_test/registered_function_lifetime_test.rb
+++ b/test/duckdb_test/registered_function_lifetime_test.rb
@@ -78,6 +78,13 @@ module DuckDBTest
       assert_equal 10, result.first.first
     end
 
+    def test_register_on_disconnected_connection_raises
+      con = @db.connect
+      con.disconnect
+
+      assert_raises(DuckDB::Error) { register_double(con, 'never_registered') }
+    end
+
     def test_database_outlives_connection
       con = @db.connect
       @db = nil

--- a/test/duckdb_test/registered_function_lifetime_test.rb
+++ b/test/duckdb_test/registered_function_lifetime_test.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module DuckDBTest
+  # DuckDB registers C-API functions in the database-level catalog and has no
+  # unregister API, so a registration must outlive the connection that made it.
+  class RegisteredFunctionLifetimeTest < Minitest::Test
+    def setup
+      @db = DuckDB::Database.open
+    end
+
+    def teardown
+      @db&.close
+    end
+
+    def register_double(con, name)
+      con.register_scalar_function(DuckDB::ScalarFunction.new.tap do |sf|
+        sf.name = name
+        sf.add_parameter(DuckDB::LogicalType::INTEGER)
+        sf.return_type = DuckDB::LogicalType::INTEGER
+        sf.set_function { |v| v * 2 }
+      end)
+    end
+
+    def test_function_survives_disconnect_of_registering_connection
+      con1 = @db.connect
+      con2 = @db.connect
+      register_double(con1, 'double_after_disconnect')
+
+      con1.disconnect
+      3.times { GC.start }
+
+      assert_equal 42, con2.query('SELECT double_after_disconnect(21)').first.first
+    end
+
+    def test_function_survives_collection_of_registering_connection
+      con2 = @db.connect
+      register_double(@db.connect, 'double_after_gc')
+      3.times { GC.start }
+
+      assert_equal 42, con2.query('SELECT double_after_gc(21)').first.first
+    end
+
+    def test_function_survives_compaction_after_disconnect
+      skip 'GC.compact not available' unless GC.respond_to?(:compact)
+      skip 'GC.compact hangs on Windows in parallel test execution' if Gem.win_platform?
+
+      con1 = @db.connect
+      con2 = @db.connect
+      register_double(con1, 'double_after_compact')
+
+      con1.disconnect
+      3.times { GC.compact }
+
+      assert_equal 42, con2.query('SELECT double_after_compact(21)').first.first
+    end
+
+    def test_aggregate_function_survives_disconnect
+      con1 = @db.connect
+      con2 = @db.connect
+      con1.register_aggregate_function(
+        DuckDB::AggregateFunction.create(
+          name: 'sum_after_disconnect',
+          return_type: :bigint,
+          params: [:bigint],
+          init: -> { 0 },
+          update: ->(state, value) { state + value },
+          combine: ->(state, other_state) { state + other_state }
+        )
+      )
+
+      con1.disconnect
+      3.times { GC.start }
+
+      result = con2.query('SELECT sum_after_disconnect(i) FROM range(1, 5) t(i)')
+
+      assert_equal 10, result.first.first
+    end
+
+    def test_database_outlives_connection
+      con = @db.connect
+      @db = nil
+      3.times { GC.start }
+
+      assert_equal 1, con.query('SELECT 1').first.first
+    end
+  end
+end


### PR DESCRIPTION

## What's wrong

DuckDB stores C-API registrations in the **database-level** catalog and offers no way to unregister them, so a registered function outlives the connection that registered it. The gem assumed the opposite: `Connection#disconnect` released the registrations.

```c
/* ext/duckdb/connection.c (before) */
static VALUE connection_disconnect(VALUE self) {
    ...
    /* Clear registered functions to release memory */
    rb_ary_clear(ctx->registered_functions);
```

`registered_functions` was the only thing keeping the Ruby `DuckDB::ScalarFunction` alive. Clearing it lets the object be collected, and `deallocate` then `xfree`s the struct that was handed to DuckDB as `extra_info`:

```c
/* ext/duckdb/scalar_function.c */
duckdb_scalar_function_set_extra_info(p->scalar_function, p, NULL);  /* no destructor */
...
static void deallocate(void *ctx) {
    rubyDuckDBScalarFunction *p = (rubyDuckDBScalarFunction *)ctx;
    duckdb_destroy_scalar_function(&(p->scalar_function));
    xfree(p);
}
```

The catalog entry survives and still points at the freed struct. Calling the function from another connection to the same database reads freed memory and invokes `rb_funcall` on whatever `VALUE` happens to be in the recycled block. Letting the `Connection` itself be collected reaches the same freed struct — `disconnect` is not required.

The same shape existed for table functions (`table_function.c`) and aggregate functions (`aggregate_function.c`), which register their `extra_info` the same way.

## Reproduction

```ruby
db  = DuckDB::Database.open
con1 = db.connect
con2 = db.connect

con1.register_scalar_function(DuckDB::ScalarFunction.new.tap do |sf|
  sf.name = 'double_it'
  sf.add_parameter(DuckDB::LogicalType::INTEGER)
  sf.return_type = DuckDB::LogicalType::INTEGER
  sf.set_function { |v| v * 2 }
end)

con1.disconnect
GC.start

con2.query('SELECT double_it(21)')  # => segfault
```

On the current `main` this crashes:

```
lib/duckdb/connection.rb:39: [BUG] Segmentation fault at 0x0000000000000042
c:0022 p:---- s:0122 e:000121 l:y b:0001 CFUNC  :_query_sql
```

## Behaviour change

`Connection#disconnect` no longer frees registered functions. That was the bug: the memory it released was still reachable from DuckDB. Registrations are now released when the `Database` object is collected, which is the first moment the catalog can no longer resolve them.

Passing a real `duckdb_delete_callback_t` to `duckdb_scalar_function_set_extra_info` instead would double-free, since `deallocate` already `xfree`s the same struct — it would need a reference count on the struct plus a GC root for the procs independent of the Ruby wrapper. Changing the owner gets the lifetimes right without any of that.

## Verification

| Check | Result |
| --- | --- |
| New test against unfixed build | segfault in `_query_sql` |
| New test against fixed build | 5 runs, 0 failures |
| Full suite | 1372 runs, 2636 assertions, 0 failures, 0 errors, 2 skips |
| RuboCop | no offenses |
| valgrind (memcheck) | `InvalidRead` / `InvalidWrite` / `InvalidFree` / `InvalidJump`: **0** |

valgrind was run over the same five scenarios with DuckDB pinned to `threads=1` and `--fair-sched=yes` — DuckDB's default worker pool (one thread per core) does not make progress under valgrind's serialized scheduler. Suppressions from `ruby_memcheck`'s `ruby.supp`. The remaining reports are 10 `UninitCondition` inside libruby and 3540 `Leak_DefinitelyLost` blocks, all allocated by libruby (the Ruby heap is not freed at interpreter exit); none originate in `libduckdb` or `duckdb_native`. The only leak whose stack passes through gem code is the global UDF executor thread created by `rbduckdb_function_executor_ensure_started`, which is intentionally long-lived and predates this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Registered functions and logical types now remain available after their connection is disconnected or garbage-collected.
  * Improved database and connection lifetime handling, including during Ruby garbage collection and compaction.
  * Databases remain usable while an associated connection is still active.
  * Registering functions through disconnected or failed connections now reports a clear error instead of proceeding unexpectedly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->