### PR TITLE
Fix out-of-bounds read and use-after-free in Appender.create_query column names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 # Unreleased
+- fix `DuckDB::Appender.create_query` reading past the end of its column name array when the array is shorter than the types array, and freeing a column name before DuckDB copies it when the array holds `to_str` objects. A column name array whose size differs from the types array now raises `ArgumentError` (PR #1453).
 - fix a bound or appended `VARCHAR` being silently truncated at an embedded NUL byte, so that a String validated on the Ruby side is now stored in full (PR #1451). Affects `Connection#query(sql, *args)`, `PreparedStatement#bind`/`#bind_varchar` and `Appender#append_varchar`.
 - fix an exception raised while converting a row for an aggregate UDF's update callback — including the `Timeout::Error` from wrapping a query in `Timeout.timeout` — unwinding into DuckDB instead of aborting the query, which could wedge the process for good (PR #1450).
 - fix a permanent hang when a UDF callback raised an exception whose message contained a NUL byte (or whose `#message` raised): the error reporter raised while reporting, killing the callback executor thread and stranding every later UDF callback in the process (PR #1448).

--- a/ext/duckdb/appender.c
+++ b/ext/duckdb/appender.c
@@ -94,6 +94,8 @@ static VALUE appender_s_create_query(VALUE klass, VALUE con, VALUE query, VALUE 
     idx_t column_count = 0;
     duckdb_logical_type *type_array = NULL;
     VALUE appender = Qnil;
+    VALUE column_name_strings = Qnil;
+    duckdb_state state;
 
     if (!rb_obj_is_kind_of(con, cDuckDBConnection)) {
         rb_raise(rb_eTypeError, "1st argument should be instance of DackDB::Connection");
@@ -122,16 +124,23 @@ static VALUE appender_s_create_query(VALUE klass, VALUE con, VALUE query, VALUE 
             rb_raise(rb_eArgError, "column names size (%ld) must be the same as types size (%ld)",
                      RARRAY_LEN(columns), RARRAY_LEN(types));
         }
+        /* Keep the converted Strings alive: StringValue on a to_str object
+         * returns a String that nothing else references. */
+        column_name_strings = rb_ary_new_capa((long)column_count);
         column_names = ALLOCA_N(const char *, (size_t)column_count);
         for (idx_t i = 0; i < column_count; i++) {
             VALUE col_name_val = rb_ary_entry(columns, i);
-            column_names[i] = StringValuePtr(col_name_val);
+            StringValue(col_name_val);
+            rb_ary_push(column_name_strings, col_name_val);
+            column_names[i] = RSTRING_PTR(col_name_val);
         }
     }
     ctxcon = rbduckdb_get_struct_connection(con);
     appender = allocate(klass);
     TypedData_Get_Struct(appender, rubyDuckDBAppender, &appender_data_type, ctx);
-    if (duckdb_appender_create_query(ctxcon->con, query_str, column_count, type_array, table_name, column_names, &ctx->appender) == DuckDBError) {
+    state = duckdb_appender_create_query(ctxcon->con, query_str, column_count, type_array, table_name, column_names, &ctx->appender);
+    RB_GC_GUARD(column_name_strings);
+    if (state == DuckDBError) {
         rb_raise(eDuckDBError, "failed to create appender from query");
     }
 

--- a/ext/duckdb/appender.c
+++ b/ext/duckdb/appender.c
@@ -116,9 +116,14 @@ static VALUE appender_s_create_query(VALUE klass, VALUE con, VALUE query, VALUE 
         if (rb_obj_is_kind_of(columns, rb_cArray) == Qfalse) {
             rb_raise(rb_eTypeError, "4th argument should be an Array or nil");
         }
-        idx_t col_count = RARRAY_LEN(columns);
-        column_names = ALLOCA_N(const char *, (size_t)col_count);
-        for (idx_t i = 0; i < col_count; i++) {
+        /* DuckDB reads column_count entries from column_names, so a shorter list
+         * makes it read uninitialized stack slots as column names. */
+        if ((idx_t)RARRAY_LEN(columns) != column_count) {
+            rb_raise(rb_eArgError, "column names size (%ld) must be the same as types size (%ld)",
+                     RARRAY_LEN(columns), RARRAY_LEN(types));
+        }
+        column_names = ALLOCA_N(const char *, (size_t)column_count);
+        for (idx_t i = 0; i < column_count; i++) {
             VALUE col_name_val = rb_ary_entry(columns, i);
             column_names[i] = StringValuePtr(col_name_val);
         }

--- a/test/duckdb_test/appender_create_query_test.rb
+++ b/test/duckdb_test/appender_create_query_test.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module DuckDBTest
+  # create_query passes the types array's length to DuckDB as the count of both
+  # the types and the column names, so a column name list of a different length
+  # made DuckDB read uninitialized stack slots as names.
+  class AppenderCreateQueryTest < Minitest::Test
+    QUERY = 'INSERT INTO t SELECT i, val FROM my_appended_data'
+
+    def setup
+      skip 'not supported' unless DuckDB::Appender.respond_to?(:create_query)
+
+      @db = DuckDB::Database.open
+      @con = @db.connect
+      @con.query('CREATE TABLE t (i INT, val VARCHAR)')
+    end
+
+    def teardown
+      @con&.close
+      @db&.close
+    end
+
+    def types
+      [DuckDB::LogicalType::INTEGER, DuckDB::LogicalType::VARCHAR]
+    end
+
+    def create_query_appender(column_names)
+      DuckDB::Appender.create_query(@con, QUERY, types, 'my_appended_data', column_names)
+    end
+
+    def test_fewer_column_names_than_types_raises_argument_error
+      error = assert_raises(ArgumentError) { create_query_appender(%w[i]) }
+
+      assert_match(/column names size \(1\).+types size \(2\)/, error.message)
+    end
+
+    def test_more_column_names_than_types_raises_argument_error
+      assert_raises(ArgumentError) { create_query_appender(%w[i val extra]) }
+    end
+
+    def test_empty_column_names_raises_argument_error
+      assert_raises(ArgumentError) { create_query_appender([]) }
+    end
+
+    def test_nil_column_names_falls_back_to_the_duckdb_defaults
+      appender = DuckDB::Appender.create_query(
+        @con, 'INSERT INTO t SELECT col1, col2 FROM my_appended_data', types, 'my_appended_data', nil
+      )
+      appender.append_row(1, 'hello')
+      appender.close
+
+      assert_equal [[1, 'hello']], @con.query('SELECT * FROM t').to_a
+    end
+  end
+end

--- a/test/duckdb_test/appender_create_query_test.rb
+++ b/test/duckdb_test/appender_create_query_test.rb
@@ -9,6 +9,17 @@ module DuckDBTest
   class AppenderCreateQueryTest < Minitest::Test
     QUERY = 'INSERT INTO t SELECT i, val FROM my_appended_data'
 
+    # to_str returns a fresh String, so nothing but the C local holds it.
+    class ColumnName
+      def initialize(name)
+        @name = name
+      end
+
+      def to_str
+        @name.dup
+      end
+    end
+
     def setup
       skip 'not supported' unless DuckDB::Appender.respond_to?(:create_query)
 
@@ -18,6 +29,7 @@ module DuckDBTest
     end
 
     def teardown
+      GC.stress = false
       @con&.close
       @db&.close
     end
@@ -28,6 +40,13 @@ module DuckDBTest
 
     def create_query_appender(column_names)
       DuckDB::Appender.create_query(@con, QUERY, types, 'my_appended_data', column_names)
+    end
+
+    def with_gc_stress
+      GC.stress = true
+      yield
+    ensure
+      GC.stress = false
     end
 
     def test_fewer_column_names_than_types_raises_argument_error
@@ -48,6 +67,14 @@ module DuckDBTest
       appender = DuckDB::Appender.create_query(
         @con, 'INSERT INTO t SELECT col1, col2 FROM my_appended_data', types, 'my_appended_data', nil
       )
+      appender.append_row(1, 'hello')
+      appender.close
+
+      assert_equal [[1, 'hello']], @con.query('SELECT * FROM t').to_a
+    end
+
+    def test_column_names_survive_gc_while_the_appender_is_created
+      appender = with_gc_stress { create_query_appender([ColumnName.new('i'), ColumnName.new('val')]) }
       appender.append_row(1, 'hello')
       appender.close
 


### PR DESCRIPTION
`DuckDB::Appender.create_query` passes the length of `types` to DuckDB as the column count for *both* the types array and the column names array, but sized the `column_names` buffer from the column list instead. Two defects, both reproduced:

**Out-of-bounds read.** With fewer column names than types, DuckDB reads uninitialized stack slots and dereferences them as C strings:

```ruby
types = [DuckDB::LogicalType::INTEGER, DuckDB::LogicalType::VARCHAR]
DuckDB::Appender.create_query(con, query, types, 'my_appended_data', %w[i]).close
# DuckDB::Error: Referenced column "val" not found in FROM clause!
# Candidate bindings: "H\xE8\xFF\xFF"      <- uninitialized stack
```

**Use-after-free.** `StringValuePtr` on an element that is not a `String` returns a `String` that nothing else references, and the loop variable is overwritten on the next iteration. With a `to_str` object under `GC.stress` the first name is freed and the second is allocated into the same buffer, so both entries point at it:

```
DuckDB::Error: table "my_appended_data" has duplicate column name "val"
```

Fixes, one commit each:

- require `column_names.length == types.length`, raising `ArgumentError`. The C API takes a single count for both arrays, so any other length is a caller error — a longer list was already being silently truncated.
- hold the converted `String`s in an `Array` guarded with `RB_GC_GUARD` for the duration of the call.

Verified with 5 new tests in `test/duckdb_test/appender_create_query_test.rb`; 4 of them fail on `main` (3 with no exception raised, 1 with the duplicate-column error above). Full suite passes, rubocop clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `Appender.create_query` validation when column names and types have different lengths.
  * Fixed handling of column names, including empty or missing names, during query creation.
  * Improved reliability when creating queries under memory-management pressure.
  * Errors from invalid query creation are now reported more consistently.

* **Tests**
  * Added coverage for valid queries, invalid inputs, default names, and appended rows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->