### PR TITLE
Read aggregate state from the registry, not the state buffer

### DIFF
--- a/ext/duckdb/aggregate_function.c
+++ b/ext/duckdb/aggregate_function.c
@@ -24,7 +24,6 @@ static unsigned long long g_next_state_id = 0;
 
 typedef struct {
     unsigned long long state_id;
-    VALUE ruby_state;
 } ruby_aggregate_state;
 
 static void mark(void *);
@@ -156,6 +155,18 @@ static inline void state_registry_store(ruby_aggregate_state *state, VALUE value
 }
 
 /*
+ * Read a state's Ruby VALUE back out of the registry.
+ *
+ * The registry is the only place the VALUE may be read from: a copy cached
+ * in the state buffer would be a raw VALUE in a C struct DuckDB allocates,
+ * which GC compaction does not update.  Returns Qnil for a state that has
+ * no entry (init failed, or the entry was already released).
+ */
+static inline VALUE state_registry_load(ruby_aggregate_state *state) {
+    return rb_hash_aref(g_aggregate_state_registry, state_registry_key(state));
+}
+
+/*
  * Remove a state entry from the registry.  Safe to call even if the
  * entry was already removed (rb_hash_delete is a no-op for missing keys).
  */
@@ -201,8 +212,7 @@ static void execute_init_callback_protected(void *user_data) {
     int exception_state;
     VALUE result;
 
-    /* Initialise buffer to a safe value before calling Ruby. */
-    state->ruby_state = Qnil;
+    /* Assign the ID before calling Ruby: the registry entry is keyed on it. */
     state->state_id = ++g_next_state_id;
 
     result = rb_protect(call_init_proc, (VALUE)arg, &exception_state);
@@ -211,7 +221,6 @@ static void execute_init_callback_protected(void *user_data) {
         return;
     }
 
-    state->ruby_state = result;
     state_registry_store(state, result);
 }
 
@@ -223,9 +232,9 @@ static void state_init_callback(duckdb_function_info info, duckdb_aggregate_stat
     if (ctx == NULL || ctx->init_proc == Qnil) {
         /* Defensive: maybe_set_functions only wires callbacks when init_proc
          * is set, so this branch should be unreachable in practice. Zero the
-         * buffer anyway to keep the Ruby state slot well-defined. */
+         * ID anyway: IDs start at 1, so this state matches no registry entry
+         * and state_registry_load returns Qnil for it. */
         ruby_aggregate_state *state = (ruby_aggregate_state *)state_p;
-        state->ruby_state = Qnil;
         state->state_id = 0;
         return;
     }
@@ -315,7 +324,7 @@ static VALUE update_process_rows(VALUE varg) {
             }
         }
 
-        rb_ary_store(args, 0, state->ruby_state);
+        rb_ary_store(args, 0, state_registry_load(state));
         for (j = 0; j < arg->col_count; j++) {
             rb_ary_store(args, (long)j + 1, rbduckdb_vector_value_at(arg->input_vectors[j], arg->input_types[j], i));
         }
@@ -340,7 +349,6 @@ static VALUE update_process_rows(VALUE varg) {
             return Qnil;
         }
 
-        state->ruby_state = ret;
         state_registry_store(state, ret);
     }
 
@@ -436,8 +444,8 @@ static void execute_combine_callback_protected(void *user_data) {
         VALUE ret;
 
         one.combine_proc = arg->ctx->combine_proc;
-        one.source_state = src[i]->ruby_state;
-        one.target_state = tgt[i]->ruby_state;
+        one.source_state = state_registry_load(src[i]);
+        one.target_state = state_registry_load(tgt[i]);
 
         ret = rb_protect(call_combine_proc, (VALUE)&one, &exception_state);
         if (exception_state) {
@@ -445,12 +453,13 @@ static void execute_combine_callback_protected(void *user_data) {
             return;
         }
 
-        tgt[i]->ruby_state = ret;
         state_registry_store(tgt[i], ret);
 
-        /* source state is consumed by combine; release its registry entry
-         * so the Ruby VALUE can be GC'd. */
-        state_registry_remove(src[i]);
+        /* The source entry is left in place: DuckDB reuses one source state
+         * across many combine calls (WindowSegmentTree does this for every
+         * frame), and the registry is now the only copy of the VALUE, so
+         * releasing it here would hand nil to the next combine. The entry is
+         * reclaimed by destroy_callback when DuckDB frees the state. */
     }
 }
 
@@ -528,7 +537,7 @@ static void execute_finalize_callback_protected(void *user_data) {
         VALUE ret;
 
         one.finalize_proc = arg->ctx->finalize_proc;
-        one.ruby_state = state->ruby_state;
+        one.ruby_state = state_registry_load(state);
 
         ret = rb_protect(call_finalize_proc, (VALUE)&one, &exception_state);
         if (exception_state) {

--- a/test/duckdb_test/aggregate_function_test.rb
+++ b/test/duckdb_test/aggregate_function_test.rb
@@ -451,6 +451,37 @@ module DuckDBTest
       assert_equal 'my_agg', result.to_s
     end
 
+    # A window frame feeds the same source state into many combine calls, so
+    # anything that releases the source state after the first call loses it for
+    # every later one.
+    def test_aggregate_as_window_function_reuses_source_state
+      force_parallel_execution(@con)
+      @con.query('CREATE TABLE w AS SELECT i FROM generate_series(1, 5000) s(i)')
+      nil_states = 0
+
+      @con.register_aggregate_function(
+        DuckDB::AggregateFunction.create(
+          name: 'win_count',
+          return_type: :bigint,
+          params: [:bigint],
+          init: -> { 0 },
+          update: ->(state, _value) { state + 1 },
+          combine: lambda { |state, other_state|
+            nil_states += 1 if state.nil? || other_state.nil?
+            (state || 0) + (other_state || 0)
+          },
+          finalize: ->(state) { state }
+        )
+      )
+
+      rows = @con.query(
+        'SELECT win_count(i) OVER (ORDER BY i ROWS BETWEEN 100 PRECEDING AND 100 FOLLOWING) FROM w'
+      ).to_a
+
+      assert_equal 0, nil_states
+      assert_equal [[101], [201], [101]], [rows.first, rows[2500], rows.last]
+    end
+
     private
 
     # Force DuckDB to actually parallelise aggregation so the combine callback

--- a/test/duckdb_test/function_argument_gc_test.rb
+++ b/test/duckdb_test/function_argument_gc_test.rb
@@ -58,6 +58,37 @@ module DuckDBTest
       assert_equal 'alpha:beta,delta:epsilon', result
     end
 
+    def test_aggregate_function_state_survives_compaction
+      skip 'GC.compact not available' unless GC.respond_to?(:compact)
+      skip 'GC.compact hangs on Windows in parallel test execution' if Gem.win_platform?
+
+      @con.query('CREATE TABLE g AS SELECT (i % 40)::VARCHAR AS k, i::VARCHAR AS v ' \
+                 'FROM generate_series(1, 400) t(i)')
+
+      @con.register_aggregate_function(
+        DuckDB::AggregateFunction.create(
+          name: 'compact_count',
+          return_type: :varchar,
+          params: %i[varchar],
+          init: -> { [] },
+          update: lambda { |state, v|
+            # Churn, then compact, so the state of every group that is not the
+            # one being updated right now gets relocated behind its back.
+            10.times { +'garbage' * 20 }
+            GC.compact
+            state + [v]
+          },
+          combine: ->(state, other_state) { state + other_state },
+          finalize: ->(state) { state.size.to_s }
+        )
+      )
+
+      result = @con.query('SELECT compact_count(v) FROM g GROUP BY k').to_a
+
+      assert_equal 40, result.size
+      assert_equal [['10']], result.uniq
+    end
+
     def test_scalar_function_arguments_survive_compaction
       skip 'GC.compact not available' unless GC.respond_to?(:compact)
       skip 'GC.compact hangs on Windows in parallel test execution' if Gem.win_platform?


### PR DESCRIPTION
Fixes #1443.

## What's wrong

The state's Ruby VALUE was held in two places, and only one of them survives compaction. Both were written together in `execute_init_callback_protected`:

```c
state->ruby_state = result;           /* raw VALUE in a C struct */
state_registry_store(state, result);  /* value in g_aggregate_state_registry */
```

The registry is a Hash pinned by `rb_gc_register_mark_object`, so Ruby rewrites its values when `GC.compact` relocates them. `ruby_aggregate_state` is a plain C struct in the state buffer DuckDB allocates — nothing tells Ruby it holds a VALUE, and it has no compaction hook, so the cached copy keeps the old address.

`update`, `combine` and `finalize` all read the struct copy. Any state that was not the one currently being updated could therefore be read back as a stale address.

This predates #1442, but #1442 changed the symptom. The stale address used to land in an `ALLOC_N` buffer the GC never scans, so it was handed to the user's proc as silent garbage. Since #1442 it lands in a Ruby Array, which the GC does scan, so it is marked through and the process aborts:

```
[BUG] try to mark T_NONE object (obj: 0x…T_NONE, parent: 0x…T_ARRAY [E] len: 2 (embed))
```

## The fix

Add `state_registry_load` and read through it at the four sites. The key is derived from the state ID, which compaction does not touch, so the lookup returns the current address. A missing entry yields `Qnil`, matching what the cached copy held for a state whose init failed.

With every read going through the registry, `ruby_state` is write-only, so the field is dropped. Keeping a raw VALUE in that buffer is what made this reachable in the first place.

## Why combine changed too

Making the registry the only copy breaks one assumption in `execute_combine_callback_protected`:

```c
/* source state is consumed by combine; release its registry entry
 * so the Ruby VALUE can be GC'd. */
state_registry_remove(src[i]);
```

A source state is *not* consumed by one combine call. DuckDB feeds the same source into many — `WindowSegmentTree` does this for every frame. That was survivable while the struct kept its own copy; with the registry as the only copy, every call after the first receives `nil`, and a window aggregate silently returns wrong results:

```
SELECT rb_cnt(i) OVER (ORDER BY i ROWS BETWEEN 500 PRECEDING AND 500 FOLLOWING) FROM t
with the remove:    first=[5]    mid=[9]     last=[5]    nil_src=351360
without the remove: first=[501]  mid=[1001]  last=[501]  nil_src=0
```

The entry is now reclaimed by `destroy_callback`, which was already the cleanup path for the intermediate states DuckDB creates by memcpy. The combine-time removal only released entries slightly earlier; it was not what prevented the leak.

## Verification

| Check | Result |
| --- | --- |
| Compaction test against unfixed build | `[BUG] Aborted`, core dumped |
| Window test against uncorrected combine | fail — 57,537 combine calls received `nil` |
| Both tests against fixed build | pass |
| Full suite | 1372 runs, 2638 assertions, 0 failures, 0 errors, 2 skips |
| RuboCop | 122 files, no offenses |
| Compiler | no warnings |

Registry drain, measured via `DuckDB::AggregateFunction._state_registry_size` after `GC.start`, to confirm dropping the combine-time removal does not leak:

| Query | Registry size |
| --- | --- |
| 50,000 groups / 500,000 rows, 8 threads | 0 |
| Window, moving 1001-row frame | 0 |

No valgrind run for this change.

## Tests

- `test_aggregate_function_state_survives_compaction` — 400 rows over 40 groups, allocating churn and calling `GC.compact` inside the update proc so the groups that are *not* currently being updated get relocated behind their backs. A smaller case does not reproduce: the update path rewrites the cached copy right after each proc call, so it self-heals; the bug only bites states sitting idle while another group updates.
- `test_aggregate_as_window_function_reuses_source_state` — an aggregate used as a window function over a moving frame. The aggregate window path had no coverage at all, which is why the combine assumption above went unnoticed.

## Known gaps, not addressed here

- `state_registry_load` returns `Qnil` for a missing entry, which is indistinguishable from a legitimately nil state — the reason the combine regression was silent rather than loud. Separating them needs `rb_hash_lookup2` plus error reporting threaded through the callers.
- `SELECT agg(x) OVER ()` segfaults in `update_process_rows`. Confirmed pre-existing on both this branch and its parent, so unrelated to this change, but it is the same untested window path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved aggregate-function stability during parallel and sliding-window calculations.
  * Preserved aggregate values correctly during Ruby garbage collection and repeated state reuse.

* **Tests**
  * Added coverage for windowed aggregates with repeated parallel processing.
  * Added garbage-collection regression coverage across multiple grouped aggregates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->