### PR TITLE
Fix VM wedge when an exception escapes the aggregate update callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 # Unreleased
+- fix an exception raised while converting a row for an aggregate UDF's update callback — including the `Timeout::Error` from wrapping a query in `Timeout.timeout` — unwinding into DuckDB instead of aborting the query, which could wedge the process for good (PR #1450).
 - fix a permanent hang when a UDF callback raised an exception whose message contained a NUL byte (or whose `#message` raised): the error reporter raised while reporting, killing the callback executor thread and stranding every later UDF callback in the process (PR #1448).
 - add `DuckDB::TableFunction::BindInfo#bind_data=` to store an arbitrary Ruby object as a custom table function's bind data.
 - add `DuckDB::TableFunction::FunctionInfo#bind_data` to retrieve, during execution, the object stored by `BindInfo#bind_data=`.

--- a/ext/duckdb/aggregate_function.c
+++ b/ext/duckdb/aggregate_function.c
@@ -266,16 +266,29 @@ static VALUE call_update_proc(VALUE varg) {
 }
 
 /*
+ * DuckDB does not call the destroy callback once update has failed, so the
+ * chunk's registry entries have to be dropped here or the Ruby VALUEs leak.
+ * Rows in a chunk may share a state; state_registry_remove is idempotent.
+ */
+static void release_chunk_states(struct update_callback_arg *arg) {
+    ruby_aggregate_state **states = (ruby_aggregate_state **)arg->states;
+    idx_t i;
+
+    for (i = 0; i < arg->row_count; i++) {
+        state_registry_remove(states[i]);
+    }
+}
+
+/*
  * Body of the update callback: allocate input buffers, walk each row,
  * dispatch to the user's update_proc. Runs inside rb_ensure so that
  * update_cleanup_callback always runs — even if rbduckdb_vector_value_at
  * or the Ruby proc call raises, allocated buffers and logical types are
  * released on the unwind path.
  *
- * Ruby exceptions raised by the user's proc are caught inline via
- * rb_protect and reported to DuckDB as scalar errors; other Ruby
- * exceptions (e.g. from vector_value_at) propagate and are cleaned up
- * by rb_ensure.
+ * Ruby exceptions raised by the user's proc are caught inline via rb_protect
+ * and reported to DuckDB; anything else (vector_value_at, or an async
+ * exception such as Timeout::Error) unwinds to execute_update_callback_protected.
  */
 static VALUE update_process_rows(VALUE varg) {
     struct update_callback_arg *arg = (struct update_callback_arg *)varg;
@@ -332,16 +345,7 @@ static VALUE update_process_rows(VALUE varg) {
         ret = rb_protect(call_update_proc, (VALUE)&one, &exception_state);
         if (exception_state) {
             report_ruby_error_to_duckdb(arg->info);
-            /*
-             * DuckDB does not call the destroy callback on the update error
-             * path, so we must remove reachable states from the registry
-             * ourselves to avoid leaking Ruby VALUEs.  Iterate all rows in
-             * the chunk — multiple rows may share the same state (same
-             * group), but state_registry_remove is idempotent.
-             */
-            for (j = 0; j < arg->row_count; j++) {
-                state_registry_remove(states[j]);
-            }
+            release_chunk_states(arg);
             RB_GC_GUARD(args);
             return Qnil;
         }
@@ -371,9 +375,25 @@ static VALUE update_cleanup_callback(VALUE varg) {
     return Qnil;
 }
 
+static VALUE update_process_rows_ensured(VALUE varg) {
+    return rb_ensure(update_process_rows, varg, update_cleanup_callback, varg);
+}
+
+/*
+ * The scalar path has always protected its callback body; this one did not, so
+ * an exception from anywhere but the user's proc unwound into DuckDB's C++
+ * frames. Reachable from ordinary Ruby: Timeout.timeout around a query lands
+ * its Timeout::Error in the row loop and wedges the VM.
+ */
 static void execute_update_callback_protected(void *user_data) {
     struct update_callback_arg *arg = (struct update_callback_arg *)user_data;
-    rb_ensure(update_process_rows, (VALUE)arg, update_cleanup_callback, (VALUE)arg);
+    int exception_state;
+
+    rb_protect(update_process_rows_ensured, (VALUE)arg, &exception_state);
+    if (exception_state) {
+        report_ruby_error_to_duckdb(arg->info);
+        release_chunk_states(arg);
+    }
 }
 
 static void update_callback(duckdb_function_info info,

--- a/test/duckdb_test/aggregate_update_exception_test.rb
+++ b/test/duckdb_test/aggregate_update_exception_test.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module DuckDBTest
+  # The update callback converts each row value before handing it to the user's
+  # proc, and only the proc call was protected. An exception from the conversion
+  # therefore unwound into DuckDB's C++ frames and wedged the VM — reachable
+  # from ordinary Ruby by wrapping a query in Timeout.timeout.
+  class AggregateUpdateExceptionTest < Minitest::Test
+    ROWS = 2000
+
+    def setup
+      @db = DuckDB::Database.open
+      @con = @db.connect
+      @con.query("CREATE TABLE d AS SELECT DATE '2020-01-01' + i::INTEGER AS d FROM range(#{ROWS}) s(i)")
+      @con.register_aggregate_function(
+        DuckDB::AggregateFunction.create(
+          name: 'count_dates',
+          return_type: :bigint,
+          params: [:date],
+          init: -> { 0 },
+          update: ->(state, _v) { state + 1 },
+          combine: ->(a, b) { a + b },
+          finalize: ->(state) { state }
+        )
+      )
+    end
+
+    def teardown
+      @con&.close
+      @db&.close
+    end
+
+    # Stands in for anything that can raise between reading a row and calling the
+    # user's proc; Timeout::Error lands in the same place, but not on a schedule.
+    def with_conversion_raising(message)
+      original = DuckDB::Converter.method(:_to_date)
+      DuckDB::Converter.define_singleton_method(:_to_date) { |*| raise message }
+      yield
+    ensure
+      DuckDB::Converter.define_singleton_method(:_to_date, original)
+    end
+
+    def failing_query
+      with_conversion_raising('conversion blew up') do
+        assert_raises(DuckDB::Error) { @con.query('SELECT count_dates(d) FROM d') }
+      end
+    end
+
+    def test_a_conversion_error_aborts_the_query_as_a_duckdb_error
+      assert_match(/conversion blew up/, failing_query.message)
+    end
+
+    def test_the_state_registry_drains_after_a_conversion_error
+      baseline = DuckDB::AggregateFunction._state_registry_size
+
+      failing_query
+
+      assert_equal baseline, DuckDB::AggregateFunction._state_registry_size
+    end
+
+    def test_the_connection_still_works_after_a_conversion_error
+      failing_query
+
+      assert_equal [[ROWS]], @con.query('SELECT count_dates(d) FROM d').to_a
+    end
+  end
+end


### PR DESCRIPTION
## Problem

`update_process_rows` builds each row's arguments and then calls the user's proc. Only that last step is protected:

```c
rb_ary_store(args, 0, state_registry_load(state));
for (j = 0; j < arg->col_count; j++) {
    rb_ary_store(args, (long)j + 1, rbduckdb_vector_value_at(...));   /* unprotected */
}
ret = rb_protect(call_update_proc, (VALUE)&one, &exception_state);    /* protected */
```

and the wrapper around it has no `rb_protect` at all:

```c
static void execute_update_callback_protected(void *user_data) {
    rb_ensure(update_process_rows, (VALUE)arg, update_cleanup_callback, (VALUE)arg);
}
```

`rb_ensure` frees the buffers but re-raises, so anything that raises outside the proc call unwinds into DuckDB's C++ frames. The scalar path does not have this hole — `execute_callback_protected` wraps its whole body in `rb_protect`.

`rbduckdb_vector_value_at` reaches Ruby for several types (`DuckDB::Converter._to_date`, `_to_time`, `_to_hugeint_from_vector`, ...), and it is also an async-exception delivery point. That makes it reachable from ordinary Ruby.

## Reproduction

Wrapping a query in `Timeout.timeout` is enough — no unusual API use:

```ruby
config = DuckDB::Config.new
config['threads'] = '1'
con = DuckDB::Database.open(nil, config: config).connect
con.query("CREATE TABLE t AS SELECT TIMESTAMP '2020-01-01' + INTERVAL (i) SECOND AS ts FROM range(4000000) s(i)")
# count_ts is an aggregate UDF over the ts column

Timeout.timeout(1.8) { con.query('SELECT count_ts(ts) FROM t') }   # ~3.5s uninterrupted
con.query("SELECT echo('x')")                                      # never returns
```

Before, on this build:

```
[f9] uninterrupted query: 3.53s over 4000000 rows
[f9] re-running under Timeout.timeout(1.76)
[f9] raised Timeout::Error: execution expired
[f9] probing whether UDF dispatch still works
  → killed at 120s
```

The same script with a scalar UDF instead of an aggregate already behaves correctly today (`DuckDB::Error: Invalid Input Error: execution expired`, process survives), which is what isolates the missing `rb_protect`.

After: the aggregate matches the scalar — `DuckDB::Error: Invalid Input Error: execution expired`, and the next query returns.

## Why this approach

The fix is to give this wrapper the protection the scalar wrapper already has, rather than to guard the dispatcher. Swallowing at the dispatcher would be wrong here: `Timeout::Error` is a `StandardError`, so a dispatcher-level discard would silently drop the user's timeout and let the query finish normally. Reporting through `duckdb_aggregate_function_set_error` aborts the query and surfaces the message, which is the behaviour the scalar path already has.

Registry entries for the chunk are released on the new path too. The inline proc-error path already did this because DuckDB does not call the destroy callback once update has failed; the same applies here, so the loop moved into a shared `release_chunk_states`.

## Verification

- `test/duckdb_test/aggregate_update_exception_test.rb`, 3 tests: a conversion error aborts the query as `DuckDB::Error`, the state registry drains afterwards, and the connection still works. The conversion is made to raise by stubbing `DuckDB::Converter._to_date` — deterministic and fast, where `Timeout` lands in the same place but not on a schedule.
- On the unfixed build all three fail with `DuckDB::Error expected, not RuntimeError: conversion blew up` — the exception leaking through DuckDB is exactly the defect. They fail rather than hang, so they are safe in CI; the permanent wedge is the large-query case shown above.
- Full suite: 1386 runs, 2660 assertions, 0 failures, 0 errors, 2 skips.

Not included: `table_function.c`'s three wrappers and `scalar_function.c`'s bind wrapper construct their info objects with `rb_class_new_instance` *before* their own `rb_protect`. Same class of hole, but I could not reach it from ordinary Ruby (only by redefining an internal class's `initialize`), so I left it out rather than present it as a bug. Happy to send it as a separate hardening PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Aggregate update errors, including timeout-related failures, are now reported as `DuckDB::Error` instead of aborting queries.
  * Improved cleanup after aggregate processing failures prevents lingering state from affecting future operations.
  * Connections remain usable after an aggregate update exception.

* **Documentation**
  * Added an Unreleased changelog entry describing the aggregate update exception handling improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->