### PR TITLE
Report a missing aggregate state instead of passing nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 # Unreleased
+- fix an aggregate UDF state that has lost its registry entry being passed to the user's `update`/`combine`/`finalize` proc as `nil`, indistinguishable from an `init` proc that legitimately returned `nil`. Such a state now reports an internal error instead of silently producing wrong results (issue #1445).
 - fix `DuckDB::Appender.create_query` reading past the end of its column name array when the array is shorter than the types array, and freeing a column name before DuckDB copies it when the array holds `to_str` objects. A column name array whose size differs from the types array now raises `ArgumentError` (PR #1453).
 - fix a bound or appended `VARCHAR` being silently truncated at an embedded NUL byte, so that a String validated on the Ruby side is now stored in full (PR #1451). Affects `Connection#query(sql, *args)`, `PreparedStatement#bind`/`#bind_varchar` and `Appender#append_varchar`.
 - fix an exception raised while converting a row for an aggregate UDF's update callback — including the `Timeout::Error` from wrapping a query in `Timeout.timeout` — unwinding into DuckDB instead of aborting the query, which could wedge the process for good (PR #1450).

--- a/ext/duckdb/aggregate_function.c
+++ b/ext/duckdb/aggregate_function.c
@@ -249,7 +249,8 @@ static void state_init_callback(duckdb_function_info info, duckdb_aggregate_stat
         /* Defensive: maybe_set_functions only wires callbacks when init_proc
          * is set, so this branch should be unreachable in practice. Zero the
          * ID anyway: IDs start at 1, so this state matches no registry entry
-         * and state_registry_load returns Qnil for it. */
+         * and the callbacks report it as a missing state rather than running
+         * the user's proc on a state that was never initialised. */
         ruby_aggregate_state *state = (ruby_aggregate_state *)state_p;
         state->state_id = 0;
         return;

--- a/ext/duckdb/aggregate_function.c
+++ b/ext/duckdb/aggregate_function.c
@@ -159,11 +159,16 @@ static inline void state_registry_store(ruby_aggregate_state *state, VALUE value
  *
  * The registry is the only place the VALUE may be read from: a copy cached
  * in the state buffer would be a raw VALUE in a C struct DuckDB allocates,
- * which GC compaction does not update.  Returns Qnil for a state that has
- * no entry (init failed, or the entry was already released).
+ * which GC compaction does not update.
+ *
+ * Returns Qundef, not Qnil, when the state has no entry: nil is a legitimate
+ * state (a user's init proc may return it), so the two must not be conflated.
+ * Every live state has an entry, so Qundef means a bug in this file; callers
+ * report it through report_missing_state_to_duckdb rather than handing the
+ * user's proc a state it never returned.
  */
 static inline VALUE state_registry_load(ruby_aggregate_state *state) {
-    return rb_hash_aref(g_aggregate_state_registry, state_registry_key(state));
+    return rb_hash_lookup2(g_aggregate_state_registry, state_registry_key(state), Qundef);
 }
 
 /*
@@ -183,6 +188,20 @@ static void report_ruby_error_to_duckdb(duckdb_function_info info) {
     VALUE msg = rbduckdb_pending_error_message();
     duckdb_aggregate_function_set_error(info, StringValueCStr(msg));
     RB_GC_GUARD(msg);
+}
+
+/*
+ * Report a state that has no registry entry.  Not reachable from Ruby code:
+ * it means a state was released while DuckDB still held it, which would
+ * otherwise pass nil to the user's proc and silently corrupt the result.
+ */
+static void report_missing_state_to_duckdb(duckdb_function_info info, ruby_aggregate_state *state) {
+    char msg[128];
+
+    snprintf(msg, sizeof(msg),
+             "aggregate state %llu has no registry entry (ruby-duckdb internal error)",
+             (unsigned long long)state->state_id);
+    duckdb_aggregate_function_set_error(info, msg);
 }
 
 /* state_size callback: constant buffer per state. */
@@ -311,6 +330,7 @@ static VALUE update_process_rows(VALUE varg) {
         ruby_aggregate_state *state = states[i];
         struct update_one_arg one;
         int exception_state;
+        VALUE ruby_state;
         VALUE ret;
 
         /*
@@ -334,7 +354,15 @@ static VALUE update_process_rows(VALUE varg) {
             }
         }
 
-        rb_ary_store(args, 0, state_registry_load(state));
+        ruby_state = state_registry_load(state);
+        if (ruby_state == Qundef) {
+            report_missing_state_to_duckdb(arg->info, state);
+            release_chunk_states(arg);
+            RB_GC_GUARD(args);
+            return Qnil;
+        }
+
+        rb_ary_store(args, 0, ruby_state);
         for (j = 0; j < arg->col_count; j++) {
             rb_ary_store(args, (long)j + 1, rbduckdb_vector_value_at(arg->input_vectors[j], arg->input_types[j], i));
         }
@@ -463,6 +491,10 @@ static void execute_combine_callback_protected(void *user_data) {
         one.combine_proc = arg->ctx->combine_proc;
         one.source_state = state_registry_load(src[i]);
         one.target_state = state_registry_load(tgt[i]);
+        if (one.source_state == Qundef || one.target_state == Qundef) {
+            report_missing_state_to_duckdb(arg->info, one.source_state == Qundef ? src[i] : tgt[i]);
+            return;
+        }
 
         ret = rb_protect(call_combine_proc, (VALUE)&one, &exception_state);
         if (exception_state) {
@@ -555,6 +587,10 @@ static void execute_finalize_callback_protected(void *user_data) {
 
         one.finalize_proc = arg->ctx->finalize_proc;
         one.ruby_state = state_registry_load(state);
+        if (one.ruby_state == Qundef) {
+            report_missing_state_to_duckdb(arg->info, state);
+            goto cleanup;
+        }
 
         ret = rb_protect(call_finalize_proc, (VALUE)&one, &exception_state);
         if (exception_state) {

--- a/test/duckdb_test/aggregate_function_test.rb
+++ b/test/duckdb_test/aggregate_function_test.rb
@@ -510,6 +510,7 @@ module DuckDBTest
 
         rows = @con.query('SELECT const_count(i) OVER () FROM c').to_a
 
+        assert_equal row_count, rows.size, 'the window should emit one row per input row'
         assert_equal [[row_count]], rows.uniq, "every row should see all #{row_count} rows"
       end
     end

--- a/test/duckdb_test/aggregate_function_test.rb
+++ b/test/duckdb_test/aggregate_function_test.rb
@@ -482,6 +482,38 @@ module DuckDBTest
       assert_equal [[101], [201], [101]], [rows.first, rows[2500], rows.last]
     end
 
+    # An empty OVER () frame is constant over the whole partition, so DuckDB
+    # switches to WindowConstantAggregator, which hands update a states array
+    # that is not row-indexed: it reports the real row count but fills only a
+    # short fixed prefix. Reading one state per row ran off the populated part
+    # and dereferenced NULL.
+    def test_aggregate_over_an_empty_window_counts_the_whole_partition
+      skip 'segfaults until issue #1446 is fixed'
+
+      @con.register_aggregate_function(
+        DuckDB::AggregateFunction.create(
+          name: 'const_count',
+          return_type: :bigint,
+          params: [:bigint],
+          init: -> { 0 },
+          update: ->(state, _value) { state + 1 },
+          combine: ->(state, other_state) { (state || 0) + (other_state || 0) },
+          finalize: ->(state) { state }
+        )
+      )
+
+      # More than one row count: the populated prefix is a constant two entries
+      # whatever the partition size, so a fix that trusts it passes at tiny row
+      # counts and is silently wrong at real ones.
+      [2, 100, 5000].each do |row_count|
+        @con.query("CREATE OR REPLACE TABLE c AS SELECT i FROM generate_series(1, #{row_count}) s(i)")
+
+        rows = @con.query('SELECT const_count(i) OVER () FROM c').to_a
+
+        assert_equal [[row_count]], rows.uniq, "every row should see all #{row_count} rows"
+      end
+    end
+
     private
 
     # Force DuckDB to actually parallelise aggregation so the combine callback


### PR DESCRIPTION
Closes #1445.

`state_registry_load` used `rb_hash_aref`, which returns `Qnil` both for a state whose `init` proc legitimately returned `nil` and for a state with no registry entry at all. A missing entry is always a bug — state IDs are monotonic and every live state has an entry — but the two were indistinguishable, so losing a state showed up as wrong answers rather than an error.

It now loads through `rb_hash_lookup2` with `Qundef` and handles the sentinel at each of the four call sites (`update_process_rows`, `execute_combine_callback_protected` ×2, `execute_finalize_callback_protected`). As the issue notes, those sites are not uniformly inside `rb_protect`, so the helper cannot raise itself; each site reports through `duckdb_aggregate_function_set_error`.

## No live bug is fixed by this

Verified with temporary env-gated fault injection that drops a live registry entry in `update`, `combine` and `finalize`. Before the change a 5000-row sum came back silently wrong (4111844 instead of 12502500); after it, each site reports `aggregate state N has no registry entry (ruby-duckdb internal error)`.

The same instrumentation, run over the full test suite and 14 query shapes (grouping sets, rollup, distinct, filter, four window frame shapes, 5000 groups, 8 threads, 20k rows), found **no** naturally reachable missing entry. There is therefore no Ruby-reachable seam for a regression test and none is added — the only way to reach the path is fault injection, and shipping a "drop a live state" hook would hand users a way to corrupt aggregates for a case that cannot otherwise happen.

## Also in this branch

A repro for #1446 (`OVER ()` segfault), committed with a `skip` guard because it dumps core until #1446 is fixed. It records the `WindowConstantAggregator` diagnosis the issue was missing: DuckDB's `WindowConstantAggregatorLocalState::Sink` writes only `state[0]` and then calls the update callback with the full row count, and the C API shim flattens the inputs but not the state vector. Delete the `skip` line when #1446 is fixed.

Note the new `Qundef` guard does **not** mitigate #1446: `state_registry_load` dereferences `state->state_id` to build the key before it could return the sentinel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GaBoGcDjmAJt4ZTYRxT7PE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Aggregate functions now report a clear internal error when their state is missing, preventing incorrect results when `nil` is a valid aggregate state.
  * Improved handling for aggregate updates, combinations, and finalization.

* **Tests**
  * Added regression coverage for aggregate window functions over empty frames.

* **Documentation**
  * Updated the unreleased changelog with details of the aggregate state handling fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->