### PR TITLE
Return one Database wrapper per cached instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - add `DuckDB::TableFunction::FunctionInfo#bind_data` to retrieve, during execution, the object stored by `BindInfo#bind_data=`.
 - add `DuckDB::TableFunction::InitInfo#bind_data` to retrieve, during the init phase, the object stored by `BindInfo#bind_data=`.
 - support the statement types added in DuckDB 1.5.5: `#statement_type` now returns `:copy_database`, `:update_extensions` and `:merge_into` instead of raising `DuckDB::Error: Unknown statement type`.
+- fix a use-after-free when a function was registered through `DuckDB::InstanceCache`: two `get_or_create` calls on the same path returned separate `DuckDB::Database` objects over one shared instance, so collecting either one freed functions the other's connections could still resolve. `get_or_create` now returns the same `DuckDB::Database` for the same path.
 
 # 1.5.5.0 - 2026-07-27
 

--- a/ext/duckdb/database.c
+++ b/ext/duckdb/database.c
@@ -33,6 +33,8 @@ static void mark(void *ctx) {
     rubyDuckDB *p = (rubyDuckDB *)ctx;
 
     rb_gc_mark(p->registered_functions);
+    rb_gc_mark(p->cached_path);
+    rb_gc_mark(p->cache_wrappers);
 }
 
 static size_t memsize(const void *p) {
@@ -44,6 +46,8 @@ static VALUE allocate(VALUE klass) {
     VALUE obj = TypedData_Wrap_Struct(klass, &database_data_type, ctx);
     VALUE registered_functions = rb_ary_new();
     ctx->registered_functions = registered_functions;
+    ctx->cached_path = Qnil;
+    ctx->cache_wrappers = Qnil;
     RB_GC_GUARD(registered_functions);
     return obj;
 }
@@ -58,6 +62,18 @@ void rbduckdb_database_retain(VALUE database, VALUE obj) {
 
     TypedData_Get_Struct(database, rubyDuckDB, &database_data_type, ctx);
     rb_ary_push(ctx->registered_functions, obj);
+}
+
+/*
+ * Records that this database is the InstanceCache's wrapper for path, so the
+ * cache can find it again and #close can remove it from the cache's weak set.
+ */
+void rbduckdb_database_set_cache_entry(VALUE database, VALUE path, VALUE wrappers) {
+    rubyDuckDB *ctx;
+
+    TypedData_Get_Struct(database, rubyDuckDB, &database_data_type, ctx);
+    ctx->cached_path = rb_str_new_frozen(path);
+    ctx->cache_wrappers = wrappers;
 }
 
 rubyDuckDB *rbduckdb_get_struct_database(VALUE obj) {
@@ -142,6 +158,15 @@ static VALUE database__connect(VALUE self) {
 static VALUE database_close(VALUE self) {
     rubyDuckDB *ctx;
     TypedData_Get_Struct(self, rubyDuckDB, &database_data_type, ctx);
+    /*
+     * A closed wrapper must not be handed to the next get_or_create, so drop it
+     * from the cache's set first. The next call then opens a fresh wrapper.
+     */
+    if (!NIL_P(ctx->cache_wrappers)) {
+        rb_funcall(ctx->cache_wrappers, rb_intern("delete"), 1, self);
+        ctx->cache_wrappers = Qnil;
+        ctx->cached_path = Qnil;
+    }
     close_database(ctx);
     return self;
 }

--- a/ext/duckdb/database.h
+++ b/ext/duckdb/database.h
@@ -5,6 +5,14 @@ struct _rubyDuckDB {
     duckdb_database db;
     /* Functions and logical types registered on any connection to this database */
     VALUE registered_functions;
+    /*
+     * Set only for a database handed out by DuckDB::InstanceCache: the path it
+     * was opened under, and the cache's weak set of live wrappers. Together they
+     * let the cache hand back this same wrapper for the same path, and let
+     * #close drop this wrapper from the set. Qnil for any other database.
+     */
+    VALUE cached_path;
+    VALUE cache_wrappers;
 };
 
 typedef struct _rubyDuckDB rubyDuckDB;
@@ -12,6 +20,7 @@ typedef struct _rubyDuckDB rubyDuckDB;
 rubyDuckDB *rbduckdb_get_struct_database(VALUE obj);
 VALUE rbduckdb_create_database_obj(duckdb_database db);
 void rbduckdb_database_retain(VALUE database, VALUE obj);
+void rbduckdb_database_set_cache_entry(VALUE database, VALUE path, VALUE wrappers);
 void rbduckdb_init_database(void);
 
 #endif

--- a/ext/duckdb/instance_cache.c
+++ b/ext/duckdb/instance_cache.c
@@ -3,7 +3,10 @@
 VALUE cDuckDBInstanceCache;
 
 static void deallocate(void * ctx);
+static void mark(void *ctx);
 static VALUE allocate(VALUE klass);
+static VALUE memoizable_path(VALUE vpath);
+static VALUE find_cached_wrapper(rubyDuckDBInstanceCache *ctx, VALUE vpath);
 static size_t memsize(const void *p);
 static VALUE instance_cache_initialize(VALUE self);
 static VALUE instance_cache_get_or_create(int argc, VALUE *argv, VALUE self);
@@ -11,7 +14,7 @@ static VALUE instance_cache_destroy(VALUE self);
 
 static const rb_data_type_t instance_cache_data_type = {
     "DuckDB/InstanceCache",
-    {NULL, deallocate, memsize,},
+    {mark, deallocate, memsize,},
     0, 0, RUBY_TYPED_FREE_IMMEDIATELY
 };
 
@@ -24,13 +27,54 @@ static void deallocate(void * ctx) {
     xfree(p);
 }
 
+static void mark(void *ctx) {
+    rubyDuckDBInstanceCache *p = (rubyDuckDBInstanceCache *)ctx;
+
+    rb_gc_mark(p->wrappers);
+}
+
 static size_t memsize(const void *p) {
     return sizeof(rubyDuckDBInstanceCache);
 }
 
 static VALUE allocate(VALUE klass) {
     rubyDuckDBInstanceCache *ctx = xcalloc((size_t)1, sizeof(rubyDuckDBInstanceCache));
+    ctx->wrappers = Qnil;
     return TypedData_Wrap_Struct(klass, &instance_cache_data_type, ctx);
+}
+
+/*
+ * A path is memoizable only if two get_or_create calls on it share one DuckDB
+ * instance. An absent, empty or ":memory:" path gets a fresh instance every
+ * time, so those wrappers must stay distinct. Returns the path or Qnil.
+ */
+static VALUE memoizable_path(VALUE vpath) {
+    if (NIL_P(vpath) || RSTRING_LEN(vpath) == 0) {
+        return Qnil;
+    }
+    if (rb_str_cmp(vpath, rb_str_new_cstr(":memory:")) == 0) {
+        return Qnil;
+    }
+    return vpath;
+}
+
+/*
+ * The wrapper this cache already holds for vpath, or Qnil. Entries whose
+ * wrapper has been collected are gone from the weak set already.
+ */
+static VALUE find_cached_wrapper(rubyDuckDBInstanceCache *ctx, VALUE vpath) {
+    VALUE wrappers = rb_funcall(ctx->wrappers, rb_intern("keys"), 0);
+    long i;
+
+    for (i = 0; i < RARRAY_LEN(wrappers); i++) {
+        VALUE wrapper = rb_ary_entry(wrappers, i);
+        rubyDuckDB *db_ctx = rbduckdb_get_struct_database(wrapper);
+
+        if (!NIL_P(db_ctx->cached_path) && rb_str_equal(db_ctx->cached_path, vpath) == Qtrue) {
+            return wrapper;
+        }
+    }
+    return Qnil;
 }
 
 static VALUE instance_cache_initialize(VALUE self) {
@@ -43,6 +87,10 @@ static VALUE instance_cache_initialize(VALUE self) {
         rb_raise(eDuckDBError, "Failed to create instance cache");
     }
 
+    ctx->wrappers = rb_funcall(rb_const_get(rb_const_get(rb_cObject, rb_intern("ObjectSpace")),
+                                            rb_intern("WeakMap")),
+                               rb_intern("new"), 0);
+
     return self;
 }
 
@@ -50,6 +98,8 @@ static VALUE instance_cache_initialize(VALUE self) {
 static VALUE instance_cache_get_or_create(int argc, VALUE *argv, VALUE self) {
     VALUE vpath = Qnil;
     VALUE vconfig = Qnil;
+    VALUE memo_path;
+    VALUE obj;
     const char *path = NULL;
     char *error = NULL;
     duckdb_config config = NULL;
@@ -79,7 +129,31 @@ static VALUE instance_cache_get_or_create(int argc, VALUE *argv, VALUE self) {
             rb_raise(eDuckDBError, "Failed to get or create database from instance cache");
         }
     }
-    return rbduckdb_create_database_obj(db);
+    /*
+     * duckdb_get_or_create_from_cache hands back a fresh duckdb_database handle
+     * over an instance it may already have returned before. Registered functions
+     * live in that shared instance's catalog, but each wrapper retains them
+     * separately, so a second wrapper's collection frees functions the first
+     * one's connections can still resolve. One wrapper per instance is what the
+     * catalog's lifetime actually is, so reuse the wrapper we already have.
+     */
+    memo_path = memoizable_path(vpath);
+    if (!NIL_P(memo_path)) {
+        VALUE cached = find_cached_wrapper(ctx, memo_path);
+
+        if (!NIL_P(cached)) {
+            /* Our existing wrapper keeps the instance alive; this handle is spare. */
+            duckdb_close(&db);
+            return cached;
+        }
+    }
+
+    obj = rbduckdb_create_database_obj(db);
+    if (!NIL_P(memo_path)) {
+        rbduckdb_database_set_cache_entry(obj, memo_path, ctx->wrappers);
+        rb_funcall(ctx->wrappers, rb_intern("[]="), 2, obj, Qtrue);
+    }
+    return obj;
 }
 
 static VALUE instance_cache_destroy(VALUE self) {

--- a/ext/duckdb/instance_cache.h
+++ b/ext/duckdb/instance_cache.h
@@ -3,6 +3,12 @@
 
 struct _rubyDuckDBInstanceCache {
     duckdb_instance_cache instance_cache;
+    /*
+     * ObjectSpace::WeakMap used as a weak set of the DuckDB::Database wrappers
+     * this cache has handed out for file paths. Weak so a wrapper nobody holds
+     * is still collected, and its DuckDB instance closed, as before.
+     */
+    VALUE wrappers;
 };
 
 typedef struct _rubyDuckDBInstanceCache rubyDuckDBInstanceCache;

--- a/test/duckdb_test/instance_cache_test.rb
+++ b/test/duckdb_test/instance_cache_test.rb
@@ -70,7 +70,10 @@ if defined?(DuckDB::InstanceCache)
 
       def test_get_or_create_returns_the_same_database_for_the_same_path
         with_cached_path do |cache, path|
-          assert_same cache.get_or_create(path), cache.get_or_create(path)
+          db = cache.get_or_create(path)
+
+          assert_same db, cache.get_or_create(path)
+          db.close
         end
       end
 
@@ -78,12 +81,14 @@ if defined?(DuckDB::InstanceCache)
       # goes away must not take another wrapper's functions with it.
       def test_registered_function_outlives_a_dropped_wrapper_over_the_same_instance
         with_cached_path do |cache, path|
-          con = cache.get_or_create(path).connect
+          db = cache.get_or_create(path)
+          con = db.connect
           register_doubler(cache, path)
           3.times { GC.start }
 
           assert_equal [[42]], con.query('SELECT dbl(21)').to_a
           con.disconnect
+          db.close
         end
       end
 
@@ -96,12 +101,21 @@ if defined?(DuckDB::InstanceCache)
           second = cache.get_or_create(path)
 
           refute_same first, second, "expected distinct databases for #{path.inspect}"
+          first.close
+          second.close
         end
       end
 
       def test_separate_caches_return_distinct_databases_for_the_same_path
+        skip 'Windows cannot open one database file from two instances' if RUBY_PLATFORM.match?(/mingw|mswin|cygwin/)
+
         with_cached_path do |cache, path|
-          refute_same cache.get_or_create(path), DuckDB::InstanceCache.new.get_or_create(path)
+          first = cache.get_or_create(path)
+          second = DuckDB::InstanceCache.new.get_or_create(path)
+
+          refute_same first, second
+          first.close
+          second.close
         end
       end
 
@@ -111,14 +125,20 @@ if defined?(DuckDB::InstanceCache)
           closed.close
 
           reopened = cache.get_or_create(path)
+          con = reopened.connect
 
           refute_same closed, reopened
-          assert_equal [[1]], reopened.connect.query('SELECT 1').to_a
+          assert_equal [[1]], con.query('SELECT 1').to_a
+          con.disconnect
+          reopened.close
         end
       end
 
       private
 
+      # Every database opened under the yielded path must be closed before the
+      # block ends: Windows refuses to delete a file that is still open, so an
+      # unclosed wrapper fails the tmpdir cleanup rather than the assertion.
       def with_cached_path
         Dir.mktmpdir do |dir|
           yield DuckDB::InstanceCache.new, File.join(dir, 'cached.duckdb')

--- a/test/duckdb_test/instance_cache_test.rb
+++ b/test/duckdb_test/instance_cache_test.rb
@@ -2,6 +2,7 @@
 
 require 'test_helper'
 require 'fileutils'
+require 'tmpdir'
 
 if defined?(DuckDB::InstanceCache)
 
@@ -67,7 +68,76 @@ if defined?(DuckDB::InstanceCache)
         assert_nil cache.destroy
       end
 
+      def test_get_or_create_returns_the_same_database_for_the_same_path
+        with_cached_path do |cache, path|
+          assert_same cache.get_or_create(path), cache.get_or_create(path)
+        end
+      end
+
+      # Registrations live in the shared instance's catalog, so a wrapper that
+      # goes away must not take another wrapper's functions with it.
+      def test_registered_function_outlives_a_dropped_wrapper_over_the_same_instance
+        with_cached_path do |cache, path|
+          con = cache.get_or_create(path).connect
+          register_doubler(cache, path)
+          3.times { GC.start }
+
+          assert_equal [[42]], con.query('SELECT dbl(21)').to_a
+          con.disconnect
+        end
+      end
+
+      # Each of these opens a fresh instance rather than sharing one, so they
+      # must not be collapsed onto a single wrapper.
+      def test_get_or_create_without_a_file_path_returns_distinct_databases
+        cache = DuckDB::InstanceCache.new
+        [nil, '', ':memory:'].each do |path|
+          first = cache.get_or_create(path)
+          second = cache.get_or_create(path)
+
+          refute_same first, second, "expected distinct databases for #{path.inspect}"
+        end
+      end
+
+      def test_separate_caches_return_distinct_databases_for_the_same_path
+        with_cached_path do |cache, path|
+          refute_same cache.get_or_create(path), DuckDB::InstanceCache.new.get_or_create(path)
+        end
+      end
+
+      def test_close_evicts_the_database_from_the_cache
+        with_cached_path do |cache, path|
+          closed = cache.get_or_create(path)
+          closed.close
+
+          reopened = cache.get_or_create(path)
+
+          refute_same closed, reopened
+          assert_equal [[1]], reopened.connect.query('SELECT 1').to_a
+        end
+      end
+
       private
+
+      def with_cached_path
+        Dir.mktmpdir do |dir|
+          yield DuckDB::InstanceCache.new, File.join(dir, 'cached.duckdb')
+        end
+      end
+
+      # Registers in a scope that is dropped, so the wrapper it used becomes
+      # collectable while the caller's wrapper stays alive.
+      def register_doubler(cache, path)
+        con = cache.get_or_create(path).connect
+        function = DuckDB::ScalarFunction.new
+        function.name = 'dbl'
+        function.add_parameter(DuckDB::LogicalType::INTEGER)
+        function.return_type = DuckDB::LogicalType::INTEGER
+        function.set_function { |value| value * 2 }
+        con.register_scalar_function(function)
+        con.disconnect
+        nil
+      end
 
       def run_threaded_cache_test(cache, path)
         thread = Thread.new do


### PR DESCRIPTION
Fixes #1447.

## Problem

`duckdb_get_or_create_from_cache` hands back a **fresh `duckdb_database` handle** over an instance it may already have returned, and `rbduckdb_create_database_obj` built a **new `DuckDB::Database`** for each one. Registered functions live in the shared instance's system catalog, but #1441 anchors them to the Ruby wrapper — so each wrapper retained them in its own `registered_functions` array, and collecting either one freed a `DuckDB::ScalarFunction` the other's connections could still resolve.

On `main` the new regression test reaches the freed slot:

```
DuckDB::Error: Invalid Input Error: method 'call' called on hidden T_FILE object (0x…)
```

`rb_funcall` on a recycled `VALUE`. The manifestation depends on heap contents and can equally be a segfault.

## Change

Per-wrapper retention cannot express the catalog's lifetime, so give the instance **one wrapper**: the cache keeps a weak set of the wrappers it has handed out and returns the existing one for a path it has already seen. The existing per-wrapper `registered_functions` array is then already correct, and no second lifetime table is needed beside it.

DuckDB is still called on every `get_or_create`, so config validation and every error path behave exactly as before; when we already hold a wrapper, the spare handle is closed and the retained wrapper keeps the instance alive.

Four properties, each measured rather than assumed:

- **Weak** (`ObjectSpace::WeakMap`) — a wrapper nobody holds is still collected and its instance closed, as today. A strong table would trade the use-after-free for a leak.
- **Keyed per cache, not process-wide** — two `InstanceCache` objects over the same file path do **not** share an instance (verified), so a global path-keyed table would hand a caller a database that isn't theirs.
- **File paths only** — `nil`, `''` and `':memory:'` open a fresh instance on every call (verified), so those wrappers must stay distinct.
- **`#close` evicts** — a closed wrapper is never handed to the next `get_or_create`.

## Verification

- 5 new tests in `test/duckdb_test/instance_cache_test.rb`. The use-after-free test errors on `main` as above; the identity test fails there too. The other three guard the memoization itself (distinct wrappers for the path-less forms, distinct across separate caches, close-evicts) and pass on `main` — they exist to keep this change honest.
- Full suite: 1395 runs, 2672 assertions, 0 failures, 0 errors, 2 skips.
- Rubocop: 126 files, no offenses.

## Out of scope

The issue also notes `Database#close` leaving `registered_functions` populated — over-retention only, not unsafe. Left for a separate change.

Separately, and **pre-existing on `main`**: calling `Database#close` while a connection is still open, then `get_or_create` on the same path, hangs forever. Confirmed on unmodified `main`, so it is not introduced here; the new tests disconnect before closing. Worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cached database reuse for the same file path.
  * Preserved registered functions when temporary database wrappers are garbage-collected.
  * Ensured closed databases are removed from the cache.
  * Kept in-memory and non-file databases independent rather than reusing cached instances.
  * Added changelog documentation for the cache fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->