### PR TITLE
Fix use-after-free of UDF arguments during GC

### DIFF
--- a/ext/duckdb/aggregate_function.c
+++ b/ext/duckdb/aggregate_function.c
@@ -245,20 +245,18 @@ struct update_callback_arg {
     duckdb_aggregate_state *states;
     duckdb_vector *input_vectors;
     duckdb_logical_type *input_types;
-    VALUE *args;
     idx_t row_count;
     idx_t col_count;
 };
 
 struct update_one_arg {
     VALUE update_proc;
-    int argc;
-    VALUE *argv;
+    VALUE args;
 };
 
 static VALUE call_update_proc(VALUE varg) {
     struct update_one_arg *arg = (struct update_one_arg *)varg;
-    return rb_funcallv(arg->update_proc, rb_intern("call"), arg->argc, arg->argv);
+    return rb_apply(arg->update_proc, rb_intern("call"), arg->args);
 }
 
 /*
@@ -278,9 +276,12 @@ static VALUE update_process_rows(VALUE varg) {
     ruby_aggregate_state **states = (ruby_aggregate_state **)arg->states;
     idx_t i, j;
 
+    /* A Ruby Array, not a plain buffer: converting a later column can trigger
+     * a GC, and the earlier columns' objects must stay reachable. */
+    VALUE args = rb_ary_new_capa((long)arg->col_count + 1);
+
     arg->input_vectors = ALLOC_N(duckdb_vector, arg->col_count);
     arg->input_types = ALLOC_N(duckdb_logical_type, arg->col_count);
-    arg->args = ALLOC_N(VALUE, arg->col_count + 1);
 
     for (j = 0; j < arg->col_count; j++) {
         arg->input_vectors[j] = duckdb_data_chunk_get_vector(arg->input, j);
@@ -314,14 +315,13 @@ static VALUE update_process_rows(VALUE varg) {
             }
         }
 
-        arg->args[0] = state->ruby_state;
+        rb_ary_store(args, 0, state->ruby_state);
         for (j = 0; j < arg->col_count; j++) {
-            arg->args[j + 1] = rbduckdb_vector_value_at(arg->input_vectors[j], arg->input_types[j], i);
+            rb_ary_store(args, (long)j + 1, rbduckdb_vector_value_at(arg->input_vectors[j], arg->input_types[j], i));
         }
 
         one.update_proc = arg->ctx->update_proc;
-        one.argc = (int)(arg->col_count + 1);
-        one.argv = arg->args;
+        one.args = args;
 
         ret = rb_protect(call_update_proc, (VALUE)&one, &exception_state);
         if (exception_state) {
@@ -336,12 +336,15 @@ static VALUE update_process_rows(VALUE varg) {
             for (j = 0; j < arg->row_count; j++) {
                 state_registry_remove(states[j]);
             }
+            RB_GC_GUARD(args);
             return Qnil;
         }
 
         state->ruby_state = ret;
         state_registry_store(state, ret);
     }
+
+    RB_GC_GUARD(args);
 
     return Qnil;
 }
@@ -355,9 +358,6 @@ static VALUE update_cleanup_callback(VALUE varg) {
             duckdb_destroy_logical_type(&arg->input_types[j]);
         }
         xfree(arg->input_types);
-    }
-    if (arg->args != NULL) {
-        xfree(arg->args);
     }
     if (arg->input_vectors != NULL) {
         xfree(arg->input_vectors);
@@ -395,7 +395,6 @@ static void update_callback(duckdb_function_info info,
     arg.states = states;
     arg.input_vectors = NULL;
     arg.input_types = NULL;
-    arg.args = NULL;
     arg.row_count = duckdb_data_chunk_get_size(input);
     arg.col_count = duckdb_data_chunk_get_column_count(input);
 

--- a/ext/duckdb/scalar_function.c
+++ b/ext/duckdb/scalar_function.c
@@ -35,7 +35,6 @@ struct callback_arg {
     duckdb_logical_type output_type;
     duckdb_vector *input_vectors;
     duckdb_logical_type *input_types;
-    VALUE *args;
     idx_t row_count;
     idx_t col_count;
 };
@@ -223,7 +222,6 @@ static void scalar_function_callback(duckdb_function_info info, duckdb_data_chun
     arg.output_type = duckdb_vector_get_column_type(output);
     arg.input_vectors = NULL;
     arg.input_types = NULL;
-    arg.args = NULL;
     arg.row_count = duckdb_data_chunk_get_size(input);
     arg.col_count = duckdb_data_chunk_get_column_count(input);
 
@@ -252,11 +250,13 @@ static VALUE process_rows(VALUE varg) {
     struct callback_arg *arg = (struct callback_arg *)varg;
     idx_t i, j;
     VALUE result;
+    /* A Ruby Array, not a plain buffer: converting a later column can trigger
+     * a GC, and the earlier columns' objects must stay reachable. */
+    VALUE args = rb_ary_new_capa((long)arg->col_count);
 
     /* Allocate arrays to hold input vectors and their types */
     arg->input_vectors = ALLOC_N(duckdb_vector, arg->col_count);
     arg->input_types = ALLOC_N(duckdb_logical_type, arg->col_count);
-    arg->args = ALLOC_N(VALUE, arg->col_count);
 
     /* Get all input vectors and their types */
     for (j = 0; j < arg->col_count; j++) {
@@ -268,15 +268,17 @@ static VALUE process_rows(VALUE varg) {
     for (i = 0; i < arg->row_count; i++) {
         /* Build arguments array for this row using vector_value_at */
         for (j = 0; j < arg->col_count; j++) {
-            arg->args[j] = rbduckdb_vector_value_at(arg->input_vectors[j], arg->input_types[j], i);
+            rb_ary_store(args, (long)j, rbduckdb_vector_value_at(arg->input_vectors[j], arg->input_types[j], i));
         }
 
         /* Call the Ruby block with the arguments */
-        result = rb_funcallv(arg->ctx->function_proc, rb_intern("call"), (int)arg->col_count, arg->args);
+        result = rb_apply(arg->ctx->function_proc, rb_intern("call"), args);
 
         /* Write result to output using helper function */
         rbduckdb_vector_set_value_at(arg->output, arg->output_type, i, result);
     }
+
+    RB_GC_GUARD(args);
 
     return Qnil;
 }
@@ -294,9 +296,6 @@ static VALUE cleanup_callback(VALUE varg) {
     duckdb_destroy_logical_type(&arg->output_type);
 
     /* Free allocated memory */
-    if (arg->args != NULL) {
-        xfree(arg->args);
-    }
     if (arg->input_types != NULL) {
         xfree(arg->input_types);
     }

--- a/test/duckdb_test/function_argument_gc_test.rb
+++ b/test/duckdb_test/function_argument_gc_test.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module DuckDBTest
+  # Per-row arguments are built one column at a time, and each conversion can
+  # allocate. Under GC.stress every allocation collects, so an argument that is
+  # not reachable from a scanned root is gone before the block runs.
+  class FunctionArgumentGCTest < Minitest::Test
+    def setup
+      @db = DuckDB::Database.open
+      @con = @db.connect
+      @con.query('CREATE TABLE t (a VARCHAR, b VARCHAR, c VARCHAR)')
+      @con.query("INSERT INTO t VALUES ('alpha', 'beta', 'gamma'), ('delta', 'epsilon', 'zeta')")
+    end
+
+    def teardown
+      GC.stress = false
+      @con&.close
+      @db&.close
+    end
+
+    def with_gc_stress
+      GC.stress = true
+      yield
+    ensure
+      GC.stress = false
+    end
+
+    def test_scalar_function_arguments_survive_gc_between_columns
+      @con.register_scalar_function(DuckDB::ScalarFunction.new.tap do |sf|
+        sf.name = 'join3'
+        3.times { sf.add_parameter(DuckDB::LogicalType::VARCHAR) }
+        sf.return_type = DuckDB::LogicalType::VARCHAR
+        sf.set_function { |a, b, c| [a, b, c].join('-') }
+      end)
+
+      result = with_gc_stress { @con.query('SELECT join3(a, b, c) FROM t ORDER BY a').to_a }
+
+      assert_equal [['alpha-beta-gamma'], ['delta-epsilon-zeta']], result
+    end
+
+    def test_aggregate_function_arguments_survive_gc_between_columns
+      @con.register_aggregate_function(
+        DuckDB::AggregateFunction.create(
+          name: 'concat_pairs',
+          return_type: :varchar,
+          params: %i[varchar varchar],
+          init: -> { [] },
+          update: ->(state, a, b) { state + ["#{a}:#{b}"] },
+          combine: ->(state, other_state) { state + other_state },
+          finalize: ->(state) { state.sort.join(',') }
+        )
+      )
+
+      result = with_gc_stress { @con.query('SELECT concat_pairs(a, b) FROM t').first.first }
+
+      assert_equal 'alpha:beta,delta:epsilon', result
+    end
+
+    def test_scalar_function_arguments_survive_compaction
+      skip 'GC.compact not available' unless GC.respond_to?(:compact)
+      skip 'GC.compact hangs on Windows in parallel test execution' if Gem.win_platform?
+
+      @con.register_scalar_function(DuckDB::ScalarFunction.new.tap do |sf|
+        sf.name = 'first_of_two'
+        2.times { sf.add_parameter(DuckDB::LogicalType::VARCHAR) }
+        sf.return_type = DuckDB::LogicalType::VARCHAR
+        sf.set_function do |a, b|
+          GC.compact
+          "#{a}/#{b}"
+        end
+      end)
+
+      result = @con.query('SELECT first_of_two(a, b) FROM t ORDER BY a').to_a
+
+      assert_equal [['alpha/beta'], ['delta/epsilon']], result
+    end
+  end
+end


### PR DESCRIPTION

## What's wrong

Both callback paths collected a row's arguments into a buffer the GC does not scan:

```c
/* ext/duckdb/scalar_function.c (before) */
arg->args = ALLOC_N(VALUE, arg->col_count);
...
for (j = 0; j < arg->col_count; j++) {
    arg->args[j] = rbduckdb_vector_value_at(arg->input_vectors[j], arg->input_types[j], i);
}
result = rb_funcallv(arg->ctx->function_proc, rb_intern("call"), (int)arg->col_count, arg->args);
```

`rbduckdb_vector_value_at` allocates for VARCHAR, BLOB, HUGEINT, temporal and nested types. While the loop converts column `j`, the objects built for columns `0..j-1` are reachable only from this `xmalloc`'d block, so a GC triggered by that conversion collects them. The block is then called with a freed `VALUE`.

`aggregate_function.c` has the same shape in `update_process_rows`, with the state at index 0 and the columns from index 1.

## Reproduction

```ruby
con.query('CREATE TABLE t (a VARCHAR, b VARCHAR, c VARCHAR)')
con.query("INSERT INTO t VALUES ('alpha', 'beta', 'gamma')")

con.register_scalar_function(DuckDB::ScalarFunction.new.tap do |sf|
  sf.name = 'join3'
  3.times { sf.add_parameter(DuckDB::LogicalType::VARCHAR) }
  sf.return_type = DuckDB::LogicalType::VARCHAR
  sf.set_function { |a, b, c| [a, b, c].join('-') }
end)

GC.stress = true
con.query('SELECT join3(a, b, c) FROM t')  # => segfault
```

On the current `main`:

```
test/duckdb_test/function_argument_gc_test.rb:35: [BUG] Segmentation fault at 0x0000000000000020
c:0027 p:---- s:0141 e:000140 l:y b:0001 CFUNC  :to_s
c:0026 p:---- s:0138 e:000137 l:y b:0001 CFUNC  :join
```

`GC.stress` only makes the window certain — the same collection happens under ordinary GC timing with enough allocation pressure.

## Why a Ruby Array

The arguments now live in a `rb_ary_new_capa` array, filled with `rb_ary_store` and passed through `rb_apply`. The array is allocated once per chunk and reused across rows, as the buffer was.

`rb_apply` rather than `rb_funcallv(..., RARRAY_CONST_PTR(ary))`: a small array stores its elements inside the object itself, which GC compaction can move, so a raw pointer into it is not stable across the call setup. `rb_apply` copies the elements before dispatching.

`ALLOCA_N` would also root the values on the machine stack, but `col_count` comes from the query and `duckdb_scalar_function_set_varargs` allows a call with any number of arguments, so the stack use would be unbounded.

## Verification

| Check | Result |
| --- | --- |
| New tests against unfixed build | segfault in both the scalar and aggregate paths |
| New tests against fixed build | 3 runs, 0 failures |
| Full suite | 1370 runs, 2634 assertions, 0 failures, 0 errors, 2 skips |
| RuboCop | no offenses |
| valgrind (memcheck) | `InvalidRead` / `InvalidWrite` / `InvalidFree` / `InvalidJump`: **0** |

Tests cover the scalar and aggregate paths under `GC.stress`, plus a scalar case that calls `GC.compact` from inside the block. valgrind was run over the same scenarios with DuckDB pinned to `threads=1` and `--fair-sched=yes`, using `ruby_memcheck`'s `ruby.supp`; the remaining reports are libruby's own allocations still live at interpreter exit, none from `libduckdb` or `duckdb_native`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when executing scalar and aggregate functions during Ruby garbage collection.
  * Prevented callback arguments from becoming invalid during memory compaction or intensive garbage-collection activity.
  * Function results now remain consistent under memory-stress conditions.

* **Tests**
  * Added coverage for scalar and aggregate functions with garbage-collection stress and compaction enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->