### PR TITLE
Fix VARCHAR values being truncated at an embedded NUL byte

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 # Unreleased
+- fix a bound or appended `VARCHAR` being silently truncated at an embedded NUL byte, so that a String validated on the Ruby side is now stored in full (PR #1451). Affects `Connection#query(sql, *args)`, `PreparedStatement#bind`/`#bind_varchar` and `Appender#append_varchar`.
 - fix an exception raised while converting a row for an aggregate UDF's update callback — including the `Timeout::Error` from wrapping a query in `Timeout.timeout` — unwinding into DuckDB instead of aborting the query, which could wedge the process for good (PR #1450).
 - fix a permanent hang when a UDF callback raised an exception whose message contained a NUL byte (or whose `#message` raised): the error reporter raised while reporting, killing the callback executor thread and stranding every later UDF callback in the process (PR #1448).
 - add `DuckDB::TableFunction::BindInfo#bind_data=` to store an arbitrary Ruby object as a custom table function's bind data.

--- a/ext/duckdb/appender.c
+++ b/ext/duckdb/appender.c
@@ -333,11 +333,13 @@ static VALUE appender__append_double(VALUE self, VALUE val) {
 /* :nodoc: */
 static VALUE appender__append_varchar(VALUE self, VALUE val) {
     rubyDuckDBAppender *ctx;
+    /* Length-aware, as duckdb_append_varchar would stop at an embedded NUL. */
     char *pval = StringValuePtr(val);
+    long len = RSTRING_LEN(val);
 
     TypedData_Get_Struct(self, rubyDuckDBAppender, &appender_data_type, ctx);
 
-    return state_to_rbool(duckdb_append_varchar(ctx->appender, pval));
+    return state_to_rbool(duckdb_append_varchar_length(ctx->appender, pval, (idx_t)len));
 }
 
 /* :nodoc: */

--- a/ext/duckdb/prepared_statement.c
+++ b/ext/duckdb/prepared_statement.c
@@ -345,10 +345,17 @@ static VALUE prepared_statement_bind_double(VALUE self, VALUE vidx, VALUE val) {
 static VALUE prepared_statement_bind_varchar(VALUE self, VALUE vidx, VALUE str) {
     rubyDuckDBPreparedStatement *ctx;
     idx_t idx = check_index(vidx);
+    const char *pstr;
+    long len;
 
     TypedData_Get_Struct(self, rubyDuckDBPreparedStatement, &prepared_statement_data_type, ctx);
 
-    if (duckdb_bind_varchar(ctx->prepared_statement, idx, StringValuePtr(str)) == DuckDBError) {
+    /* Pass the byte length: duckdb_bind_varchar stops at the first NUL, so an
+     * embedded one stored a prefix of the String the caller had validated. */
+    pstr = StringValuePtr(str);
+    len = RSTRING_LEN(str);
+
+    if (duckdb_bind_varchar_length(ctx->prepared_statement, idx, pstr, (idx_t)len) == DuckDBError) {
         rb_raise(eDuckDBError, "fail to bind %llu parameter", (unsigned long long)idx);
     }
     return self;

--- a/test/duckdb_test/varchar_null_byte_test.rb
+++ b/test/duckdb_test/varchar_null_byte_test.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module DuckDBTest
+  # VARCHAR values used to be handed to DuckDB as a bare pointer, so an embedded
+  # NUL ended them early: Ruby validated the whole String while the database
+  # stored only the prefix.
+  class VarcharNullByteTest < Minitest::Test
+    EMBEDDED_NUL = "attacker@evil.test\0@corp.example"
+
+    def setup
+      @db = DuckDB::Database.open
+      @con = @db.connect
+      @con.query('CREATE TABLE t (v VARCHAR)')
+    end
+
+    def teardown
+      @con&.close
+      @db&.close
+    end
+
+    def stored
+      @con.query('SELECT v FROM t').first.first
+    end
+
+    def test_query_binding_keeps_the_bytes_after_a_null_byte
+      @con.query('INSERT INTO t VALUES (?)', EMBEDDED_NUL)
+
+      assert_equal EMBEDDED_NUL, stored
+    end
+
+    def test_bind_varchar_keeps_the_bytes_after_a_null_byte
+      stmt = DuckDB::PreparedStatement.new(@con, 'INSERT INTO t VALUES (?)')
+      stmt.bind_varchar(1, EMBEDDED_NUL)
+      stmt.execute
+
+      assert_equal EMBEDDED_NUL, stored
+    end
+
+    def test_appending_keeps_the_bytes_after_a_null_byte
+      @con.appender('t') { |appender| appender.append_row(EMBEDDED_NUL) }
+
+      assert_equal EMBEDDED_NUL, stored
+    end
+
+    def test_a_leading_null_byte_no_longer_stores_an_empty_string
+      @con.query('INSERT INTO t VALUES (?)', "\0hidden")
+
+      assert_equal "\0hidden", stored
+    end
+  end
+end


### PR DESCRIPTION
## Problem

Two entry points hand a Ruby String to DuckDB as a bare pointer:

```c
duckdb_bind_varchar(ctx->prepared_statement, idx, StringValuePtr(str));   /* prepared_statement.c:351 */
duckdb_append_varchar(ctx->appender, pval);                              /* appender.c:340 */
```

Both take a C string, so the value ends at the first NUL byte. Ruby Strings are length-counted and can carry one, so what the application validated and what the database stored could differ.

To be clear about what this is not: the parameter stays a parameter, so it is not SQL injection. `"x'); DROP TABLE canary; --"` is stored verbatim as data and the canary table survives. What it is, is a validation bypass — the application's check runs on the whole String and the row gets the prefix.

## Reproduction

```ruby
email = "attacker@evil.test\0@corp.example"
email.end_with?('@corp.example')   # => true, so a domain check passes

con.query('INSERT INTO users VALUES (?)', email)
con.query('SELECT email FROM users').first.first
```

Before:

```
ruby-side value      : "attacker@evil.test@corp.example" (32 bytes)
ruby-side check      : ends_with?('@corp.example') => true
stored in duckdb     : "attacker@evil.test" (18 bytes)
round-trip equal?    : false
appender stored      : "appended" (8 bytes)     # from "appended\0hidden"
```

After: all 32 bytes are stored, the round trip is equal, and the appender keeps all 15.

A signup that enforces `raise unless email.end_with?('@corp.example')` and then binds the address is enough to reach it; the row lands as `attacker@evil.test`. The same shape applies to blocklists, uniqueness pre-checks, and any normalization done before the bind.

## Why this approach

`duckdb_bind_varchar_length` and `duckdb_append_varchar_length` take an explicit length, so the value is passed as the byte string it already is. The extension already uses the length-aware form elsewhere — `value.c:133` calls `duckdb_create_varchar_length`, and `_append_varchar_length` is exposed as `Appender#append_varchar_length` — so this brings the two default paths in line with the rest.

The append fix is in C rather than in `Appender#append_varchar`. Computing the length in Ruby would mean `value.to_s.bytesize` alongside a separate `StringValuePtr` conversion in C, and those can disagree for an object with `to_str`. Taking `RSTRING_LEN` right after `StringValuePtr` uses the same converted String.

The alternative — `StringValueCStr`, which raises `ArgumentError` — would also close the gap, but it turns a value DuckDB can store perfectly well into an error.

## Verification

- `test/duckdb_test/varchar_null_byte_test.rb`, 4 tests: `Connection#query` binding, `PreparedStatement#bind_varchar`, the appender, and a leading NUL (which previously stored an empty string). All four fail on the unfixed build with the truncated value.
- Full suite: 1387 runs, 2657 assertions, 0 failures, 0 errors, 2 skips — nothing depended on the truncation.

## Not included

- `duckdb_prepare` at `prepared_statement.c:105` also uses `StringValuePtr`, so a NUL in the SQL *text* silently truncates the statement, while `Connection#query` uses `StringValueCStr` and raises `ArgumentError` for the same input. Worth making consistent, but that is statement text rather than data and the fix means adding an exception, so I left it out of this PR.
- `prepared_statement_bind_blob` (line 363) evaluates `StringValuePtr(blob)` and `RSTRING_LEN(blob)` as two arguments of one call, whose order C leaves unspecified. Harmless in practice since the caller always passes a String, but it is the pattern this PR deliberately avoids in the varchar path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
