### PR TITLE
Bound the CI test step and drop the unusable dispatch guard

### DIFF
--- a/.github/workflows/test_on_macos.yml
+++ b/.github/workflows/test_on_macos.yml
@@ -88,7 +88,10 @@ jobs:
           puts "duckdb library #{actual}"
         '
 
+    # A UDF callback that strands the dispatcher wedges the VM with the GVL
+    # held, so the run never returns. Bound the step: the suite takes ~1 minute.
     - name: test with Ruby ${{ matrix.ruby }}
+      timeout-minutes: 3
       env:
         MYSQL_TEST: 1
         DYLD_LIBRARY_PATH: ${{ github.workspace }}/libduckdb-osx-universal

--- a/.github/workflows/test_on_ubuntu.yml
+++ b/.github/workflows/test_on_ubuntu.yml
@@ -95,7 +95,10 @@ jobs:
           puts "duckdb library #{actual}"
         '
 
+    # A UDF callback that strands the dispatcher wedges the VM with the GVL
+    # held, so the run never returns. Bound the step: the suite takes ~1 minute.
     - name: test with Ruby ${{ matrix.ruby }}
+      timeout-minutes: 3
       env:
         MYSQL_TEST: 1
       run: |

--- a/test/duckdb_test/function_error_message_test.rb
+++ b/test/duckdb_test/function_error_message_test.rb
@@ -36,25 +36,15 @@ module DuckDBTest
       end)
     end
 
-    # Bounds a query that stops returning once the dispatcher is stranded, so a
-    # regression fails the run instead of blocking it forever.
-    def within_dispatch_timeout(timeout = 60, &block)
-      thread = Thread.new do
-        Thread.current.report_on_exception = false
-        block.call
-      end
-      return thread.value if thread.join(timeout)
-
-      thread.kill
-
-      flunk 'UDF callback dispatch is stranded'
-    end
-
+    # A regression here strands the dispatcher, and the queries below then never
+    # return. Nothing in Ruby can bound that: the stranded state holds the GVL,
+    # so Thread#join timeouts never fire and even SIGTERM is not delivered. The
+    # bound lives in CI instead, as timeout-minutes on the test step.
     def test_scalar_error_message_with_a_null_byte_is_reported_to_duckdb
       register_scalar('nul_boom') { |v| raise "bad token: \0#{v}" }
 
       error = assert_raises(DuckDB::Error) do
-        within_dispatch_timeout { @con.query('SELECT nul_boom(a) FROM t') }
+        @con.query('SELECT nul_boom(a) FROM t')
       end
 
       assert_match(/bad token:/, error.message)
@@ -64,7 +54,7 @@ module DuckDBTest
       register_scalar('unreadable_boom') { |_v| raise MessageRaises }
 
       assert_raises(DuckDB::Error) do
-        within_dispatch_timeout { @con.query('SELECT unreadable_boom(a) FROM t') }
+        @con.query('SELECT unreadable_boom(a) FROM t')
       end
     end
 
@@ -82,7 +72,7 @@ module DuckDBTest
       )
 
       error = assert_raises(DuckDB::Error) do
-        within_dispatch_timeout { @con.query('SELECT nul_boom_agg(a) FROM t') }
+        @con.query('SELECT nul_boom_agg(a) FROM t')
       end
 
       assert_match(/bad token:/, error.message)
@@ -95,10 +85,10 @@ module DuckDBTest
       # Deliberately loose: the reporting path is asserted above, and a regression
       # there must not fail this test before it reaches the recovery check.
       assert_raises(StandardError) do
-        within_dispatch_timeout { @con.query('SELECT nul_boom2(a) FROM t') }
+        @con.query('SELECT nul_boom2(a) FROM t')
       end
 
-      result = within_dispatch_timeout { @con.query('SELECT echo(a) FROM t LIMIT 1').to_a }
+      result = @con.query('SELECT echo(a) FROM t LIMIT 1').to_a
 
       assert_equal [['echo0']], result
     end


### PR DESCRIPTION
Follow-up to #1448.

## Problem

`within_dispatch_timeout`, added in #1448, cannot do what it claims. A stranded UDF dispatcher wedges the VM with the GVL held, so `Thread#join(timeout)` never returns and the `flunk` after it is unreachable — a regression hangs the run exactly as it would with no guard at all.

Verified against the unfixed build (`main` before #1448): the NUL-message query strands the dispatcher and the next query never returns, at `threads=1` and at default threads, with a 10-row table and with 300k rows. The wedged process also ignores `SIGTERM`, so plain `timeout` cannot reclaim it — only `timeout -s KILL`.

So the guard is a bound that looks like a bound and isn't, which is worse than none: the next person to break this trusts it and CI hangs anyway.

## Change

Put the bound where it can actually be enforced — `timeout-minutes: 3` on the test step in `test_on_ubuntu.yml` and `test_on_macos.yml` — and delete the guard.

The step, not the job, because the test step is the only part that can wedge. Keeping it off the job clock leaves checkout, `setup-ruby`, the MySQL service health-checks, a possible cold duckdb download and `rake build` out of the budget; recent green `main` runs took 1m47s–3m30s end to end, so a 3-minute *job* cap would have failed two of the last five.

`test_on_windows.yml` needs nothing — it already bounds its test step through `nick-fields/retry` with `timeout_minutes: 1`.

Job-level `timeout-minutes: 120` stays as the backstop, since a wedged VM ignoring SIGTERM means the step kill wants something behind it.

## Verification

Against merged `main` (4a0b3ed), extension rebuilt:

- `test/duckdb_test/function_error_message_test.rb` — 4 runs, 9 assertions, 0 failures, **0.21s**
- Full suite — 1383 runs, 2653 assertions, 0 failures, 2 skips, **52.6s wall**
- `rubocop` — no offenses

52s against a 3-minute step bound is ~3.5x headroom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Simplified function error and recovery tests while preserving verification that subsequent function calls succeed after an error.
  * Improved test execution reliability by removing unnecessary thread-based timeout handling.

* **Chores**
  * Added three-minute limits to Ruby test runs on macOS and Ubuntu to prevent stalled builds from running indefinitely.
  * Documented expected test duration and handling of potential callback-related hangs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->